### PR TITLE
feat: enable Malicious User Detection on the reference load balancer

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -27,7 +27,7 @@ internet-reachable), with remote state in Azure Blob Storage.
 
 ## Security controls
 
-The `http-lb` module attaches three F5 XC app-security controls to the load balancer:
+The `http-lb` module attaches four F5 XC app-security controls to the load balancer:
 
 - **WAF** — `xcsh_app_firewall.this` (`webapp-api-protection-waf`) is referenced by the
   load balancer's `app_firewall {}` block. Enforcement mode is set by the `waf_mode`
@@ -51,6 +51,16 @@ The `http-lb` module attaches three F5 XC app-security controls to the load bala
   is owned by a separate tenant plan. The served root domain is registered with the CSD
   reporting engine via `xcsh_protected_domain` (system namespace). Telemetry beacons and
   detected scripts appear in the console (Web App & API Protection → Client-Side Defense).
+- **Malicious User Detection** — the load balancer's `enable_malicious_user_detection {}`
+  block scores per-user behavior into threat levels (users identified by the server-default
+  client IP). Auto-mitigation is wired through the `enable_challenge` block, which references
+  an `xcsh_malicious_user_mitigation` policy (`webapp-api-protection-mud`) that escalates by
+  threat level: low → JavaScript challenge, medium → CAPTCHA, high → temporary block. Toggled
+  by the `mud_enabled` variable (default `true`). MUD is a WAAP capability: the plan asserts
+  the tenant WAAP entitlement via a `data xcsh_addon_service_activation_status` guard
+  (`f5xc-waap-standard`, state `AS_SUBSCRIBED`) rather than managing the subscription. Flagged
+  users and mitigation actions appear in the console (Web App & API Protection → Malicious
+  Users).
 
 ## Architecture
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -64,11 +64,14 @@ module "http_lb" {
   labels            = var.labels
   waf_mode          = var.waf_mode
   csd_enabled       = var.csd_enabled
+  mud_enabled       = var.mud_enabled
 
   # Enabling client_side_defense on the LB requires a protected domain to already
   # exist in this namespace (F5 XC generates the CSD JS config from it), so the
-  # LB must be created/updated AFTER the protected domain.
-  depends_on = [xcsh_protected_domain.csd]
+  # LB must be created/updated AFTER the protected domain. The MUD entitlement
+  # guard is a prerequisite too: fail fast if the WAAP addon is not subscribed
+  # before the module creates the malicious_user_mitigation policy / LB.
+  depends_on = [xcsh_protected_domain.csd, data.xcsh_addon_service_activation_status.mud]
 }
 
 # --- Client-Side Defense tenant dependency (verified, NOT managed) ------------
@@ -103,6 +106,26 @@ resource "xcsh_protected_domain" "csd" {
   protected_domain = "f5-sales-demo.com"
 
   depends_on = [data.xcsh_addon_service_activation_status.csd]
+}
+
+# --- Malicious User Detection tenant dependency (verified, NOT managed) -------
+# MUD is a Web App & API Protection (WAAP) capability: enabling
+# enable_malicious_user_detection on the LB and creating the
+# xcsh_malicious_user_mitigation policy require the tenant to be subscribed to the
+# WAAP addon. As with CSD, tenant entitlement is owned by a separate tenant-level
+# plan, so here we only ASSERT the dependency (fail fast if not subscribed) rather
+# than managing the subscription. Confirmed live: the MUD feature maps to
+# f5xc-waap-standard (there is no MUD-specific addon; MUD is not bot defense).
+data "xcsh_addon_service_activation_status" "mud" {
+  count         = var.mud_enabled ? 1 : 0
+  addon_service = "f5xc-waap-standard"
+
+  lifecycle {
+    postcondition {
+      condition     = self.state == "AS_SUBSCRIBED"
+      error_message = "Malicious User Detection requires the WAAP addon, which is not subscribed on this tenant (state: ${self.state}). Enable it via the tenant entitlements plan before applying MUD."
+    }
+  }
 }
 
 # --- Azure traffic generator (drives live load at the load balancer) ----------

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -88,6 +88,46 @@ resource "xcsh_app_firewall" "this" {
   }
 }
 
