### PR TITLE
feat(mud): exhaustive MUD/mitigation option coverage + live matrix verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+# webapp-api-protection developer targets.
+
+.PHONY: mud-matrix mud-verify test
+
+# Run the MUD plan-level test suite (no tenant contact).
+test:
+	cd terraform && terraform test
+
+# Cycle the live LB through every MUD option combination and verify apply /
+# idempotency / round-trip import. See scripts/mud-matrix.sh.
+mud-matrix:
+	bash scripts/mud-matrix.sh
+
+# Verify MUD detection + active mitigation under malicious-user traffic. See
+# scripts/mud-verify.sh.
+mud-verify:
+	bash scripts/mud-verify.sh

--- a/scripts/mud-matrix.sh
+++ b/scripts/mud-matrix.sh
@@ -22,7 +22,7 @@ COMMON=(-input=false -lock=true
   -var 'subscription_id=75f86c46-9cbc-4f6c-85ea-195e3d3c8ac0')
 REPORT=../reports/mud-matrix.txt
 mkdir -p ../reports
-: > "$REPORT"
+: >"$REPORT"
 
 # round_trip <label> -- for each managed MUD resource present in state, state rm +
 # import, then a clean plan. Sets RT_FAIL on any failure.
@@ -38,29 +38,46 @@ round_trip() {
   fi
   local a addr id
   for a in "${addrs[@]}"; do
-    addr="${a%%|*}"; id="${a##*|}"
-    terraform state rm "$addr" >/dev/null 2>&1 || { echo "FAIL $label state-rm($addr)" >>"$REPORT"; return; }
-    terraform import "${COMMON[@]}" "${VARS[@]}" "$addr" "$id" >/tmp/mud-import.log 2>&1 || { echo "FAIL $label import($addr)" >>"$REPORT"; return; }
+    addr="${a%%|*}"
+    id="${a##*|}"
+    terraform state rm "$addr" >/dev/null 2>&1 || {
+      echo "FAIL $label state-rm($addr)" >>"$REPORT"
+      return
+    }
+    terraform import "${COMMON[@]}" "${VARS[@]}" "$addr" "$id" >/tmp/mud-import.log 2>&1 || {
+      echo "FAIL $label import($addr)" >>"$REPORT"
+      return
+    }
   done
   terraform plan -detailed-exitcode "${COMMON[@]}" "${VARS[@]}" >/tmp/mud-rt-plan.log 2>&1
   case $? in
-    0) echo "PASS $label" >>"$REPORT" ;;
-    2) echo "FAIL $label import-drift" >>"$REPORT" ;;
-    *) echo "FAIL $label rt-plan-error" >>"$REPORT" ;;
+  0) echo "PASS $label" >>"$REPORT" ;;
+  2) echo "FAIL $label import-drift" >>"$REPORT" ;;
+  *) echo "FAIL $label rt-plan-error" >>"$REPORT" ;;
   esac
 }
 
 # check <label> <var...> -- apply the combo, assert idempotent, then round-trip.
 check() {
-  local label="$1"; shift
+  local label="$1"
+  shift
   VARS=("$@")
   echo "--- $label ---"
-  terraform apply -auto-approve "${COMMON[@]}" "${VARS[@]}" >/tmp/mud-apply.log 2>&1 || { echo "FAIL $label apply" >>"$REPORT"; return; }
+  terraform apply -auto-approve "${COMMON[@]}" "${VARS[@]}" >/tmp/mud-apply.log 2>&1 || {
+    echo "FAIL $label apply" >>"$REPORT"
+    return
+  }
   terraform plan -detailed-exitcode "${COMMON[@]}" "${VARS[@]}" >/tmp/mud-plan.log 2>&1
   case $? in
-    0) : ;;
-    2) echo "FAIL $label not-idempotent" >>"$REPORT"; return ;;
-    *) echo "FAIL $label plan-error" >>"$REPORT"; return ;;
+  0) : ;;
+  2)
+    echo "FAIL $label not-idempotent" >>"$REPORT"
+    return
+    ;;
+  *)
+    echo "FAIL $label plan-error" >>"$REPORT"
+    return
+    ;;
   esac
   round_trip "$label"
 }
@@ -77,9 +94,9 @@ done
 
 # --- every user-identification rule type ---
 for rule in cookie_name http_header_name ip_and_http_header_name jwt_claim_name \
-            query_param_key client_asn client_city client_country client_ip \
-            client_region tls_fingerprint ip_and_tls_fingerprint ja4_tls_fingerprint \
-            ip_and_ja4_tls_fingerprint none; do
+  query_param_key client_asn client_city client_country client_ip \
+  client_region tls_fingerprint ip_and_tls_fingerprint ja4_tls_fingerprint \
+  ip_and_ja4_tls_fingerprint none; do
   check "userid-$rule" -var mud_user_id=user_identification -var "mud_user_id_rule=$rule"
 done
 

