### PR TITLE
fix: mud-verify queries security-log plane, not the ES-backed ML dataset

### DIFF
--- a/scripts/mud-verify.sh
+++ b/scripts/mud-verify.sh
@@ -4,13 +4,16 @@
 # 1) Confirms Malicious User Detection is ACTIVE on the load balancer
 #    (enable_malicious_user_detection + a resolvable malicious_user_mitigation
 #    reference) — a config check, always available.
-# 2) Polls the F5 XC analytics API for FLAGGED malicious users (the suspicious-users
-#    dataset MUD produces) under the enhanced traffic generator, until at least one
-#    user is flagged or the budget elapses.
+# 2) Queries the F5 XC security-log plane for the suspicious-user detection records
+#    MUD produces, and reports flagged identities (threat_level != None) plus the
+#    mitigation actions applied (mum_temporarily_blocking / mum_captcha_challenge /
+#    mum_js_challenge). This is the same dataset the console's "Malicious Users" view
+#    uses — POST /api/data/namespaces/{ns}/app_security/suspicious_user_logs — NOT the
+#    ML dataset /api/ml/data/.../suspicious_users (which depends on a separate
+#    Elasticsearch cluster and can be independently unavailable).
 #
-# Exit codes: 0 = MUD active AND ≥1 user flagged; 1 = MUD not active;
-# 2 = MUD active but the tenant analytics backend (Elasticsearch) is unavailable, so
-# flagged users cannot be confirmed here; 3 = MUD active but no flags within budget.
+# Exit codes: 0 = MUD active AND >=1 detection record in the window; 1 = MUD not active;
+# 3 = MUD active but no detection records within the window (increase traffic).
 set -uo pipefail
 
 : "${XCSH_API_URL:?XCSH_API_URL required}"
@@ -18,10 +21,14 @@ set -uo pipefail
 base="${XCSH_API_URL%/}"
 NS="${1:-webapp-api-protection}"
 LB="${2:-webapp-api-protection}"
-APP="ves-io-${NS}-${LB}"
 auth=(-H "Authorization: APIToken ${XCSH_API_TOKEN}")
-budget="${MUD_VERIFY_BUDGET:-1200}"
-interval="${MUD_VERIFY_INTERVAL:-60}"
+window_min="${MUD_VERIFY_WINDOW_MIN:-60}"
+
+# Portable UTC timestamp N minutes ago (BSD date -v on macOS, GNU date -d on Linux).
+ago_utc() {
+  date -u -v-"$1"M +%Y-%m-%dT%H:%M:%SZ 2>/dev/null ||
+    date -u -d "$1 minutes ago" +%Y-%m-%dT%H:%M:%SZ
+}
 
 echo "== 1) MUD active on ${NS}/${LB} =="
 lb=$(curl -s "${auth[@]}" "${base}/api/config/namespaces/${NS}/http_loadbalancers/${LB}")
@@ -41,39 +48,69 @@ if [ "${det}" != "yes" ] || [ "${mit}" = "none" ]; then
 fi
 echo "  => MUD ACTIVE"
 