+# Malicious User Detection mitigation policy — the actions F5 XC takes once a user
+# is scored into a threat level. Referenced by the load balancer's enable_challenge
+# block below (there is no top-level malicious_user_mitigation field on the LB; the
+# reference lives inside the challenge oneof). Escalating response by threat level:
+# low → JavaScript challenge, medium → CAPTCHA, high → temporary block. Based on the
+# acceptance-tested example xcsh_malicious_user_mitigation/with-mitigation-type.tf.
+resource "xcsh_malicious_user_mitigation" "mud" {
+  count     = var.mud_enabled ? 1 : 0
+  name      = "webapp-api-protection-mud"
+  namespace = var.namespace
+  labels    = var.labels
+
+  mitigation_type {
+    rules {
+      threat_level {
+        low {}
+      }
+      mitigation_action {
+        javascript_challenge {}
+      }
+    }
+    rules {
+      threat_level {
+        medium {}
+      }
+      mitigation_action {
+        captcha_challenge {}
+      }
+    }
+    rules {
+      threat_level {
+        high {}
+      }
+      mitigation_action {
+        block_temporarily {}
+      }
+    }
+  }
+}
+
 resource "xcsh_http_loadbalancer" "this" {
   name      = "webapp-api-protection"
   namespace = var.namespace
@@ -149,6 +189,30 @@ resource "xcsh_http_loadbalancer" "this" {
     content {
       policy {
         js_insert_all_pages {}
+      }
+    }
+  }
+
+  # Malicious User Detection — score per-user behavior into threat levels
+  # (malicious_user_detection oneof vs the server default disable_malicious_user_detection).
+  # User identification uses the server-default client IP (user_id_client_ip); both the
+  # disable marker and the client-IP default are suppressed by the provider on import, so
+  # when mud_enabled is false we emit NO block (no drift; do not declare them).
+  dynamic "enable_malicious_user_detection" {
+    for_each = var.mud_enabled ? [1] : []
+    content {}
+  }
+
+  # Auto-mitigation for detected malicious users. enable_challenge is the challenge
+  # oneof arm that carries the malicious_user_mitigation reference (peer to the server
+  # default no_challenge, which the provider suppresses on import). It points at the
+  # mitigation policy created above.
+  dynamic "enable_challenge" {
+    for_each = var.mud_enabled ? [1] : []
+    content {
+      malicious_user_mitigation {
+        name      = xcsh_malicious_user_mitigation.mud[0].name
+        namespace = xcsh_malicious_user_mitigation.mud[0].namespace
       }
     }
   }

--- a/terraform/modules/http-lb/outputs.tf
+++ b/terraform/modules/http-lb/outputs.tf
@@ -37,3 +37,8 @@ output "csd_enabled" {
   description = "Whether Client-Side Defense JavaScript injection is enabled on the load balancer."
   value       = var.csd_enabled
 }
+
+output "mud_enabled" {
+  description = "Whether Malicious User Detection (with auto-mitigation) is enabled on the load balancer."
+  value       = var.mud_enabled
+}

--- a/terraform/modules/http-lb/variables.tf
+++ b/terraform/modules/http-lb/variables.tf
@@ -47,3 +47,9 @@ variable "csd_enabled" {
   type        = bool
   default     = true
 }
+
+variable "mud_enabled" {
+  description = "Enable Malicious User Detection on the load balancer (score per-user behavior into threat levels and auto-mitigate via a malicious_user_mitigation policy). Requires the MUD tenant addon."
+  type        = bool
+  default     = true
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -38,6 +38,11 @@ output "csd_enabled" {
   value       = module.http_lb.csd_enabled
 }
 
+output "mud_enabled" {
+  description = "Whether Malicious User Detection (with auto-mitigation) is enabled on the load balancer."
+  value       = module.http_lb.mud_enabled
+}
+
 
 # --- Azure origin server ------------------------------------------------------
 

--- a/terraform/tests/apply.tftest.hcl
+++ b/terraform/tests/apply.tftest.hcl
@@ -24,8 +24,9 @@ run "apply_to_tenant_creates_objects" {
     health_check_path = "/health"
     labels            = {}
     waf_mode          = "blocking"
-    # Keep this deliberate apply test addon-independent (CSD needs the tenant addon).
+    # Keep this deliberate apply test addon-independent (CSD/MUD need tenant addons).
     csd_enabled = false
+    mud_enabled = false
   }
 
   assert {

--- a/terraform/tests/plan.tftest.hcl
+++ b/terraform/tests/plan.tftest.hcl
@@ -20,6 +20,7 @@ run "plan_creates_loadbalancer_and_pool" {
     labels            = {}
     waf_mode          = "blocking"
     csd_enabled       = true
+    mud_enabled       = true
   }
 
   assert {
@@ -30,6 +31,11 @@ run "plan_creates_loadbalancer_and_pool" {
   assert {
     condition     = output.csd_enabled == true
     error_message = "Client-Side Defense should be enabled on the load balancer"
+  }
+
+  assert {
+    condition     = output.mud_enabled == true
+    error_message = "Malicious User Detection should be enabled on the load balancer"
   }
 
   assert {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -47,6 +47,12 @@ variable "csd_enabled" {
   default     = true
 }
 
+variable "mud_enabled" {
+  description = "Enable Malicious User Detection: score per-user behavior into threat levels and auto-mitigate (JS challenge / CAPTCHA / temporary block) via a malicious_user_mitigation policy. Requires the tenant MUD addon (verified via a data-source guard, not managed here)."
+  type        = bool
+  default     = true
+}
+
 # ---------------------------------------------------------
 # Azure (origin server + traffic generator this plan deploys)
 # ---------------------------------------------------------


### PR DESCRIPTION
## Summary

Enables **Malicious User Detection (MUD)** on the reference HTTP load balancer, the fourth
F5 XC app-security control (after WAF, API Discovery, Client-Side Defense). MUD scores
per-user behavior into threat levels and auto-mitigates.

Closes #9.

## What changed

- **`mud_enabled`** toggle (default `true`) on the `http-lb` module + root re-export, mirroring
  `csd_enabled`.
- LB emits `enable_malicious_user_detection {}` plus an `enable_challenge` block referencing a
  new **`xcsh_malicious_user_mitigation`** policy (`webapp-api-protection-mud`) with escalating
  actions: low → JavaScript challenge, medium → CAPTCHA, high → temporary block. Users are
  identified by the server-default client IP. Nothing is emitted when `mud_enabled = false`.
- Root **entitlement guard** `data xcsh_addon_service_activation_status` (`f5xc-waap-standard`,
  `AS_SUBSCRIBED`) — asserts the WAAP tenant dependency without managing it, mirroring CSD.
- README security-controls entry (three → four controls).
- Tests: `plan.tftest` asserts `output.mud_enabled == true`; `apply.tftest` sets
  `mud_enabled = false` to stay addon-independent.

## Verification (evidence in #9)

- `terraform test` (plan) green; `terraform fmt` clean; `textlint` (repo `.textlintrc`) clean.
- Live apply on the pre-prod `f5-sales-demo` tenant (Azure-backed state, built on the existing
  deployment): plan `1 add / 1 change / 0 destroy`, apply success, **idempotent** (immediate
  plan = No changes).
- **Round-trip import clean** for both `xcsh_malicious_user_mitigation.mud` and
  `xcsh_http_loadbalancer.this` — no new provider suppressions required.
- API ground truth confirms MUD active on the LB with the mitigation policy referenced.

## Lock-step notes

- **terraform-provider-xcsh:** no change required — MUD is already import-clean on v3.70.0
  (oneof defaults `disable_malicious_user_detection` / `user_id_client_ip` pre-suppressed), and
  mitigation ordering is enforced by the LB's direct reference to the MUM resource (no hidden
  cross-resource prerequisite like CSD's `protected_domain`, so no apply-time preflight is
  warranted — one would be a false guard).
- **api-specs-enriched:** no `x-f5xc-requires` dependency to encode (reference-enforced), and no
  characteristic MUD error surfaced.

Every MUD correctness rule maps to a shipped artifact: oneof suppressions (provider binary),
reference-enforced ordering + WAAP entitlement postcondition (this module).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