--- a/scripts/mud-matrix.sh
+++ b/scripts/mud-matrix.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# MUD live config-matrix harness.
+#
+# Cycles the LIVE webapp-api-protection load balancer through every MUD option
+# combination and verifies each is (a) applies, (b) idempotent (immediate plan =
+# No changes), and (c) round-trip-import clean (state rm -> import -> plan clean)
+# for the LB, the malicious_user_mitigation policy, and (when present) the
+# user_identification policy. Results append to reports/mud-matrix.txt. Ends by
+# applying the canonical full config so the live LB is left healthy.
+#
+# Pre-prod tenant, in-place on the live LB (per the approved spec). Sequential —
+# no concurrent terraform against the shared state.
+set -uo pipefail
+
+cd "$(dirname "$0")/../terraform"
+export ARM_ACCESS_KEY=$(az storage account keys list -n f5salesdemotfstate -g f5-sales-demo-tfstate --query "[0].value" -o tsv)
+
+NS="webapp-api-protection"
+COMMON=(-input=false -lock=true
+  -var 'lb_domains=["www.f5-sales-demo.com","api.f5-sales-demo.com"]'
+  -var 'subscription_id=75f86c46-9cbc-4f6c-85ea-195e3d3c8ac0')
+REPORT=../reports/mud-matrix.txt
+mkdir -p ../reports
+: > "$REPORT"
+
+# round_trip <label> -- for each managed MUD resource present in state, state rm +
+# import, then a clean plan. Sets RT_FAIL on any failure.
+round_trip() {
+  local label="$1"
+  local -a addrs=(
+    "module.http_lb.xcsh_http_loadbalancer.this|${NS}/${NS}"
+    "module.http_lb.xcsh_malicious_user_mitigation.mud[0]|${NS}/${NS}-mud"
+  )
+  # user_identification only exists for user_identification combos
+  if terraform state list 2>/dev/null | grep -q 'xcsh_user_identification.mud\[0\]'; then
+    addrs+=("module.http_lb.xcsh_user_identification.mud[0]|${NS}/${NS}-mud-userid")
+  fi
+  local a addr id
+  for a in "${addrs[@]}"; do
+    addr="${a%%|*}"; id="${a##*|}"
+    terraform state rm "$addr" >/dev/null 2>&1 || { echo "FAIL $label state-rm($addr)" >>"$REPORT"; return; }
+    terraform import "${COMMON[@]}" "${VARS[@]}" "$addr" "$id" >/tmp/mud-import.log 2>&1 || { echo "FAIL $label import($addr)" >>"$REPORT"; return; }
+  done
+  terraform plan -detailed-exitcode "${COMMON[@]}" "${VARS[@]}" >/tmp/mud-rt-plan.log 2>&1
+  case $? in
+    0) echo "PASS $label" >>"$REPORT" ;;
+    2) echo "FAIL $label import-drift" >>"$REPORT" ;;
+    *) echo "FAIL $label rt-plan-error" >>"$REPORT" ;;
+  esac
+}
+
+# check <label> <var...> -- apply the combo, assert idempotent, then round-trip.
+check() {
+  local label="$1"; shift
+  VARS=("$@")
+  echo "--- $label ---"
+  terraform apply -auto-approve "${COMMON[@]}" "${VARS[@]}" >/tmp/mud-apply.log 2>&1 || { echo "FAIL $label apply" >>"$REPORT"; return; }
+  terraform plan -detailed-exitcode "${COMMON[@]}" "${VARS[@]}" >/tmp/mud-plan.log 2>&1
+  case $? in
+    0) : ;;
+    2) echo "FAIL $label not-idempotent" >>"$REPORT"; return ;;
+    *) echo "FAIL $label plan-error" >>"$REPORT"; return ;;
+  esac
+  round_trip "$label"
+}
+
+# --- challenge modes ---
+for mode in enable_challenge policy_based_challenge none; do
+  check "challenge-$mode" -var "mud_challenge_mode=$mode"
+done
+
+# --- mitigation action at every level (all-same-action covers 9 pairings) ---
+for act in block_temporarily captcha_challenge javascript_challenge; do
+  check "mitigation-all-$act" -var "mud_mitigation={low=\"$act\",medium=\"$act\",high=\"$act\"}"
+done
+
+# --- every user-identification rule type ---
+for rule in cookie_name http_header_name ip_and_http_header_name jwt_claim_name \
+            query_param_key client_asn client_city client_country client_ip \
+            client_region tls_fingerprint ip_and_tls_fingerprint ja4_tls_fingerprint \
+            ip_and_ja4_tls_fingerprint none; do
+  check "userid-$rule" -var mud_user_id=user_identification -var "mud_user_id_rule=$rule"
+done
+
+# --- canonical end-state (leave the live LB healthy) ---
+check "canonical" -var mud_user_id=client_ip -var mud_challenge_mode=enable_challenge \
+  -var 'mud_mitigation={low="javascript_challenge",medium="captcha_challenge",high="block_temporarily"}'
+
+echo "===== MUD MATRIX RESULTS ====="
+cat "$REPORT"
+echo "PASS=$(grep -c '^PASS ' "$REPORT") FAIL=$(grep -c '^FAIL ' "$REPORT")"

--- a/scripts/mud-matrix.sh
+++ b/scripts/mud-matrix.sh
@@ -12,8 +12,9 @@
 # no concurrent terraform against the shared state.
 set -uo pipefail
 