-echo "== 2) Flagged malicious users (poll up to ${budget}s) =="
-waited=0
-while :; do
-  resp=$(curl -s -w $'\n%{http_code}' "${auth[@]}" \
-    "${base}/api/ml/data/namespaces/${NS}/app_settings/${APP}/suspicious_users?topn=20")
-  code=$(printf '%s' "$resp" | tail -1)
-  body=$(printf '%s' "$resp" | sed '$d')
-  if [ "$code" = "200" ]; then
-    n=$(printf '%s' "$body" | python3 -c '
+echo "== 2) Suspicious-user detection records (last ${window_min}m) =="
+end=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+start=$(ago_utc "${window_min}")
+req=$(printf '{"namespace":"%s","start_time":"%s","end_time":"%s","limit":500}' "${NS}" "${start}" "${end}")
+resp=$(curl -s -w $'\n%{http_code}' "${auth[@]}" -H "Content-Type: application/json" \
+  -X POST -d "${req}" \
+  "${base}/api/data/namespaces/${NS}/app_security/suspicious_user_logs")
+code=$(printf '%s' "$resp" | tail -1)
+body=$(printf '%s' "$resp" | sed '$d')
+if [ "$code" != "200" ]; then
+  echo "  unexpected HTTP ${code}: $(printf '%s' "$body" | head -c 200)"
+  exit 3
+fi
+
+printf '%s' "$body" | python3 -c '
 import sys, json
+from collections import Counter, defaultdict
 d = json.load(sys.stdin) or {}
-u = d.get("suspicious_users") or d.get("users") or d.get("data") or []
-print(len(u) if isinstance(u, list) else 0)
-' 2>/dev/null || echo 0)
-    if [ "${n:-0}" -gt 0 ]; then
-      echo "  FLAGGED users: ${n}"
-      printf '%s' "$body" | python3 -m json.tool 2>/dev/null | head -40
-      echo "  => DETECTION CONFIRMED"
-      exit 0
-    fi
-    echo "  [${waited}s] MUD active, 0 users flagged yet"
-  elif printf '%s' "$body" | grep -q "no Elasticsearch node available"; then
-    echo "  ANALYTICS BACKEND UNAVAILABLE: the tenant Elasticsearch is down, so flagged"
-    echo "  users cannot be read on this tenant. MUD is configured + active (step 1);"
-    echo "  detection is blocked by tenant infra, not by config or traffic."
-    exit 2
-  else
-    echo "  [${waited}s] unexpected HTTP ${code}: $(printf '%s' "$body" | head -c 160)"
-  fi
-  waited=$((waited + interval))
-  if [ "${waited}" -ge "${budget}" ]; then
-    echo "  no users flagged within ${budget}s (MUD active; increase traffic intensity/duration)"
+logs = []
+for x in d.get("logs", []):
+    try:
+        logs.append(json.loads(x))
+    except Exception:
+        pass
+print(f"  detection records: {len(logs)}")
+if not logs:
+    sys.exit(3)
+per = defaultdict(lambda: {"n": 0, "threat": set(), "mit": Counter(), "susp": 0.0})
+for l in logs:
+    uid = l.get("user") or l.get("src_ip") or "unknown"
+    e = per[uid]
+    e["n"] += 1
+    e["threat"].add(l.get("threat_level"))
+    try:
+        e["susp"] = max(e["susp"], float(l.get("suspicion_score") or 0))
+    except Exception:
+        pass
+    mi = l.get("mitigation_activity_info")
+    if isinstance(mi, str):
+        try:
+            mi = json.loads(mi)
+        except Exception:
+            mi = {}
+    for k, v in (mi or {}).items():
+        e["mit"][k] += int(v or 0)
+flagged = 0
+for uid, e in sorted(per.items(), key=lambda kv: -kv[1]["n"]):
+    threats = sorted(t for t in e["threat"] if t and t != "None") or ["None"]
+    mit = {k: v for k, v in e["mit"].items() if v} or {}
+    if threats != ["None"] or mit:
+        flagged += 1
+    n = e["n"]
+    susp = round(e["susp"], 2)
+    print("    %s: records=%d max_suspicion=%s threat=%s mitigation=%s"
+          % (uid, n, susp, threats, mit))
+print("  => DETECTION CONFIRMED (%d identities, %d with threat/mitigation)"
+      % (len(per), flagged))
+' || {
+  rc=$?
+  if [ "$rc" = "3" ]; then
+    echo "  MUD active but no detection records in the last ${window_min}m"
+    echo "  (drive the malicious-user traffic profile, then re-run)"
     exit 3
   fi
-  sleep "${interval}"
-done
+  exit "$rc"
+}


### PR DESCRIPTION
## Summary

Fixes `scripts/mud-verify.sh`, which queried the wrong endpoint to confirm MUD flagged a user.

It called `GET /api/ml/data/namespaces/{ns}/app_settings/{app}/suspicious_users` — an **ML dataset
backed by a separate Elasticsearch cluster** that is unavailable on the pre-prod tenant (HTTP 500
`no Elasticsearch node available`). The script treated that as "detection unverifiable on this
tenant" (exit 2), which was a false conclusion.

The F5 XC console's **Malicious Users** data comes from the security-log plane:

```
POST /api/data/namespaces/{ns}/app_security/suspicious_user_logs
```

That endpoint is healthy and returns full detection records. Step 2 now queries it over a recent
window (default 60m, `MUD_VERIFY_WINDOW_MIN`) and reports, per identity: record count, max
suspicion score, threat levels, and mitigation-action counters. Step 1 (config active) is unchanged.
Exit 0 = detections present; exit 3 = MUD active but none in window.

## Live verification (webapp-api-protection LB)

A single-source attack burst (SQLi/XSS/traversal/cmdi + forbidden + failed logins) was driven from
one IP. Within ~90s the corrected script reported:

```
== 1) MUD active ... => MUD ACTIVE
== 2) Suspicious-user detection records (last 60m) ==
  detection records: 500
    IP-40.75.20.196:  records=479 max_suspicion=0.1 threat=['None'] mitigation={}
    IP-104.219.105.84: records=21 max_suspicion=1.0 threat=['High']
                       mitigation={'mum_temporarily_blocking': 684}
  => DETECTION CONFIRMED (2 identities, 1 with threat/mitigation)
```

i.e. detection **and** the configured `high → block_temporarily` mitigation, confirmed end-to-end.
The ML/ES outage is now correctly understood as irrelevant to MUD verification.

## Verification

- `shellcheck` clean; `shfmt -i 2 -d` clean.
- Live run exits 0 against the production LB (output above).

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)