-cd "$(dirname "$0")/../terraform"
-export ARM_ACCESS_KEY=$(az storage account keys list -n f5salesdemotfstate -g f5-sales-demo-tfstate --query "[0].value" -o tsv)
+cd "$(dirname "$0")/../terraform" || exit 1
+ARM_ACCESS_KEY=$(az storage account keys list -n f5salesdemotfstate -g f5-sales-demo-tfstate --query "[0].value" -o tsv)
+export ARM_ACCESS_KEY
 
 NS="webapp-api-protection"
 COMMON=(-input=false -lock=true

--- a/scripts/mud-verify.sh
+++ b/scripts/mud-verify.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# MUD behavioral verification.
+#
+# 1) Confirms Malicious User Detection is ACTIVE on the load balancer
+#    (enable_malicious_user_detection + a resolvable malicious_user_mitigation
+#    reference) — a config check, always available.
+# 2) Polls the F5 XC analytics API for FLAGGED malicious users (the suspicious-users
+#    dataset MUD produces) under the enhanced traffic generator, until at least one
+#    user is flagged or the budget elapses.
+#
+# Exit codes: 0 = MUD active AND ≥1 user flagged; 1 = MUD not active;
+# 2 = MUD active but the tenant analytics backend (Elasticsearch) is unavailable, so
+# flagged users cannot be confirmed here; 3 = MUD active but no flags within budget.
+set -uo pipefail
+
+: "${XCSH_API_URL:?XCSH_API_URL required}"
+: "${XCSH_API_TOKEN:?XCSH_API_TOKEN required}"
+base="${XCSH_API_URL%/}"
+NS="${1:-webapp-api-protection}"
+LB="${2:-webapp-api-protection}"
+APP="ves-io-${NS}-${LB}"
+auth=(-H "Authorization: APIToken ${XCSH_API_TOKEN}")
+budget="${MUD_VERIFY_BUDGET:-1200}"
+interval="${MUD_VERIFY_INTERVAL:-60}"
+
+echo "== 1) MUD active on ${NS}/${LB} =="
+lb=$(curl -s "${auth[@]}" "${base}/api/config/namespaces/${NS}/http_loadbalancers/${LB}")
+read -r det mit < <(printf '%s' "$lb" | python3 -c '
+import sys, json
+s = (json.load(sys.stdin) or {}).get("spec", {})
+det = "yes" if "enable_malicious_user_detection" in s else "no"
+ec = s.get("enable_challenge") or s.get("policy_based_challenge") or {}
+ref = (ec or {}).get("malicious_user_mitigation") or {}
+print(det, ref.get("name", "none"))
+')
+echo "  enable_malicious_user_detection: ${det}"
+echo "  active mitigation policy:        ${mit}"
+if [ "${det}" != "yes" ] || [ "${mit}" = "none" ]; then
+  echo "  => MUD NOT fully active"
+  exit 1
+fi
+echo "  => MUD ACTIVE"
+
+echo "== 2) Flagged malicious users (poll up to ${budget}s) =="
+waited=0
+while :; do
+  resp=$(curl -s -w $'\n%{http_code}' "${auth[@]}" \
+    "${base}/api/ml/data/namespaces/${NS}/app_settings/${APP}/suspicious_users?topn=20")
+  code=$(printf '%s' "$resp" | tail -1)
+  body=$(printf '%s' "$resp" | sed '$d')
+  if [ "$code" = "200" ]; then
+    n=$(printf '%s' "$body" | python3 -c '
+import sys, json
+d = json.load(sys.stdin) or {}
+u = d.get("suspicious_users") or d.get("users") or d.get("data") or []
+print(len(u) if isinstance(u, list) else 0)
+' 2>/dev/null || echo 0)
+    if [ "${n:-0}" -gt 0 ]; then
+      echo "  FLAGGED users: ${n}"
+      printf '%s' "$body" | python3 -m json.tool 2>/dev/null | head -40
+      echo "  => DETECTION CONFIRMED"
+      exit 0
+    fi
+    echo "  [${waited}s] MUD active, 0 users flagged yet"
+  elif printf '%s' "$body" | grep -q "no Elasticsearch node available"; then
+    echo "  ANALYTICS BACKEND UNAVAILABLE: the tenant Elasticsearch is down, so flagged"
+    echo "  users cannot be read on this tenant. MUD is configured + active (step 1);"
+    echo "  detection is blocked by tenant infra, not by config or traffic."
+    exit 2
+  else
+    echo "  [${waited}s] unexpected HTTP ${code}: $(printf '%s' "$body" | head -c 160)"
+  fi
+  waited=$((waited + interval))
+  if [ "${waited}" -ge "${budget}" ]; then
+    echo "  no users flagged within ${budget}s (MUD active; increase traffic intensity/duration)"
+    exit 3
+  fi
+  sleep "${interval}"
+done

--- a/terraform/cloud-init/traffic-generator.yaml
+++ b/terraform/cloud-init/traffic-generator.yaml
@@ -196,6 +196,14 @@ write_files:
       CONTINUOUS_ENABLED=true
       CONTINUOUS_RATE=50
       CONTINUOUS_DURATION=30s
+      # --- Malicious-user profile (drives Malicious User Detection scoring) ---
+      # When true, each burst also emits identifiable bad-user traffic (WAF-triggering
+      # payloads, forbidden-path scanning, failed logins) carrying a stable identity via
+      # header/cookie/query so MUD attributes it to one user regardless of which
+      # user-identification rule is active. Read every run by tgen-continuous.
+      MUD_BAD_TRAFFIC=${mud_bad_traffic}
+      MUD_BAD_USER_ID=mud-attacker-01
+      MUD_BAD_ITERATIONS=40
 
   - path: /opt/traffic-generator/status.json
     content: |
@@ -296,6 +304,30 @@ write_files:
         while [ "$(date +%s)" -lt "$${end}" ]; do
           for ep in $${ENDPOINTS}; do curl -s -o /dev/null "$${BASE}$${ep}"; done
         done
+      fi
+      # --- Malicious-user burst: identifiable bad-user traffic to drive MUD scoring. ---
+      # Sends WAF-triggering / forbidden / high-error requests plus failed logins, all
+      # tagged with one identity (X-MUD-User header + x-mud-user cookie + mud_user query)
+      # so F5 XC attributes the abuse to a single user and raises its threat level.
+      if [ "$${MUD_BAD_TRAFFIC:-false}" = "true" ]; then
+        _uid="$${MUD_BAD_USER_ID:-mud-attacker-01}"
+        _hdr="X-MUD-User: $${_uid}"
+        _ck="x-mud-user=$${_uid}"
+        _iter="$${MUD_BAD_ITERATIONS:-40}"
+        echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] malicious-user burst -> $${BASE} as $${_uid}" >> "$${LOG}"
+        for _n in $(seq 1 "$${_iter}"); do
+          for _p in "/?q=%27+OR+%271%27%3D%271" "/?x=%3Cscript%3Ealert(1)%3C%2Fscript%3E" "/admin" "/.env" "/wp-login.php" "/phpmyadmin/" "/httpbin/status/401" "/httpbin/status/403"; do
+            curl -s -o /dev/null -m 5 -H "$${_hdr}" -b "$${_ck}" "$${BASE}$${_p}"
+          done
+          # query-param identity variant (covers the query_param_key user-id rule)
+          curl -s -o /dev/null -m 5 -H "$${_hdr}" -b "$${_ck}" "$${BASE}/admin?mud_user=$${_uid}"
+          # failed-login pattern (credential stuffing) against juice-shop
+          curl -s -o /dev/null -m 5 -H "$${_hdr}" -b "$${_ck}" -X POST \
+            -H 'Content-Type: application/json' \
+            -d "{\"email\":\"admin@juice-sh.op\",\"password\":\"wrong$${_n}\"}" \
+            "$${BASE}/juice-shop/rest/user/login"
+        done
+        echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] malicious-user burst complete" >> "$${LOG}"
       fi
       tail -n 2000 "$${LOG}" > "$${LOG}.tmp" 2>/dev/null && mv "$${LOG}.tmp" "$${LOG}"
       echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] burst complete" >> "$${LOG}"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -158,6 +158,9 @@ module "traffic_generator" {
     target_fqdn      = var.lb_domains[0]
     target_origin_ip = module.origin_server.public_ip
     tool_tier        = var.traffic_gen_tool_tier
+    # Emit identifiable malicious-user traffic each burst so MUD scores a user and
+    # applies the configured mitigation (only meaningful when mud_enabled).
+    mud_bad_traffic = var.mud_enabled && var.mud_bad_traffic
   }))
 
   # The generator is only useful once the LB exists to receive its traffic.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -58,13 +58,17 @@ module "http_lb" {
   lb_domains = var.lb_domains
   # Point the origin pool at the Azure origin server's public IP (created above).
   # Terraform orders VM creation before the pool that references its IP.
-  origin_ip         = module.origin_server.public_ip
-  origin_port       = var.origin_port
-  health_check_path = var.health_check_path
-  labels            = var.labels
-  waf_mode          = var.waf_mode
-  csd_enabled       = var.csd_enabled
-  mud_enabled       = var.mud_enabled
+  origin_ip          = module.origin_server.public_ip
+  origin_port        = var.origin_port
+  health_check_path  = var.health_check_path
+  labels             = var.labels
+  waf_mode           = var.waf_mode
+  csd_enabled        = var.csd_enabled
+  mud_enabled        = var.mud_enabled
+  mud_user_id        = var.mud_user_id
+  mud_user_id_rule   = var.mud_user_id_rule
+  mud_mitigation     = var.mud_mitigation
+  mud_challenge_mode = var.mud_challenge_mode
 
   # Enabling client_side_defense on the LB requires a protected domain to already
   # exist in this namespace (F5 XC generates the CSD JS config from it), so the

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -166,6 +166,67 @@ resource "xcsh_malicious_user_mitigation" "mud" {
   }
 }
 
+# User-identification policy — only when mud_user_id = user_identification. Exactly one
+# rule of the selected type: keyed rule-types set the matching string attribute; marker
+# rule-types are emitted as an empty block. Referenced by the LB's user_identification
+# block below. When mud_user_id = client_ip we create nothing and the LB uses the
+# server-default user_id_client_ip (import-suppressed).
+resource "xcsh_user_identification" "mud" {
+  count     = var.mud_enabled && var.mud_user_id == "user_identification" ? 1 : 0
+  name      = "webapp-api-protection-mud-userid"
+  namespace = var.namespace
+  labels    = var.labels
+
+  rules {
+    cookie_name             = var.mud_user_id_rule == "cookie_name" ? "x-mud-user" : null
+    http_header_name        = var.mud_user_id_rule == "http_header_name" ? "X-MUD-User" : null
+    ip_and_http_header_name = var.mud_user_id_rule == "ip_and_http_header_name" ? "X-MUD-User" : null
+    jwt_claim_name          = var.mud_user_id_rule == "jwt_claim_name" ? "sub" : null
+    query_param_key         = var.mud_user_id_rule == "query_param_key" ? "mud_user" : null
+
+    dynamic "client_asn" {
+      for_each = var.mud_user_id_rule == "client_asn" ? [1] : []
+      content {}
+    }
+    dynamic "client_city" {
+      for_each = var.mud_user_id_rule == "client_city" ? [1] : []
+      content {}
+    }
+    dynamic "client_country" {
+      for_each = var.mud_user_id_rule == "client_country" ? [1] : []
+      content {}
+    }
+    dynamic "client_ip" {
+      for_each = var.mud_user_id_rule == "client_ip" ? [1] : []
+      content {}
+    }
+    dynamic "client_region" {
+      for_each = var.mud_user_id_rule == "client_region" ? [1] : []
+      content {}
+    }
+    dynamic "tls_fingerprint" {
+      for_each = var.mud_user_id_rule == "tls_fingerprint" ? [1] : []
+      content {}
+    }
+    dynamic "ip_and_tls_fingerprint" {
+      for_each = var.mud_user_id_rule == "ip_and_tls_fingerprint" ? [1] : []
+      content {}
+    }
+    dynamic "ja4_tls_fingerprint" {
+      for_each = var.mud_user_id_rule == "ja4_tls_fingerprint" ? [1] : []
+      content {}
+    }
+    dynamic "ip_and_ja4_tls_fingerprint" {
+      for_each = var.mud_user_id_rule == "ip_and_ja4_tls_fingerprint" ? [1] : []
+      content {}
+    }
+    dynamic "none" {
+      for_each = var.mud_user_id_rule == "none" ? [1] : []
+      content {}
+    }
+  }
+}
+
 resource "xcsh_http_loadbalancer" "this" {
   name      = "webapp-api-protection"
   namespace = var.namespace
@@ -233,12 +294,24 @@ resource "xcsh_http_loadbalancer" "this" {
 
   # Malicious User Detection — score per-user behavior into threat levels
   # (malicious_user_detection oneof vs the server default disable_malicious_user_detection).
-  # User identification uses the server-default client IP (user_id_client_ip); both the
-  # disable marker and the client-IP default are suppressed by the provider on import, so
-  # when mud_enabled is false we emit NO block (no drift; do not declare them).
+  # (malicious_user_detection oneof vs the server default disable_malicious_user_detection).
+  # When mud_enabled is false we emit NO block — the server applies the disable marker,
+  # which the provider suppresses on import (no drift; do not declare it).
   dynamic "enable_malicious_user_detection" {
     for_each = var.mud_enabled ? [1] : []
     content {}
+  }
+
+  # User identification: reference a user_identification policy when mud_user_id is
+  # user_identification; otherwise emit nothing and the server applies the default
+  # user_id_client_ip (import-suppressed). (user_id oneof: user_id_client_ip vs
+  # user_identification.)
+  dynamic "user_identification" {
+    for_each = var.mud_enabled && var.mud_user_id == "user_identification" ? [1] : []
+    content {
+      name      = xcsh_user_identification.mud[0].name
+      namespace = xcsh_user_identification.mud[0].namespace
+    }
   }
 
   # Auto-mitigation for detected malicious users. enable_challenge is the challenge

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -314,12 +314,22 @@ resource "xcsh_http_loadbalancer" "this" {
     }
   }
 
-  # Auto-mitigation for detected malicious users. enable_challenge is the challenge
-  # oneof arm that carries the malicious_user_mitigation reference (peer to the server
-  # default no_challenge, which the provider suppresses on import). It points at the
-  # mitigation policy created above.
+  # Auto-mitigation for detected malicious users, via the challenge oneof. mud_challenge_mode
+  # selects enable_challenge (risk-based) or policy_based_challenge (policy-rule-based); both
+  # carry the malicious_user_mitigation reference. "none" emits neither → server default
+  # no_challenge (import-suppressed). Both arms are gated on mud_enabled.
   dynamic "enable_challenge" {
-    for_each = var.mud_enabled ? [1] : []
+    for_each = var.mud_enabled && var.mud_challenge_mode == "enable_challenge" ? [1] : []
+    content {
+      malicious_user_mitigation {
+        name      = xcsh_malicious_user_mitigation.mud[0].name
+        namespace = xcsh_malicious_user_mitigation.mud[0].namespace
+      }
+    }
+  }
+
+  dynamic "policy_based_challenge" {
+    for_each = var.mud_enabled && var.mud_challenge_mode == "policy_based_challenge" ? [1] : []
     content {
       malicious_user_mitigation {
         name      = xcsh_malicious_user_mitigation.mud[0].name

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -100,13 +100,29 @@ resource "xcsh_malicious_user_mitigation" "mud" {
   namespace = var.namespace
   labels    = var.labels
 
+  # One static rule per threat level (low/medium/high); the ACTION within each is chosen
+  # by var.mud_mitigation. The rules list is kept static (3 entries) because a dynamic
+  # rules list produces an unknown-typed value the generated provider model cannot handle
+  # (mitigation_type.rules → []RulesModel, not a ListValue). Action is a oneof; emit the
+  # selected member as an empty marker.
   mitigation_type {
     rules {
       threat_level {
         low {}
       }
       mitigation_action {
-        javascript_challenge {}
+        dynamic "block_temporarily" {
+          for_each = var.mud_mitigation.low == "block_temporarily" ? [1] : []
+          content {}
+        }
+        dynamic "captcha_challenge" {
+          for_each = var.mud_mitigation.low == "captcha_challenge" ? [1] : []
+          content {}
+        }
+        dynamic "javascript_challenge" {
+          for_each = var.mud_mitigation.low == "javascript_challenge" ? [1] : []
+          content {}
+        }
       }
     }
     rules {
@@ -114,7 +130,18 @@ resource "xcsh_malicious_user_mitigation" "mud" {
         medium {}
       }
       mitigation_action {
-        captcha_challenge {}
+        dynamic "block_temporarily" {
+          for_each = var.mud_mitigation.medium == "block_temporarily" ? [1] : []
+          content {}
+        }
+        dynamic "captcha_challenge" {
+          for_each = var.mud_mitigation.medium == "captcha_challenge" ? [1] : []
+          content {}
+        }
+        dynamic "javascript_challenge" {
+          for_each = var.mud_mitigation.medium == "javascript_challenge" ? [1] : []
+          content {}
+        }
       }
     }
     rules {
@@ -122,7 +149,18 @@ resource "xcsh_malicious_user_mitigation" "mud" {
         high {}
       }
       mitigation_action {
-        block_temporarily {}
+        dynamic "block_temporarily" {
+          for_each = var.mud_mitigation.high == "block_temporarily" ? [1] : []
+          content {}
+        }
+        dynamic "captcha_challenge" {
+          for_each = var.mud_mitigation.high == "captcha_challenge" ? [1] : []
+          content {}
+        }
+        dynamic "javascript_challenge" {
+          for_each = var.mud_mitigation.high == "javascript_challenge" ? [1] : []
+          content {}
+        }
       }
     }
   }

--- a/terraform/modules/http-lb/outputs.tf
+++ b/terraform/modules/http-lb/outputs.tf
@@ -42,3 +42,18 @@ output "mud_enabled" {
   description = "Whether Malicious User Detection (with auto-mitigation) is enabled on the load balancer."
   value       = var.mud_enabled
 }
+
+output "mud_user_id" {
+  description = "Effective MUD user-identification method (client_ip or user_identification)."
+  value       = var.mud_user_id
+}
+
+output "mud_mitigation" {
+  description = "Effective MUD mitigation action per threat level (low/medium/high)."
+  value       = var.mud_mitigation
+}
+
+output "mud_challenge_mode" {
+  description = "Effective MUD challenge mode (none/enable_challenge/policy_based_challenge)."
+  value       = var.mud_challenge_mode
+}

--- a/terraform/modules/http-lb/variables.tf
+++ b/terraform/modules/http-lb/variables.tf
@@ -53,3 +53,62 @@ variable "mud_enabled" {
   type        = bool
   default     = true
 }
+
+variable "mud_user_id" {
+  description = "User identification method for MUD: client_ip (server default) or user_identification (a policy resource)."
+  type        = string
+  default     = "client_ip"
+
+  validation {
+    condition     = contains(["client_ip", "user_identification"], var.mud_user_id)
+    error_message = "mud_user_id must be \"client_ip\" or \"user_identification\"."
+  }
+}
+
+variable "mud_user_id_rule" {
+  description = "When mud_user_id=user_identification, the rule type used to identify users (one of the xcsh_user_identification rule types)."
+  type        = string
+  default     = "client_ip"
+
+  validation {
+    condition = contains([
+      "cookie_name", "http_header_name", "ip_and_http_header_name", "jwt_claim_name",
+      "query_param_key", "client_asn", "client_city", "client_country", "client_ip",
+      "client_region", "tls_fingerprint", "ip_and_tls_fingerprint", "none"
+    ], var.mud_user_id_rule)
+    error_message = "mud_user_id_rule must be one of the supported xcsh_user_identification rule types."
+  }
+}
+
+variable "mud_mitigation" {
+  description = "Malicious-user mitigation action per threat level. Each value is block_temporarily, captcha_challenge, or javascript_challenge."
+  type = object({
+    low    = string
+    medium = string
+    high   = string
+  })
+  default = {
+    low    = "javascript_challenge"
+    medium = "captcha_challenge"
+    high   = "block_temporarily"
+  }
+
+  validation {
+    condition = alltrue([
+      for action in values(var.mud_mitigation) :
+      contains(["block_temporarily", "captcha_challenge", "javascript_challenge"], action)
+    ])
+    error_message = "each mud_mitigation action must be block_temporarily, captcha_challenge, or javascript_challenge."
+  }
+}
+
+variable "mud_challenge_mode" {
+  description = "LB challenge integration for MUD auto-mitigation: none, enable_challenge, or policy_based_challenge."
+  type        = string
+  default     = "enable_challenge"
+
+  validation {
+    condition     = contains(["none", "enable_challenge", "policy_based_challenge"], var.mud_challenge_mode)
+    error_message = "mud_challenge_mode must be none, enable_challenge, or policy_based_challenge."
+  }
+}

--- a/terraform/modules/http-lb/variables.tf
+++ b/terraform/modules/http-lb/variables.tf
@@ -74,7 +74,8 @@ variable "mud_user_id_rule" {
     condition = contains([
       "cookie_name", "http_header_name", "ip_and_http_header_name", "jwt_claim_name",
       "query_param_key", "client_asn", "client_city", "client_country", "client_ip",
-      "client_region", "tls_fingerprint", "ip_and_tls_fingerprint", "none"
+      "client_region", "tls_fingerprint", "ip_and_tls_fingerprint", "ja4_tls_fingerprint",
+      "ip_and_ja4_tls_fingerprint", "none"
     ], var.mud_user_id_rule)
     error_message = "mud_user_id_rule must be one of the supported xcsh_user_identification rule types."
   }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -43,6 +43,21 @@ output "mud_enabled" {
   value       = module.http_lb.mud_enabled
 }
 
+output "mud_user_id" {
+  description = "Effective MUD user-identification method."
+  value       = module.http_lb.mud_user_id
+}
+
+output "mud_mitigation" {
+  description = "Effective MUD mitigation action per threat level."
+  value       = module.http_lb.mud_mitigation
+}
+
+output "mud_challenge_mode" {
+  description = "Effective MUD challenge mode."
+  value       = module.http_lb.mud_challenge_mode
+}
+
 
 # --- Azure origin server ------------------------------------------------------
 

--- a/terraform/tests/mud_challenge.tftest.hcl
+++ b/terraform/tests/mud_challenge.tftest.hcl
@@ -1,0 +1,44 @@
+# Plan-level test: the LB challenge integration is selected by mud_challenge_mode —
+# enable_challenge, policy_based_challenge, or none (neither block). Each mode must
+# produce a valid plan. Targets ./modules/http-lb with a dummy origin — no tenant.
+variables {
+  namespace         = "webapp-api-protection"
+  lb_domains        = ["www.f5-sales-demo.com"]
+  origin_ip         = "203.0.113.10"
+  origin_port       = 80
+  health_check_path = "/health"
+  labels            = {}
+  waf_mode          = "blocking"
+  csd_enabled       = false
+  mud_enabled       = true
+}
+
+run "challenge_enable_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { mud_challenge_mode = "enable_challenge" }
+  assert {
+    condition     = output.mud_challenge_mode == "enable_challenge"
+    error_message = "challenge mode must be enable_challenge"
+  }
+}
+
+run "challenge_policy_based_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { mud_challenge_mode = "policy_based_challenge" }
+  assert {
+    condition     = output.mud_challenge_mode == "policy_based_challenge"
+    error_message = "challenge mode must be policy_based_challenge"
+  }
+}
+
+run "challenge_none_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { mud_challenge_mode = "none" }
+  assert {
+    condition     = output.mud_challenge_mode == "none"
+    error_message = "challenge mode none must render (neither challenge block emitted)"
+  }
+}

--- a/terraform/tests/mud_defaults.tftest.hcl
+++ b/terraform/tests/mud_defaults.tftest.hcl
@@ -1,0 +1,36 @@
+# Plan-level test: the MUD option variables expose sensible defaults and render.
+# Targets ./modules/http-lb directly with a dummy origin — no tenant contact.
+run "mud_defaults_render" {
+  command = plan
+
+  module {
+    source = "./modules/http-lb"
+  }
+
+  variables {
+    namespace         = "webapp-api-protection"
+    lb_domains        = ["www.f5-sales-demo.com"]
+    origin_ip         = "203.0.113.10"
+    origin_port       = 80
+    health_check_path = "/health"
+    labels            = {}
+    waf_mode          = "blocking"
+    csd_enabled       = false
+    mud_enabled       = true
+  }
+
+  assert {
+    condition     = output.mud_user_id == "client_ip"
+    error_message = "default MUD user-id method must be client_ip"
+  }
+
+  assert {
+    condition     = output.mud_challenge_mode == "enable_challenge"
+    error_message = "default MUD challenge mode must be enable_challenge"
+  }
+
+  assert {
+    condition     = output.mud_mitigation.high == "block_temporarily"
+    error_message = "default high-threat action must be block_temporarily"
+  }
+}

--- a/terraform/tests/mud_matrix.tftest.hcl
+++ b/terraform/tests/mud_matrix.tftest.hcl
@@ -1,0 +1,246 @@
+# Exhaustive plan-level matrix: every MUD user-identification rule type, and every
+# mitigation action at every threat level, must produce a valid plan. Challenge modes
+# are covered in mud_challenge.tftest.hcl. Targets ./modules/http-lb — no tenant contact.
+variables {
+  namespace         = "webapp-api-protection"
+  lb_domains        = ["www.f5-sales-demo.com"]
+  origin_ip         = "203.0.113.10"
+  origin_port       = 80
+  health_check_path = "/health"
+  labels            = {}
+  waf_mode          = "blocking"
+  csd_enabled       = false
+  mud_enabled       = true
+  mud_user_id       = "user_identification"
+}
+
+run "uid_cookie_name" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    mud_user_id_rule = "cookie_name"
+  }
+  assert {
+    condition     = length(xcsh_user_identification.mud) == 1
+    error_message = "cookie_name policy must be created"
+  }
+}
+
+run "uid_http_header_name" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    mud_user_id_rule = "http_header_name"
+  }
+  assert {
+    condition     = length(xcsh_user_identification.mud) == 1
+    error_message = "http_header_name policy must be created"
+  }
+}
+
+run "uid_ip_and_http_header_name" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    mud_user_id_rule = "ip_and_http_header_name"
+  }
+  assert {
+    condition     = length(xcsh_user_identification.mud) == 1
+    error_message = "ip_and_http_header_name policy must be created"
+  }
+}
+
+run "uid_jwt_claim_name" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    mud_user_id_rule = "jwt_claim_name"
+  }
+  assert {
+    condition     = length(xcsh_user_identification.mud) == 1
+    error_message = "jwt_claim_name policy must be created"
+  }
+}
+
+run "uid_query_param_key" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    mud_user_id_rule = "query_param_key"
+  }
+  assert {
+    condition     = length(xcsh_user_identification.mud) == 1
+    error_message = "query_param_key policy must be created"
+  }
+}
+
+run "uid_client_asn" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    mud_user_id_rule = "client_asn"
+  }
+  assert {
+    condition     = length(xcsh_user_identification.mud) == 1
+    error_message = "client_asn policy must be created"
+  }
+}
+
+run "uid_client_city" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    mud_user_id_rule = "client_city"
+  }
+  assert {
+    condition     = length(xcsh_user_identification.mud) == 1
+    error_message = "client_city policy must be created"
+  }
+}
+
+run "uid_client_country" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    mud_user_id_rule = "client_country"
+  }
+  assert {
+    condition     = length(xcsh_user_identification.mud) == 1
+    error_message = "client_country policy must be created"
+  }
+}
+
+run "uid_client_ip" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    mud_user_id_rule = "client_ip"
+  }
+  assert {
+    condition     = length(xcsh_user_identification.mud) == 1
+    error_message = "client_ip policy must be created"
+  }
+}
+
+run "uid_client_region" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    mud_user_id_rule = "client_region"
+  }
+  assert {
+    condition     = length(xcsh_user_identification.mud) == 1
+    error_message = "client_region policy must be created"
+  }
+}
+
+run "uid_tls_fingerprint" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    mud_user_id_rule = "tls_fingerprint"
+  }
+  assert {
+    condition     = length(xcsh_user_identification.mud) == 1
+    error_message = "tls_fingerprint policy must be created"
+  }
+}
+
+run "uid_ip_and_tls_fingerprint" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    mud_user_id_rule = "ip_and_tls_fingerprint"
+  }
+  assert {
+    condition     = length(xcsh_user_identification.mud) == 1
+    error_message = "ip_and_tls_fingerprint policy must be created"
+  }
+}
+
+run "uid_ja4_tls_fingerprint" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    mud_user_id_rule = "ja4_tls_fingerprint"
+  }
+  assert {
+    condition     = length(xcsh_user_identification.mud) == 1
+    error_message = "ja4_tls_fingerprint policy must be created"
+  }
+}
+
+run "uid_ip_and_ja4_tls_fingerprint" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    mud_user_id_rule = "ip_and_ja4_tls_fingerprint"
+  }
+  assert {
+    condition     = length(xcsh_user_identification.mud) == 1
+    error_message = "ip_and_ja4_tls_fingerprint policy must be created"
+  }
+}
+
+run "uid_none" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    mud_user_id_rule = "none"
+  }
+  assert {
+    condition     = length(xcsh_user_identification.mud) == 1
+    error_message = "none policy must be created"
+  }
+}
+
+run "mit_all_block" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    mud_user_id = "client_ip"
+    mud_mitigation = {
+      low    = "block_temporarily"
+      medium = "block_temporarily"
+      high   = "block_temporarily"
+    }
+  }
+  assert {
+    condition     = output.mud_mitigation.high == "block_temporarily"
+    error_message = "all-block mitigation map must render"
+  }
+}
+
+run "mit_all_captcha" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    mud_user_id = "client_ip"
+    mud_mitigation = {
+      low    = "captcha_challenge"
+      medium = "captcha_challenge"
+      high   = "captcha_challenge"
+    }
+  }
+  assert {
+    condition     = output.mud_mitigation.high == "captcha_challenge"
+    error_message = "all-captcha mitigation map must render"
+  }
+}
+
+run "mit_all_js" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    mud_user_id = "client_ip"
+    mud_mitigation = {
+      low    = "javascript_challenge"
+      medium = "javascript_challenge"
+      high   = "javascript_challenge"
+    }
+  }
+  assert {
+    condition     = output.mud_mitigation.high == "javascript_challenge"
+    error_message = "all-js mitigation map must render"
+  }
+}

--- a/terraform/tests/mud_mitigation.tftest.hcl
+++ b/terraform/tests/mud_mitigation.tftest.hcl
@@ -1,0 +1,39 @@
+# Plan-level test: the mitigation policy is driven by var.mud_mitigation and every
+# action renders at every threat level (dynamic block validity). Deep resource content
+# is verified live by the config-matrix round-trip import (plan tests cannot introspect
+# nested blocks). Targets ./modules/http-lb with a dummy origin — no tenant contact.
+variables {
+  namespace         = "webapp-api-protection"
+  lb_domains        = ["www.f5-sales-demo.com"]
+  origin_ip         = "203.0.113.10"
+  origin_port       = 80
+  health_check_path = "/health"
+  labels            = {}
+  waf_mode          = "blocking"
+  csd_enabled       = false
+  mud_enabled       = true
+}
+
+run "mitigation_permuted_map_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    mud_mitigation = { low = "block_temporarily", medium = "javascript_challenge", high = "captcha_challenge" }
+  }
+  assert {
+    condition     = output.mud_mitigation.low == "block_temporarily" && output.mud_mitigation.medium == "javascript_challenge" && output.mud_mitigation.high == "captcha_challenge"
+    error_message = "mitigation map must flow through to the module unchanged"
+  }
+}
+
+run "mitigation_all_captcha_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    mud_mitigation = { low = "captcha_challenge", medium = "captcha_challenge", high = "captcha_challenge" }
+  }
+  assert {
+    condition     = output.mud_enabled == true
+    error_message = "plan must succeed for an all-captcha mitigation map"
+  }
+}

--- a/terraform/tests/mud_userid.tftest.hcl
+++ b/terraform/tests/mud_userid.tftest.hcl
@@ -1,0 +1,56 @@
+# Plan-level test: MUD user identification switches between the client-IP default and a
+# user_identification policy resource selecting a specific rule type. Targets
+# ./modules/http-lb with a dummy origin — no tenant contact.
+variables {
+  namespace         = "webapp-api-protection"
+  lb_domains        = ["www.f5-sales-demo.com"]
+  origin_ip         = "203.0.113.10"
+  origin_port       = 80
+  health_check_path = "/health"
+  labels            = {}
+  waf_mode          = "blocking"
+  csd_enabled       = false
+  mud_enabled       = true
+}
+
+run "userid_http_header_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    mud_user_id      = "user_identification"
+    mud_user_id_rule = "http_header_name"
+  }
+  assert {
+    condition     = output.mud_user_id == "user_identification"
+    error_message = "user-id method must be user_identification"
+  }
+  assert {
+    condition     = length(xcsh_user_identification.mud) == 1
+    error_message = "a user_identification policy must be created when mud_user_id=user_identification"
+  }
+}
+
+run "userid_ja4_fingerprint_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    mud_user_id      = "user_identification"
+    mud_user_id_rule = "ja4_tls_fingerprint"
+  }
+  assert {
+    condition     = length(xcsh_user_identification.mud) == 1
+    error_message = "ja4_tls_fingerprint must be an accepted user-id rule type"
+  }
+}
+
+run "userid_client_ip_no_policy" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    mud_user_id = "client_ip"
+  }
+  assert {
+    condition     = length(xcsh_user_identification.mud) == 0
+    error_message = "no user_identification policy when mud_user_id=client_ip (server default)"
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -113,6 +113,12 @@ variable "mud_challenge_mode" {
   }
 }
 
+variable "mud_bad_traffic" {
+  description = "Have the traffic generator emit identifiable malicious-user traffic (WAF-triggering payloads, forbidden-path scanning, failed logins) so MUD flags a user and applies mitigation. Only takes effect when mud_enabled. Off by default to keep the baseline demo benign."
+  type        = bool
+  default     = false
+}
+
 # ---------------------------------------------------------
 # Azure (origin server + traffic generator this plan deploys)
 # ---------------------------------------------------------

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -53,6 +53,66 @@ variable "mud_enabled" {
   default     = true
 }
 
+variable "mud_user_id" {
+  description = "MUD user identification method: client_ip (server default) or user_identification (a policy resource)."
+  type        = string
+  default     = "client_ip"
+
+  validation {
+    condition     = contains(["client_ip", "user_identification"], var.mud_user_id)
+    error_message = "mud_user_id must be \"client_ip\" or \"user_identification\"."
+  }
+}
+
+variable "mud_user_id_rule" {
+  description = "When mud_user_id=user_identification, the rule type used to identify users (one of the xcsh_user_identification rule types)."
+  type        = string
+  default     = "client_ip"
+
+  validation {
+    condition = contains([
+      "cookie_name", "http_header_name", "ip_and_http_header_name", "jwt_claim_name",
+      "query_param_key", "client_asn", "client_city", "client_country", "client_ip",
+      "client_region", "tls_fingerprint", "ip_and_tls_fingerprint", "ja4_tls_fingerprint",
+      "ip_and_ja4_tls_fingerprint", "none"
+    ], var.mud_user_id_rule)
+    error_message = "mud_user_id_rule must be one of the supported xcsh_user_identification rule types."
+  }
+}
+
+variable "mud_mitigation" {
+  description = "MUD mitigation action per threat level. Each ∈ block_temporarily, captcha_challenge, javascript_challenge."
+  type = object({
+    low    = string
+    medium = string
+    high   = string
+  })
+  default = {
+    low    = "javascript_challenge"
+    medium = "captcha_challenge"
+    high   = "block_temporarily"
+  }
+
+  validation {
+    condition = alltrue([
+      for action in values(var.mud_mitigation) :
+      contains(["block_temporarily", "captcha_challenge", "javascript_challenge"], action)
+    ])
+    error_message = "each mud_mitigation action must be block_temporarily, captcha_challenge, or javascript_challenge."
+  }
+}
+
+variable "mud_challenge_mode" {
+  description = "MUD challenge integration: none, enable_challenge, or policy_based_challenge."
+  type        = string
+  default     = "enable_challenge"
+
+  validation {
+    condition     = contains(["none", "enable_challenge", "policy_based_challenge"], var.mud_challenge_mode)
+    error_message = "mud_challenge_mode must be none, enable_challenge, or policy_based_challenge."
+  }
+}
+
 # ---------------------------------------------------------
 # Azure (origin server + traffic generator this plan deploys)
 # ---------------------------------------------------------


### PR DESCRIPTION
## Summary

Parameterizes **every** MUD option on the `http-lb` module, proves each applies idempotently and round-trip-imports clean on the live LB, adds a malicious-user traffic profile, and a behavioral verification harness. Closes #19.

## What changed

- **Variables** (module + root, validated): `mud_user_id` (client_ip | user_identification), `mud_user_id_rule` (all 15 schema rule types), `mud_mitigation` (per-threat-level action map), `mud_challenge_mode` (none | enable_challenge | policy_based_challenge), `mud_bad_traffic`. Effective-config outputs.
- **Module**: mitigation policy driven by the map (static rules + parameterized action); count-gated `xcsh_user_identification` with the selected rule; challenge oneof driven by mode.
- **Tests**: `tests/mud_*.tftest.hcl` — 27 plan-level assertions (TDD red→green).
- **Live harness**: `scripts/mud-matrix.sh` / `make mud-matrix` — apply → idempotent → round-trip import across every combination.
- **Traffic**: `scripts/`-driven malicious-user profile in the traffic generator (gated `mud_bad_traffic`): identifiable bad-user traffic (WAF-triggering, forbidden scanning, failed logins) tagged with one identity so MUD attributes it to a single user.
- **Verify**: `scripts/mud-verify.sh` / `make mud-verify` — confirms MUD active + polls the analytics suspicious-users dataset for flagged users.

## Verification

- `terraform test`: **27 passed**; `terraform fmt` clean; template escaping verified.
- **Live matrix** (pre-prod LB): **21/21 combinations** apply idempotently + round-trip-import clean; **zero import drift**. Live LB left canonical + idempotent.
- **MUD active** confirmed live (`enable_malicious_user_detection` + mitigation `webapp-api-protection-mud`).
- **Behavioral flagged-user detection is pending tenant infrastructure**: the analytics API (`/api/ml/data/.../suspicious_users`) currently returns `HTTP 500 no Elasticsearch node available` on this pre-prod tenant. The traffic profile + `mud-verify` will confirm end-to-end detection once the tenant's Elasticsearch is back — MUD config/coverage itself is fully verified.

## Lock-step

- terraform-provider-xcsh **#1079 / PR #1080** (green): object-reference `tenant` inconsistent/invalid-result on newly-added blocks — surfaced by this matrix, fixed (two-part codegen), live-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
