### PR TITLE
feat: exhaustive WAF (app_firewall) option coverage + all-pairs live matrix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,6 @@ mud-verify:
 # Cycle the live app_firewall through the all-pairs + enum + min/max + maximal
 # WAF variant set and verify apply / idempotency / round-trip import. Runs in
 # batches: `make waf-matrix` (all) or `bash scripts/waf-matrix.sh START END`.
-# See scripts/waf-pairs.py (generator) and scripts/waf-matrix.sh (harness).
+# See scripts/waf_pairs.py (generator) and scripts/waf-matrix.sh (harness).
 waf-matrix:
 	bash scripts/waf-matrix.sh

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # webapp-api-protection developer targets.
 
-.PHONY: mud-matrix mud-verify test
+.PHONY: mud-matrix mud-verify waf-matrix test
 
-# Run the MUD plan-level test suite (no tenant contact).
+# Run the plan-level test suite (no tenant contact).
 test:
 	cd terraform && terraform test
 
@@ -15,3 +15,10 @@ mud-matrix:
 # scripts/mud-verify.sh.
 mud-verify:
 	bash scripts/mud-verify.sh
+
+# Cycle the live app_firewall through the all-pairs + enum + min/max + maximal
+# WAF variant set and verify apply / idempotency / round-trip import. Runs in
+# batches: `make waf-matrix` (all) or `bash scripts/waf-matrix.sh START END`.
+# See scripts/waf-pairs.py (generator) and scripts/waf-matrix.sh (harness).
+waf-matrix:
+	bash scripts/waf-matrix.sh

--- a/scripts/waf-matrix.sh
+++ b/scripts/waf-matrix.sh
@@ -2,7 +2,7 @@
 # WAF (app_firewall) live coverage-matrix harness.
 #
 # Cycles the LIVE webapp-api-protection app_firewall through the all-pairs +
-# enum + min/max + maximal variant set (scripts/waf-pairs.py) and verifies each
+# enum + min/max + maximal variant set (scripts/waf_pairs.py) and verifies each
 # variant is (a) applies, (b) idempotent (immediate plan = No changes), and
 # (c) round-trip-import clean (state rm -> import -> plan clean) for
 # module.http_lb.xcsh_app_firewall.this. Entitlement/permission-rejected arms are
@@ -40,7 +40,7 @@ END="${2:-9999}"
 # blocking-page code). A 400 BAD_REQUEST (invalid arm combination) is a real FAIL.
 GATED_RE='entitlement|not subscribed|not entitled|not enabled for|permission denied|unauthorized|AS_NOT_SUBSCRIBED|status: 401|status: 403'
 
-count=$(python3 ../scripts/waf-pairs.py --emit "$VARDIR")
+count=$(python3 ../scripts/waf_pairs.py --emit "$VARDIR")
 echo "generated $count variants into $VARDIR (running [$START..$END])"
 
 round_trip() {

--- a/scripts/waf-matrix.sh
+++ b/scripts/waf-matrix.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# WAF (app_firewall) live coverage-matrix harness.
+#
+# Cycles the LIVE webapp-api-protection app_firewall through the all-pairs +
+# enum + min/max + maximal variant set (scripts/waf-pairs.py) and verifies each
+# variant is (a) applies, (b) idempotent (immediate plan = No changes), and
+# (c) round-trip-import clean (state rm -> import -> plan clean) for
+# module.http_lb.xcsh_app_firewall.this. Entitlement/permission-rejected arms are
+# recorded as SKIP (not FAIL). Ends on the canonical-restore variant so the live
+# WAF is left healthy (blocking + server defaults). Results append to
+# reports/waf-matrix.txt.
+#
+# Pre-prod tenant, in-place on the live app_firewall (per the approved spec).
+# Sequential — no concurrent terraform against the shared azurerm state.
+#
+# Usage: waf-matrix.sh [START [END]]   (inclusive 0-based variant index range;
+# run in short batches to survive long runs, e.g. `waf-matrix.sh 0 9`).
+set -uo pipefail
+
+cd "$(dirname "$0")/../terraform" || exit 1
+ARM_ACCESS_KEY=$(az storage account keys list -n f5salesdemotfstate -g f5-sales-demo-tfstate --query "[0].value" -o tsv)
+export ARM_ACCESS_KEY
+
+NS="webapp-api-protection"
+WAF_ADDR="module.http_lb.xcsh_app_firewall.this"
+WAF_ID="${NS}/${NS}-waf"
+COMMON=(-input=false -lock=true
+  -var 'lb_domains=["www.f5-sales-demo.com","api.f5-sales-demo.com"]'
+  -var 'subscription_id=75f86c46-9cbc-4f6c-85ea-195e3d3c8ac0')
+VARDIR=/tmp/waf-variants
+REPORT=../reports/waf-matrix.txt
+mkdir -p ../reports
+
+START="${1:-0}"
+END="${2:-9999}"
+
+# entitlement/permission rejection signatures -> record SKIP, not FAIL. Word/phrase
+# signals only: bare status numbers like "403" are NOT matched (they false-match
+# response-code values such as allowed_response_codes=[...,403] or a "Forbidden"
+# blocking-page code). A 400 BAD_REQUEST (invalid arm combination) is a real FAIL.
+GATED_RE='entitlement|not subscribed|not entitled|not enabled for|permission denied|unauthorized|AS_NOT_SUBSCRIBED|status: 401|status: 403'
+
+count=$(python3 ../scripts/waf-pairs.py --emit "$VARDIR")
+echo "generated $count variants into $VARDIR (running [$START..$END])"
+
+round_trip() {
+  local label="$1" vf="$2"
+  terraform state rm "$WAF_ADDR" >/dev/null 2>&1 || {
+    echo "FAIL $label state-rm" >>"$REPORT"
+    return
+  }
+  terraform import "${COMMON[@]}" -var-file="$vf" "$WAF_ADDR" "$WAF_ID" >/tmp/waf-import.log 2>&1 || {
+    echo "FAIL $label import" >>"$REPORT"
+    return
+  }
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$vf" >/tmp/waf-rt-plan.log 2>&1
+  case $? in
+  0) echo "PASS $label" >>"$REPORT" ;;
+  2) echo "FAIL $label import-drift" >>"$REPORT" ;;
+  *) echo "FAIL $label rt-plan-error" >>"$REPORT" ;;
+  esac
+}
+
+while read -r idx name vf; do
+  [ "$idx" -lt "$START" ] && continue
+  [ "$idx" -gt "$END" ] && continue
+  label="$idx-$name"
+  echo "--- $label ---"
+  if ! terraform apply -auto-approve "${COMMON[@]}" -var-file="${VARDIR}/${vf}" >/tmp/waf-apply.log 2>&1; then
+    if grep -qiE "$GATED_RE" /tmp/waf-apply.log; then
+      echo "SKIP $label gated-arm ($(grep -oiE "$GATED_RE" /tmp/waf-apply.log | head -1))" >>"$REPORT"
+    else
+      echo "FAIL $label apply ($(grep -iE 'error' /tmp/waf-apply.log | head -1 | cut -c1-80))" >>"$REPORT"
+    fi
+    continue
+  fi
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="${VARDIR}/${vf}" >/tmp/waf-plan.log 2>&1
+  case $? in
+  0) round_trip "$label" "${VARDIR}/${vf}" ;;
+  2)
+    echo "FAIL $label not-idempotent" >>"$REPORT"
+    ;;
+  *)
+    echo "FAIL $label plan-error" >>"$REPORT"
+    ;;
+  esac
+done <"${VARDIR}/manifest.txt"
+
+echo "===== WAF MATRIX RESULTS ($START..$END) ====="
+cat "$REPORT"
+echo "PASS=$(grep -c '^PASS ' "$REPORT") FAIL=$(grep -c '^FAIL ' "$REPORT") SKIP=$(grep -c '^SKIP ' "$REPORT")"

--- a/scripts/waf-pairs.py
+++ b/scripts/waf-pairs.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Generate the WAF (app_firewall) coverage matrix as a JSON manifest.
+
+Coverage model (see docs/superpowers/specs/2026-07-13-waf-exhaustive-coverage-design.md):
+  * all-pairs (pairwise) over every app_firewall oneof-group dimension, so every
+    pair of option-values co-occurs in at least one variant (AETG-style greedy);
+  * PLUS an explicit case per enum value (bot actions, AI risk action);
+  * PLUS an explicit case per list min/max bound (response codes, disabled
+    violation/attack types);
+  * PLUS one maximal all-on variant.
+
+Deterministic: dimension/value ordering is fixed and the greedy tie-break is
+lowest-index, so the same manifest is produced on every run (no RNG).
+
+Output: JSON array of {"name": str, "vars": {tfvar: value}} to stdout.
+Payload vars (lists, actions, periods) are attached only when the selecting arm
+is active, so each variant is a valid, minimal config.
+"""
+
+import itertools
+import json
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+# Core pairwise dimensions: oneof-group arm selectors. Detection sub-dimensions
+# are only meaningful when waf_detection_mode=custom; when it is "default" the
+# module ignores them (harmless no-ops), so pairwise still covers the custom space.
+# Custom bot protection (waf_bot_mode/waf_detection_bot_mode = "custom") is
+# intentionally NOT in the live matrix: it requires the tenant Bot Defense add-on,
+# and without it the API silently normalizes custom bot actions back to
+# default_bot_setting (verified live -> guaranteed round-trip import drift). The
+# module still renders it (plan-tested) for Bot-Defense-entitled tenants; here we
+# exercise only the omit/default arms so the live matrix is idempotent + import-clean.
+DIMENSIONS = {
+    "waf_mode": ["blocking", "monitoring"],
+    "waf_allowed_response_codes_mode": ["omit", "list"],
+    "waf_blocking_page_mode": ["omit", "custom"],
+    "waf_anonymization_mode": ["omit", "disable"],
+    "waf_ai_mode": ["omit", "enable"],
+    "waf_detection_mode": ["default", "custom"],
+    "waf_violation_mode": ["default", "custom"],
+    "waf_staging_mode": ["disable", "new", "new_and_updated"],
+    "waf_suppression": ["enable", "disable"],
+    "waf_threat_campaigns": ["enable", "disable"],
+    "waf_signature_accuracy": ["only_high", "high_medium", "high_medium_low"],
+    "waf_attack_type_mode": ["default", "custom"],
+}
+
+VIOLATION_TYPES = [
+    "VIOL_NONE",
+    "VIOL_FILETYPE",
+    "VIOL_METHOD",
+    "VIOL_MANDATORY_HEADER",
+    "VIOL_HTTP_RESPONSE_STATUS",
+    "VIOL_REQUEST_MAX_LENGTH",
+    "VIOL_FILE_UPLOAD",
+    "VIOL_FILE_UPLOAD_IN_BODY",
+    "VIOL_XML_MALFORMED",
+    "VIOL_JSON_MALFORMED",
+    "VIOL_ASM_COOKIE_MODIFIED",
+    "VIOL_HTTP_PROTOCOL_MULTIPLE_HOST_HEADERS",
+    "VIOL_HTTP_PROTOCOL_BAD_HOST_HEADER_VALUE",
+    "VIOL_HTTP_PROTOCOL_UNPARSABLE_REQUEST_CONTENT",
+    "VIOL_HTTP_PROTOCOL_NULL_IN_REQUEST",
+    "VIOL_HTTP_PROTOCOL_BAD_HTTP_VERSION",
+    "VIOL_HTTP_PROTOCOL_CRLF_CHARACTERS_BEFORE_REQUEST_START",
+    "VIOL_HTTP_PROTOCOL_NO_HOST_HEADER_IN_HTTP_1_1_REQUEST",
+    "VIOL_HTTP_PROTOCOL_BAD_MULTIPART_PARAMETERS_PARSING",
+    "VIOL_HTTP_PROTOCOL_SEVERAL_CONTENT_LENGTH_HEADERS",
+    "VIOL_HTTP_PROTOCOL_CONTENT_LENGTH_SHOULD_BE_A_POSITIVE_NUMBER",
+    "VIOL_EVASION_DIRECTORY_TRAVERSALS",
+    "VIOL_MALFORMED_REQUEST",
+    "VIOL_EVASION_MULTIPLE_DECODING",
+    "VIOL_DATA_GUARD",
+    "VIOL_EVASION_APACHE_WHITESPACE",
+    "VIOL_COOKIE_MODIFIED",
+    "VIOL_EVASION_IIS_UNICODE_CODEPOINTS",
+    "VIOL_EVASION_IIS_BACKSLASHES",
+    "VIOL_EVASION_PERCENT_U_DECODING",
+    "VIOL_EVASION_BARE_BYTE_DECODING",
+    "VIOL_EVASION_BAD_UNESCAPE",
+    "VIOL_HTTP_PROTOCOL_BAD_MULTIPART_FORMDATA_REQUEST_PARSING",
+    "VIOL_HTTP_PROTOCOL_BODY_IN_GET_OR_HEAD_REQUEST",
+    "VIOL_HTTP_PROTOCOL_HIGH_ASCII_CHARACTERS_IN_HEADERS",
+    "VIOL_ENCODING",
+    "VIOL_COOKIE_MALFORMED",
+    "VIOL_GRAPHQL_FORMAT",
+    "VIOL_GRAPHQL_MALFORMED",
+    "VIOL_GRAPHQL_INTROSPECTION_QUERY",
+]  # 40 total (= maxItems)
+
+ATTACK_TYPES = [
+    "ATTACK_TYPE_NONE",
+    "ATTACK_TYPE_NON_BROWSER_CLIENT",
+    "ATTACK_TYPE_OTHER_APPLICATION_ATTACKS",
+    "ATTACK_TYPE_TROJAN_BACKDOOR_SPYWARE",
+    "ATTACK_TYPE_DETECTION_EVASION",
+    "ATTACK_TYPE_VULNERABILITY_SCAN",
+    "ATTACK_TYPE_ABUSE_OF_FUNCTIONALITY",
+    "ATTACK_TYPE_AUTHENTICATION_AUTHORIZATION_ATTACKS",
+    "ATTACK_TYPE_BUFFER_OVERFLOW",
+    "ATTACK_TYPE_PREDICTABLE_RESOURCE_LOCATION",
+    "ATTACK_TYPE_INFORMATION_LEAKAGE",
+    "ATTACK_TYPE_DIRECTORY_INDEXING",
+    "ATTACK_TYPE_PATH_TRAVERSAL",
+    "ATTACK_TYPE_XPATH_INJECTION",
+    "ATTACK_TYPE_LDAP_INJECTION",
+    "ATTACK_TYPE_SERVER_SIDE_CODE_INJECTION",
+    "ATTACK_TYPE_COMMAND_EXECUTION",
+    "ATTACK_TYPE_SQL_INJECTION",
+    "ATTACK_TYPE_CROSS_SITE_SCRIPTING",
+    "ATTACK_TYPE_DENIAL_OF_SERVICE",
+    "ATTACK_TYPE_HTTP_PARSER_ATTACK",
+    "ATTACK_TYPE_SESSION_HIJACKING",
+]  # first 22 of 27 (= maxItems 22)
+
+
+def all_pairs(dims: dict[str, list[str]]) -> list[dict[str, str]]:
+    """Return AETG-style greedy all-pairs rows ({dim: value})."""
+    names = list(dims)
+    # every unordered pair of (dim_i, val_i)-(dim_j, val_j) that must co-occur
+    uncovered = set()
+    for i, j in itertools.combinations(range(len(names)), 2):
+        for vi in dims[names[i]]:
+            for vj in dims[names[j]]:
+                uncovered.add((i, vi, j, vj))
+
+    rows = []
+    while uncovered:
+        # Seed the row from a still-uncovered pair so every row covers >=1 new
+        # pair (guarantees termination; a purely greedy row can cover 0 new pairs
+        # and, with a deterministic tie-break, loop forever). Take the smallest
+        # uncovered tuple for determinism.
+        si, sv, sj, sv2 = min(uncovered)
+        row = {si: sv, sj: sv2}
+        # fill remaining dimensions greedily (fixed order, lowest-index tie-break)
+        for idx in range(len(names)):
+            if idx in row:
+                continue
+            best_val, best_gain = dims[names[idx]][0], -1
+            for val in dims[names[idx]]:
+                gain = 0
+                for pidx, pval in row.items():
+                    a, b = sorted([(pidx, pval), (idx, val)])
+                    if (a[0], a[1], b[0], b[1]) in uncovered:
+                        gain += 1
+                if gain > best_gain:
+                    best_gain, best_val = gain, val
+            row[idx] = best_val
+        # retire the pairs this row covers
+        for i, j in itertools.combinations(sorted(row), 2):
+            uncovered.discard((i, row[i], j, row[j]))
+        rows.append({names[k]: v for k, v in row.items()})
+    return rows
+
+
+def payloads(v: Mapping[str, object]) -> dict[str, object]:
+    """Attach payload vars required by the active arms in variant v."""
+    out: dict[str, object] = dict(v)
+    if v.get("waf_allowed_response_codes_mode") == "list":
+        out["waf_allowed_response_codes"] = [200, 204, 301, 302, 403]
+    if v.get("waf_ai_mode") == "enable":
+        out.setdefault("waf_ai_risk_action", "high")
+    if (
+        v.get("waf_detection_mode") == "custom"
+        and v.get("waf_violation_mode") == "custom"
+    ):
+        out["waf_disabled_violation_types"] = [
+            "VIOL_EVASION_DIRECTORY_TRAVERSALS",
+            "VIOL_DATA_GUARD",
+        ]
+    if v.get("waf_staging_mode") in ("new", "new_and_updated"):
+        out.setdefault("waf_staging_period", 7)
+    if (
+        v.get("waf_detection_mode") == "custom"
+        and v.get("waf_attack_type_mode") == "custom"
+    ):
+        out["waf_disabled_attack_types"] = [
+            "ATTACK_TYPE_SQL_INJECTION",
+            "ATTACK_TYPE_CROSS_SITE_SCRIPTING",
+        ]
+    return out
+
+
+def canonical() -> dict[str, object]:
+    """Return the live-canonical WAF end state (blocking + all server defaults)."""
+    return {"waf_mode": "blocking"}
+
+
+def build() -> list[dict[str, object]]:
+    """Build the full ordered variant manifest (all-pairs + enum + bounds + maximal)."""
+    variants: list[dict[str, object]] = []
+
+    # 1) all-pairs core
+    for i, row in enumerate(all_pairs(DIMENSIONS)):
+        variants.append({"name": f"pair-{i:03d}", "vars": payloads(row)})
+
+    # 2) explicit enum cases (bot-action enums are plan-tested only — see DIMENSIONS
+    # note; they require Bot Defense and are excluded from the live matrix).
+    variants.extend(
+        {
+            "name": f"enum-ai-{ra}",
+            "vars": {
+                "waf_mode": "blocking",
+                "waf_ai_mode": "enable",
+                "waf_ai_risk_action": ra,
+            },
+        }
+        for ra in ("high", "high_medium")
+    )
+
+    # 3) explicit min/max bounds
+    variants.append(
+        {
+            "name": "bound-rc-min",
+            "vars": {
+                "waf_mode": "blocking",
+                "waf_allowed_response_codes_mode": "list",
+                "waf_allowed_response_codes": [200],
+            },
+        }
+    )
+    variants.append(
+        {
+            "name": "bound-rc-max",
+            "vars": {
+                "waf_mode": "blocking",
+                "waf_allowed_response_codes_mode": "list",
+                "waf_allowed_response_codes": list(range(200, 248)),
+            },
+        }
+    )
+    variants.append(
+        {
+            "name": "bound-viol-max",
+            "vars": {
+                "waf_mode": "blocking",
+                "waf_detection_mode": "custom",
+                "waf_violation_mode": "custom",
+                "waf_disabled_violation_types": VIOLATION_TYPES,
+                "waf_staging_mode": "disable",
+                "waf_suppression": "enable",
+                "waf_threat_campaigns": "enable",
+                "waf_detection_bot_mode": "default",
+                "waf_signature_accuracy": "high_medium",
+                "waf_attack_type_mode": "default",
+            },
+        }
+    )
+    variants.append(
+        {
+            "name": "bound-attack-max",
+            "vars": {
+                "waf_mode": "blocking",
+                "waf_detection_mode": "custom",
+                "waf_violation_mode": "default",
+                "waf_staging_mode": "disable",
+                "waf_suppression": "enable",
+                "waf_threat_campaigns": "enable",
+                "waf_detection_bot_mode": "default",
+                "waf_signature_accuracy": "high_medium",
+                "waf_attack_type_mode": "custom",
+                "waf_disabled_attack_types": ATTACK_TYPES,
+            },
+        }
+    )
+
+    # 4) maximal all-on. staging is kept at "disable" here: the F5 XC API rejects
+    # signature staging (stage_new/stage_new_and_updated) combined with the rest of
+    # the maximal detection_settings (violation-custom + attack-custom +
+    # high_medium_low accuracy) with 400 BAD_REQUEST "Invalid request parameters"
+    # (bisected live). Staging is independently exercised by the pairwise rows, so
+    # the maximal stays a valid all-on rather than an invalid combination.
+    variants.append(
+        {
+            "name": "maximal",
+            "vars": {
+                "waf_mode": "monitoring",
+                "waf_allowed_response_codes_mode": "list",
+                "waf_allowed_response_codes": [200, 204, 301, 302, 403],
+                "waf_blocking_page_mode": "custom",
+                "waf_anonymization_mode": "disable",
+                "waf_ai_mode": "enable",
+                "waf_ai_risk_action": "high_medium",
+                "waf_detection_mode": "custom",
+                "waf_violation_mode": "custom",
+                "waf_disabled_violation_types": VIOLATION_TYPES,
+                "waf_staging_mode": "disable",
+                "waf_suppression": "disable",
+                "waf_threat_campaigns": "disable",
+                "waf_signature_accuracy": "high_medium_low",
+                "waf_attack_type_mode": "custom",
+                "waf_disabled_attack_types": ATTACK_TYPES,
+            },
+        }
+    )
+
+    # 5) restore canonical last
+    variants.append({"name": "canonical-restore", "vars": canonical()})
+    return variants
+
+
+def emit(directory: str) -> int:
+    """Write one <NNN>-<name>.tfvars.json per variant plus manifest.txt (NNN name)."""
+    out_dir = Path(directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for existing in out_dir.iterdir():
+        if existing.name.endswith(".tfvars.json") or existing.name == "manifest.txt":
+            existing.unlink()
+    variants = build()
+    named = [(f"{i:03d}-{v['name']}.tfvars.json", v) for i, v in enumerate(variants)]
+    for fname, v in named:
+        (out_dir / fname).write_text(json.dumps(v["vars"], indent=2) + "\n")
+    lines = [f"{i:03d} {v['name']} {fname}" for i, (fname, v) in enumerate(named)]
+    (out_dir / "manifest.txt").write_text("\n".join(lines) + "\n")
+    return len(variants)
+
+
+def main(argv: list[str]) -> None:
+    """CLI: --count prints the variant count, --emit <dir> writes files, else JSON to stdout."""
+    match argv[1:]:
+        case ["--count"]:
+            sys.stdout.write(f"{len(build())}\n")
+        case ["--emit", directory]:
+            sys.stdout.write(f"{emit(directory)}\n")
+        case _:
+            json.dump(build(), sys.stdout, indent=2)
+            sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/scripts/waf_pairs.py
+++ b/scripts/waf_pairs.py
@@ -116,11 +116,34 @@ ATTACK_TYPES = [
 ]  # first 22 of 27 (= maxItems 22)
 
 
+def _best_value(
+    values: list[str],
+    idx: int,
+    row: dict[int, str],
+    uncovered: set[tuple[int, str, int, str]],
+) -> str:
+    """Pick the value for dimension idx covering the most still-uncovered pairs.
+
+    Deterministic lowest-index tie-break: scan values in order and keep the first
+    that strictly improves on the best gain so far.
+    """
+    best_val, best_gain = values[0], -1
+    for val in values:
+        gain = 0
+        for pidx, pval in row.items():
+            a, b = sorted([(pidx, pval), (idx, val)])
+            if (a[0], a[1], b[0], b[1]) in uncovered:
+                gain += 1
+        if gain > best_gain:
+            best_gain, best_val = gain, val
+    return best_val
+
+
 def all_pairs(dims: dict[str, list[str]]) -> list[dict[str, str]]:
     """Return AETG-style greedy all-pairs rows ({dim: value})."""
     names = list(dims)
     # every unordered pair of (dim_i, val_i)-(dim_j, val_j) that must co-occur
-    uncovered = set()
+    uncovered: set[tuple[int, str, int, str]] = set()
     for i, j in itertools.combinations(range(len(names)), 2):
         for vi in dims[names[i]]:
             for vj in dims[names[j]]:
@@ -135,19 +158,9 @@ def all_pairs(dims: dict[str, list[str]]) -> list[dict[str, str]]:
         si, sv, sj, sv2 = min(uncovered)
         row = {si: sv, sj: sv2}
         # fill remaining dimensions greedily (fixed order, lowest-index tie-break)
-        for idx in range(len(names)):
-            if idx in row:
-                continue
-            best_val, best_gain = dims[names[idx]][0], -1
-            for val in dims[names[idx]]:
-                gain = 0
-                for pidx, pval in row.items():
-                    a, b = sorted([(pidx, pval), (idx, val)])
-                    if (a[0], a[1], b[0], b[1]) in uncovered:
-                        gain += 1
-                if gain > best_gain:
-                    best_gain, best_val = gain, val
-            row[idx] = best_val
+        for idx, name in enumerate(names):
+            if idx not in row:
+                row[idx] = _best_value(dims[name], idx, row, uncovered)
         # retire the pairs this row covers
         for i, j in itertools.combinations(sorted(row), 2):
             uncovered.discard((i, row[i], j, row[j]))

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -58,17 +58,40 @@ module "http_lb" {
   lb_domains = var.lb_domains
   # Point the origin pool at the Azure origin server's public IP (created above).
   # Terraform orders VM creation before the pool that references its IP.
-  origin_ip          = module.origin_server.public_ip
-  origin_port        = var.origin_port
-  health_check_path  = var.health_check_path
-  labels             = var.labels
-  waf_mode           = var.waf_mode
-  csd_enabled        = var.csd_enabled
-  mud_enabled        = var.mud_enabled
-  mud_user_id        = var.mud_user_id
-  mud_user_id_rule   = var.mud_user_id_rule
-  mud_mitigation     = var.mud_mitigation
-  mud_challenge_mode = var.mud_challenge_mode
+  origin_ip         = module.origin_server.public_ip
+  origin_port       = var.origin_port
+  health_check_path = var.health_check_path
+  labels            = var.labels
+  waf_mode          = var.waf_mode
+  csd_enabled       = var.csd_enabled
+
+  # WAF (app_firewall) exhaustive-coverage passthrough.
+  waf_allowed_response_codes_mode = var.waf_allowed_response_codes_mode
+  waf_allowed_response_codes      = var.waf_allowed_response_codes
+  waf_blocking_page_mode          = var.waf_blocking_page_mode
+  waf_blocking_page               = var.waf_blocking_page
+  waf_blocking_page_response_code = var.waf_blocking_page_response_code
+  waf_bot_mode                    = var.waf_bot_mode
+  waf_bot_actions                 = var.waf_bot_actions
+  waf_anonymization_mode          = var.waf_anonymization_mode
+  waf_ai_mode                     = var.waf_ai_mode
+  waf_ai_risk_action              = var.waf_ai_risk_action
+  waf_detection_mode              = var.waf_detection_mode
+  waf_violation_mode              = var.waf_violation_mode
+  waf_disabled_violation_types    = var.waf_disabled_violation_types
+  waf_staging_mode                = var.waf_staging_mode
+  waf_staging_period              = var.waf_staging_period
+  waf_suppression                 = var.waf_suppression
+  waf_threat_campaigns            = var.waf_threat_campaigns
+  waf_detection_bot_mode          = var.waf_detection_bot_mode
+  waf_signature_accuracy          = var.waf_signature_accuracy
+  waf_attack_type_mode            = var.waf_attack_type_mode
+  waf_disabled_attack_types       = var.waf_disabled_attack_types
+  mud_enabled                     = var.mud_enabled
+  mud_user_id                     = var.mud_user_id
+  mud_user_id_rule                = var.mud_user_id_rule
+  mud_mitigation                  = var.mud_mitigation
+  mud_challenge_mode              = var.mud_challenge_mode
 
   # Enabling client_side_defense on the LB requires a protected domain to already
   # exist in this namespace (F5 XC generates the CSD JS config from it), so the

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -76,8 +76,7 @@ resource "xcsh_app_firewall" "this" {
   namespace = var.namespace
   labels    = var.labels
 
-  default_detection_settings {}
-
+  # enforcement_mode_choice
   dynamic "blocking" {
     for_each = var.waf_mode == "blocking" ? [1] : []
     content {}
@@ -85,6 +84,161 @@ resource "xcsh_app_firewall" "this" {
   dynamic "monitoring" {
     for_each = var.waf_mode == "monitoring" ? [1] : []
     content {}
+  }
+
+  # allowed_response_codes_choice (omit => server default allow_all, suppressed)
+  dynamic "allowed_response_codes" {
+    for_each = var.waf_allowed_response_codes_mode == "list" ? [1] : []
+    content {
+      response_code = var.waf_allowed_response_codes
+    }
+  }
+
+  # blocking_page_choice (omit => server default use_default_blocking_page, suppressed)
+  dynamic "blocking_page" {
+    for_each = var.waf_blocking_page_mode == "custom" ? [1] : []
+    content {
+      blocking_page = var.waf_blocking_page
+      response_code = var.waf_blocking_page_response_code
+    }
+  }
+
+  # bot_protection_choice, top level (omit => server default default_bot_setting, suppressed)
+  dynamic "bot_protection_setting" {
+    for_each = var.waf_bot_mode == "custom" ? [1] : []
+    content {
+      good_bot_action       = var.waf_bot_actions.good
+      malicious_bot_action  = var.waf_bot_actions.malicious
+      suspicious_bot_action = var.waf_bot_actions.suspicious
+    }
+  }
+
+  # anonymization_setting (omit => server default default_anonymization, suppressed)
+  dynamic "disable_anonymization" {
+    for_each = var.waf_anonymization_mode == "disable" ? [1] : []
+    content {}
+  }
+  # NOTE: custom_anonymization is intentionally NOT rendered. The generated provider
+  # cannot build a value for its anonymization_config list-nested-block (Value
+  # Conversion Error: model []AppFirewall...AnonymizationConfigModel vs expected
+  # ListValue) for BOTH static and dynamic blocks — a lock-step provider codegen bug.
+  # waf_anonymization_mode therefore supports omit + disable until the provider is fixed.
+
+  # enhance_with_ai_choice. "omit" emits nothing: disable_ai_enhancements is the
+  # server default AND is import-suppressed, so emitting it explicitly drifts on
+  # round-trip import (config has it, imported state does not). omit therefore IS
+  # the disable state. Only the non-default enable arm is emitted.
+  dynamic "enable_ai_enhancements" {
+    for_each = var.waf_ai_mode == "enable" ? [1] : []
+    content {
+      dynamic "mitigate_high_risk_action" {
+        for_each = var.waf_ai_risk_action == "high" ? [1] : []
+        content {}
+      }
+      dynamic "mitigate_high_medium_risk_action" {
+        for_each = var.waf_ai_risk_action == "high_medium" ? [1] : []
+        content {}
+      }
+    }
+  }
+
+  # detection_setting_choice
+  dynamic "default_detection_settings" {
+    for_each = var.waf_detection_mode == "default" ? [1] : []
+    content {}
+  }
+  dynamic "detection_settings" {
+    for_each = var.waf_detection_mode == "custom" ? [1] : []
+    content {
+      # violation_detection_setting
+      dynamic "default_violation_settings" {
+        for_each = var.waf_violation_mode == "default" ? [1] : []
+        content {}
+      }
+      dynamic "violation_settings" {
+        for_each = var.waf_violation_mode == "custom" ? [1] : []
+        content {
+          disabled_violation_types = var.waf_disabled_violation_types
+        }
+      }
+
+      # signatures_staging_settings (disable => omit, server default)
+      dynamic "stage_new_signatures" {
+        for_each = var.waf_staging_mode == "new" ? [1] : []
+        content {
+          staging_period = var.waf_staging_period
+        }
+      }
+      dynamic "stage_new_and_updated_signatures" {
+        for_each = var.waf_staging_mode == "new_and_updated" ? [1] : []
+        content {
+          staging_period = var.waf_staging_period
+        }
+      }
+
+      # false_positive_suppression
+      dynamic "enable_suppression" {
+        for_each = var.waf_suppression == "enable" ? [1] : []
+        content {}
+      }
+      dynamic "disable_suppression" {
+        for_each = var.waf_suppression == "disable" ? [1] : []
+        content {}
+      }
+
+      # threat_campaign_choice
+      dynamic "enable_threat_campaigns" {
+        for_each = var.waf_threat_campaigns == "enable" ? [1] : []
+        content {}
+      }
+      dynamic "disable_threat_campaigns" {
+        for_each = var.waf_threat_campaigns == "disable" ? [1] : []
+        content {}
+      }
+
+      # bot_protection_choice, nested. "default" omits the block: nested
+      # default_bot_setting is import-suppressed (materialized by the server), so
+      # emitting it drifts on round-trip import. The custom arm (bot_protection_setting)
+      # requires the tenant Bot Defense add-on; without it the API silently normalizes
+      # custom actions back to default_bot_setting (verified live -> guaranteed import
+      # drift), so custom bot is only import-clean on Bot-Defense-entitled tenants.
+      dynamic "bot_protection_setting" {
+        for_each = var.waf_detection_bot_mode == "custom" ? [1] : []
+        content {
+          good_bot_action       = var.waf_bot_actions.good
+          malicious_bot_action  = var.waf_bot_actions.malicious
+          suspicious_bot_action = var.waf_bot_actions.suspicious
+        }
+      }
+
+      signature_selection_setting {
+        # signature_selection_by_accuracy
+        dynamic "only_high_accuracy_signatures" {
+          for_each = var.waf_signature_accuracy == "only_high" ? [1] : []
+          content {}
+        }
+        dynamic "high_medium_accuracy_signatures" {
+          for_each = var.waf_signature_accuracy == "high_medium" ? [1] : []
+          content {}
+        }
+        dynamic "high_medium_low_accuracy_signatures" {
+          for_each = var.waf_signature_accuracy == "high_medium_low" ? [1] : []
+          content {}
+        }
+
+        # attack_type_setting
+        dynamic "default_attack_type_settings" {
+          for_each = var.waf_attack_type_mode == "default" ? [1] : []
+          content {}
+        }
+        dynamic "attack_type_settings" {
+          for_each = var.waf_attack_type_mode == "custom" ? [1] : []
+          content {
+            disabled_attack_types = var.waf_disabled_attack_types
+          }
+        }
+      }
+    }
   }
 }
 

--- a/terraform/modules/http-lb/outputs.tf
+++ b/terraform/modules/http-lb/outputs.tf
@@ -57,3 +57,33 @@ output "mud_challenge_mode" {
   description = "Effective MUD challenge mode (none/enable_challenge/policy_based_challenge)."
   value       = var.mud_challenge_mode
 }
+
+output "waf_allowed_response_codes_mode" {
+  description = "Effective allowed_response_codes_choice arm (omit or list)."
+  value       = var.waf_allowed_response_codes_mode
+}
+
+output "waf_blocking_page_mode" {
+  description = "Effective blocking_page_choice arm (omit or custom)."
+  value       = var.waf_blocking_page_mode
+}
+
+output "waf_bot_mode" {
+  description = "Effective top-level bot_protection_choice arm (omit or custom)."
+  value       = var.waf_bot_mode
+}
+
+output "waf_anonymization_mode" {
+  description = "Effective anonymization_setting arm (omit, disable, or custom)."
+  value       = var.waf_anonymization_mode
+}
+
+output "waf_ai_mode" {
+  description = "Effective enhance_with_ai_choice arm (omit, disable, or enable)."
+  value       = var.waf_ai_mode
+}
+
+output "waf_detection_mode" {
+  description = "Effective detection_setting_choice arm (default or custom)."
+  value       = var.waf_detection_mode
+}

--- a/terraform/modules/http-lb/variables.tf
+++ b/terraform/modules/http-lb/variables.tf
@@ -113,3 +113,241 @@ variable "mud_challenge_mode" {
     error_message = "mud_challenge_mode must be none, enable_challenge, or policy_based_challenge."
   }
 }
+
+# ---------------------------------------------------------------------------
+# Web Application Firewall (xcsh_app_firewall) — exhaustive option coverage.
+# Every variable defaults to the current live config (server-default oneof
+# arms omitted, since those are import-suppressed by the provider), so a normal
+# apply is a 0-change no-op. The waf-matrix harness cycles the non-default arms.
+# ---------------------------------------------------------------------------
+
+variable "waf_allowed_response_codes_mode" {
+  description = "allowed_response_codes_choice: omit (server default allow_all, suppressed) or list (explicit allowed_response_codes)."
+  type        = string
+  default     = "omit"
+
+  validation {
+    condition     = contains(["omit", "list"], var.waf_allowed_response_codes_mode)
+    error_message = "waf_allowed_response_codes_mode must be \"omit\" or \"list\"."
+  }
+}
+
+variable "waf_allowed_response_codes" {
+  description = "Response codes allowed when waf_allowed_response_codes_mode=list (1-48 entries)."
+  type        = list(number)
+  default     = [200]
+
+  validation {
+    condition     = length(var.waf_allowed_response_codes) >= 1 && length(var.waf_allowed_response_codes) <= 48
+    error_message = "waf_allowed_response_codes must have between 1 and 48 entries."
+  }
+}
+
+variable "waf_blocking_page_mode" {
+  description = "blocking_page_choice: omit (server default use_default_blocking_page, suppressed) or custom."
+  type        = string
+  default     = "omit"
+
+  validation {
+    condition     = contains(["omit", "custom"], var.waf_blocking_page_mode)
+    error_message = "waf_blocking_page_mode must be \"omit\" or \"custom\"."
+  }
+}
+
+variable "waf_blocking_page" {
+  description = "Custom blocking page (URL or inline HTML, <=4096 chars) when waf_blocking_page_mode=custom."
+  type        = string
+  default     = "https://www.f5-sales-demo.com/blocked.html"
+
+  validation {
+    condition     = length(var.waf_blocking_page) <= 4096
+    error_message = "waf_blocking_page must be at most 4096 characters."
+  }
+}
+
+variable "waf_blocking_page_response_code" {
+  description = "HTTP status returned with the custom blocking page (F5 XC response-code enum name)."
+  type        = string
+  default     = "Forbidden"
+}
+
+variable "waf_bot_mode" {
+  description = "Top-level bot_protection_choice: omit (server default default_bot_setting, suppressed) or custom (explicit per-class actions)."
+  type        = string
+  default     = "omit"
+
+  validation {
+    condition     = contains(["omit", "custom"], var.waf_bot_mode)
+    error_message = "waf_bot_mode must be \"omit\" or \"custom\"."
+  }
+}
+
+variable "waf_bot_actions" {
+  description = "Per-class bot actions when waf_bot_mode=custom. Each is BLOCK, REPORT, or IGNORE."
+  type = object({
+    good       = string
+    malicious  = string
+    suspicious = string
+  })
+  default = {
+    good       = "REPORT"
+    malicious  = "BLOCK"
+    suspicious = "REPORT"
+  }
+
+  validation {
+    condition = alltrue([
+      for a in values(var.waf_bot_actions) : contains(["BLOCK", "REPORT", "IGNORE"], a)
+    ])
+    error_message = "each waf_bot_actions value must be BLOCK, REPORT, or IGNORE."
+  }
+}
+
+variable "waf_anonymization_mode" {
+  description = "anonymization_setting: omit (server default default_anonymization, suppressed) or disable. The custom_anonymization arm is unsupported pending a provider codegen fix (see main.tf note)."
+  type        = string
+  default     = "omit"
+
+  validation {
+    condition     = contains(["omit", "disable"], var.waf_anonymization_mode)
+    error_message = "waf_anonymization_mode must be \"omit\" or \"disable\"."
+  }
+}
+
+variable "waf_ai_mode" {
+  description = "enhance_with_ai_choice: omit (server default disable_ai_enhancements, suppressed) or enable. There is no explicit disable arm: omit IS disable (emitting the suppressed default drifts on import)."
+  type        = string
+  default     = "omit"
+
+  validation {
+    condition     = contains(["omit", "enable"], var.waf_ai_mode)
+    error_message = "waf_ai_mode must be \"omit\" or \"enable\"."
+  }
+}
+
+variable "waf_ai_risk_action" {
+  description = "risk_score_action_choice when waf_ai_mode=enable: high (mitigate_high_risk_action) or high_medium (mitigate_high_medium_risk_action)."
+  type        = string
+  default     = "high"
+
+  validation {
+    condition     = contains(["high", "high_medium"], var.waf_ai_risk_action)
+    error_message = "waf_ai_risk_action must be \"high\" or \"high_medium\"."
+  }
+}
+
+variable "waf_detection_mode" {
+  description = "detection_setting_choice: default (default_detection_settings) or custom (explicit detection_settings)."
+  type        = string
+  default     = "default"
+
+  validation {
+    condition     = contains(["default", "custom"], var.waf_detection_mode)
+    error_message = "waf_detection_mode must be \"default\" or \"custom\"."
+  }
+}
+
+variable "waf_violation_mode" {
+  description = "detection_settings violation_detection_setting: default or custom (disabled_violation_types list)."
+  type        = string
+  default     = "default"
+
+  validation {
+    condition     = contains(["default", "custom"], var.waf_violation_mode)
+    error_message = "waf_violation_mode must be \"default\" or \"custom\"."
+  }
+}
+
+variable "waf_disabled_violation_types" {
+  description = "Violation types to disable when waf_violation_mode=custom (<=40 entries)."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition     = length(var.waf_disabled_violation_types) <= 40
+    error_message = "waf_disabled_violation_types must have at most 40 entries."
+  }
+}
+
+variable "waf_staging_mode" {
+  description = "detection_settings signatures_staging_settings: disable, new (stage_new_signatures), or new_and_updated."
+  type        = string
+  default     = "disable"
+
+  validation {
+    condition     = contains(["disable", "new", "new_and_updated"], var.waf_staging_mode)
+    error_message = "waf_staging_mode must be \"disable\", \"new\", or \"new_and_updated\"."
+  }
+}
+
+variable "waf_staging_period" {
+  description = "Staging period (days) when waf_staging_mode is new or new_and_updated."
+  type        = number
+  default     = 7
+}
+
+variable "waf_suppression" {
+  description = "detection_settings false_positive_suppression: enable or disable."
+  type        = string
+  default     = "enable"
+
+  validation {
+    condition     = contains(["enable", "disable"], var.waf_suppression)
+    error_message = "waf_suppression must be \"enable\" or \"disable\"."
+  }
+}
+
+variable "waf_threat_campaigns" {
+  description = "detection_settings threat_campaign_choice: enable or disable."
+  type        = string
+  default     = "enable"
+
+  validation {
+    condition     = contains(["enable", "disable"], var.waf_threat_campaigns)
+    error_message = "waf_threat_campaigns must be \"enable\" or \"disable\"."
+  }
+}
+
+variable "waf_detection_bot_mode" {
+  description = "detection_settings nested bot_protection_choice: default or custom."
+  type        = string
+  default     = "default"
+
+  validation {
+    condition     = contains(["default", "custom"], var.waf_detection_bot_mode)
+    error_message = "waf_detection_bot_mode must be \"default\" or \"custom\"."
+  }
+}
+
+variable "waf_signature_accuracy" {
+  description = "detection_settings signature_selection_by_accuracy: only_high, high_medium, or high_medium_low."
+  type        = string
+  default     = "high_medium"
+
+  validation {
+    condition     = contains(["only_high", "high_medium", "high_medium_low"], var.waf_signature_accuracy)
+    error_message = "waf_signature_accuracy must be only_high, high_medium, or high_medium_low."
+  }
+}
+
+variable "waf_attack_type_mode" {
+  description = "detection_settings attack_type_setting: default or custom (disabled_attack_types list)."
+  type        = string
+  default     = "default"
+
+  validation {
+    condition     = contains(["default", "custom"], var.waf_attack_type_mode)
+    error_message = "waf_attack_type_mode must be \"default\" or \"custom\"."
+  }
+}
+
+variable "waf_disabled_attack_types" {
+  description = "Attack types to disable when waf_attack_type_mode=custom (<=22 entries)."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition     = length(var.waf_disabled_attack_types) <= 22
+    error_message = "waf_disabled_attack_types must have at most 22 entries."
+  }
+}

--- a/terraform/tests/waf_detection.tftest.hcl
+++ b/terraform/tests/waf_detection.tftest.hcl
@@ -1,0 +1,265 @@
+# Plan-level tests: detection_setting_choice and every detection_settings nested
+# oneof arm + enum + list bound render. Targets ./modules/http-lb, no tenant contact.
+variables {
+  namespace          = "webapp-api-protection"
+  lb_domains         = ["www.f5-sales-demo.com"]
+  origin_ip          = "203.0.113.10"
+  origin_port        = 80
+  health_check_path  = "/health"
+  labels             = {}
+  csd_enabled        = false
+  mud_enabled        = false
+  waf_detection_mode = "custom"
+}
+
+# --- detection_setting_choice ------------------------------------------------
+run "detection_default" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { waf_detection_mode = "default" }
+  assert {
+    condition     = output.waf_detection_mode == "default"
+    error_message = "default_detection_settings arm must render"
+  }
+}
+
+run "detection_custom_baseline" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  assert {
+    condition     = output.waf_detection_mode == "custom"
+    error_message = "detection_settings (custom) arm must render"
+  }
+}
+
+# --- violation_detection_setting ---------------------------------------------
+run "violation_default" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { waf_violation_mode = "default" }
+  assert {
+    condition     = output.waf_detection_mode == "custom"
+    error_message = "default_violation_settings arm must render"
+  }
+}
+
+run "violation_custom_empty" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    waf_violation_mode           = "custom"
+    waf_disabled_violation_types = []
+  }
+  assert {
+    condition     = output.waf_detection_mode == "custom"
+    error_message = "violation_settings with empty disabled list must render"
+  }
+}
+
+run "violation_custom_max_40" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    waf_violation_mode = "custom"
+    waf_disabled_violation_types = [
+      "VIOL_NONE", "VIOL_FILETYPE", "VIOL_METHOD", "VIOL_MANDATORY_HEADER",
+      "VIOL_HTTP_RESPONSE_STATUS", "VIOL_REQUEST_MAX_LENGTH", "VIOL_FILE_UPLOAD",
+      "VIOL_FILE_UPLOAD_IN_BODY", "VIOL_XML_MALFORMED", "VIOL_JSON_MALFORMED",
+      "VIOL_ASM_COOKIE_MODIFIED", "VIOL_HTTP_PROTOCOL_MULTIPLE_HOST_HEADERS",
+      "VIOL_HTTP_PROTOCOL_BAD_HOST_HEADER_VALUE",
+      "VIOL_HTTP_PROTOCOL_UNPARSABLE_REQUEST_CONTENT",
+      "VIOL_HTTP_PROTOCOL_NULL_IN_REQUEST", "VIOL_HTTP_PROTOCOL_BAD_HTTP_VERSION",
+      "VIOL_HTTP_PROTOCOL_CRLF_CHARACTERS_BEFORE_REQUEST_START",
+      "VIOL_HTTP_PROTOCOL_NO_HOST_HEADER_IN_HTTP_1_1_REQUEST",
+      "VIOL_HTTP_PROTOCOL_BAD_MULTIPART_PARAMETERS_PARSING",
+      "VIOL_HTTP_PROTOCOL_SEVERAL_CONTENT_LENGTH_HEADERS",
+      "VIOL_HTTP_PROTOCOL_CONTENT_LENGTH_SHOULD_BE_A_POSITIVE_NUMBER",
+      "VIOL_EVASION_DIRECTORY_TRAVERSALS", "VIOL_MALFORMED_REQUEST",
+      "VIOL_EVASION_MULTIPLE_DECODING", "VIOL_DATA_GUARD",
+      "VIOL_EVASION_APACHE_WHITESPACE", "VIOL_COOKIE_MODIFIED",
+      "VIOL_EVASION_IIS_UNICODE_CODEPOINTS", "VIOL_EVASION_IIS_BACKSLASHES",
+      "VIOL_EVASION_PERCENT_U_DECODING", "VIOL_EVASION_BARE_BYTE_DECODING",
+      "VIOL_EVASION_BAD_UNESCAPE",
+      "VIOL_HTTP_PROTOCOL_BAD_MULTIPART_FORMDATA_REQUEST_PARSING",
+      "VIOL_HTTP_PROTOCOL_BODY_IN_GET_OR_HEAD_REQUEST",
+      "VIOL_HTTP_PROTOCOL_HIGH_ASCII_CHARACTERS_IN_HEADERS", "VIOL_ENCODING",
+      "VIOL_COOKIE_MALFORMED", "VIOL_GRAPHQL_FORMAT", "VIOL_GRAPHQL_MALFORMED",
+      "VIOL_GRAPHQL_INTROSPECTION_QUERY"
+    ]
+  }
+  assert {
+    condition     = length(var.waf_disabled_violation_types) == 40
+    error_message = "violation_settings with all 40 disabled types must render"
+  }
+}
+
+# --- signatures_staging_settings ---------------------------------------------
+run "staging_disable" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { waf_staging_mode = "disable" }
+  assert {
+    condition     = output.waf_detection_mode == "custom"
+    error_message = "staging disable (omit) arm must render"
+  }
+}
+
+run "staging_new" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    waf_staging_mode   = "new"
+    waf_staging_period = 7
+  }
+  assert {
+    condition     = output.waf_detection_mode == "custom"
+    error_message = "stage_new_signatures arm must render"
+  }
+}
+
+run "staging_new_and_updated" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    waf_staging_mode   = "new_and_updated"
+    waf_staging_period = 30
+  }
+  assert {
+    condition     = output.waf_detection_mode == "custom"
+    error_message = "stage_new_and_updated_signatures arm must render"
+  }
+}
+
+# --- false_positive_suppression ----------------------------------------------
+run "suppression_enable" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { waf_suppression = "enable" }
+  assert {
+    condition     = output.waf_detection_mode == "custom"
+    error_message = "enable_suppression arm must render"
+  }
+}
+
+run "suppression_disable" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { waf_suppression = "disable" }
+  assert {
+    condition     = output.waf_detection_mode == "custom"
+    error_message = "disable_suppression arm must render"
+  }
+}
+
+# --- threat_campaign_choice --------------------------------------------------
+run "threat_campaigns_enable" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { waf_threat_campaigns = "enable" }
+  assert {
+    condition     = output.waf_detection_mode == "custom"
+    error_message = "enable_threat_campaigns arm must render"
+  }
+}
+
+run "threat_campaigns_disable" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { waf_threat_campaigns = "disable" }
+  assert {
+    condition     = output.waf_detection_mode == "custom"
+    error_message = "disable_threat_campaigns arm must render"
+  }
+}
+
+# --- nested bot_protection_choice --------------------------------------------
+run "detection_bot_default" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { waf_detection_bot_mode = "default" }
+  assert {
+    condition     = output.waf_detection_mode == "custom"
+    error_message = "nested default_bot_setting arm must render"
+  }
+}
+
+run "detection_bot_custom" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    waf_detection_bot_mode = "custom"
+    waf_bot_actions        = { good = "IGNORE", malicious = "BLOCK", suspicious = "REPORT" }
+  }
+  assert {
+    condition     = output.waf_detection_mode == "custom"
+    error_message = "nested bot_protection_setting arm must render"
+  }
+}
+
+# --- signature_selection_by_accuracy -----------------------------------------
+run "accuracy_only_high" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { waf_signature_accuracy = "only_high" }
+  assert {
+    condition     = output.waf_detection_mode == "custom"
+    error_message = "only_high_accuracy_signatures arm must render"
+  }
+}
+
+run "accuracy_high_medium" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { waf_signature_accuracy = "high_medium" }
+  assert {
+    condition     = output.waf_detection_mode == "custom"
+    error_message = "high_medium_accuracy_signatures arm must render"
+  }
+}
+
+run "accuracy_high_medium_low" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { waf_signature_accuracy = "high_medium_low" }
+  assert {
+    condition     = output.waf_detection_mode == "custom"
+    error_message = "high_medium_low_accuracy_signatures arm must render"
+  }
+}
+
+# --- attack_type_setting (max 22) --------------------------------------------
+run "attack_type_default" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { waf_attack_type_mode = "default" }
+  assert {
+    condition     = output.waf_detection_mode == "custom"
+    error_message = "default_attack_type_settings arm must render"
+  }
+}
+
+run "attack_type_custom_max_22" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    waf_attack_type_mode = "custom"
+    waf_disabled_attack_types = [
+      "ATTACK_TYPE_NONE", "ATTACK_TYPE_NON_BROWSER_CLIENT",
+      "ATTACK_TYPE_OTHER_APPLICATION_ATTACKS", "ATTACK_TYPE_TROJAN_BACKDOOR_SPYWARE",
+      "ATTACK_TYPE_DETECTION_EVASION", "ATTACK_TYPE_VULNERABILITY_SCAN",
+      "ATTACK_TYPE_ABUSE_OF_FUNCTIONALITY",
+      "ATTACK_TYPE_AUTHENTICATION_AUTHORIZATION_ATTACKS", "ATTACK_TYPE_BUFFER_OVERFLOW",
+      "ATTACK_TYPE_PREDICTABLE_RESOURCE_LOCATION", "ATTACK_TYPE_INFORMATION_LEAKAGE",
+      "ATTACK_TYPE_DIRECTORY_INDEXING", "ATTACK_TYPE_PATH_TRAVERSAL",
+      "ATTACK_TYPE_XPATH_INJECTION", "ATTACK_TYPE_LDAP_INJECTION",
+      "ATTACK_TYPE_SERVER_SIDE_CODE_INJECTION", "ATTACK_TYPE_COMMAND_EXECUTION",
+      "ATTACK_TYPE_SQL_INJECTION", "ATTACK_TYPE_CROSS_SITE_SCRIPTING",
+      "ATTACK_TYPE_DENIAL_OF_SERVICE", "ATTACK_TYPE_HTTP_PARSER_ATTACK",
+      "ATTACK_TYPE_SESSION_HIJACKING"
+    ]
+  }
+  assert {
+    condition     = length(var.waf_disabled_attack_types) == 22
+    error_message = "attack_type_settings with 22 disabled types (max) must render"
+  }
+}

--- a/terraform/tests/waf_top_level.tftest.hcl
+++ b/terraform/tests/waf_top_level.tftest.hcl
@@ -1,0 +1,205 @@
+# Plan-level tests: every top-level app_firewall oneof arm + enum + bound renders.
+# Targets ./modules/http-lb with a dummy origin — no tenant contact. A successful
+# plan for each arm proves the dynamic block builds a valid provider value (catches
+# the Value Conversion Error class client-side); the assert pins the effective arm.
+variables {
+  namespace         = "webapp-api-protection"
+  lb_domains        = ["www.f5-sales-demo.com"]
+  origin_ip         = "203.0.113.10"
+  origin_port       = 80
+  health_check_path = "/health"
+  labels            = {}
+  csd_enabled       = false
+  mud_enabled       = false
+}
+
+# --- enforcement_mode_choice -------------------------------------------------
+run "enforcement_blocking" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { waf_mode = "blocking" }
+  assert {
+    condition     = output.waf_mode == "blocking"
+    error_message = "blocking enforcement arm must render"
+  }
+}
+
+run "enforcement_monitoring" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { waf_mode = "monitoring" }
+  assert {
+    condition     = output.waf_mode == "monitoring"
+    error_message = "monitoring enforcement arm must render"
+  }
+}
+
+# --- allowed_response_codes_choice (min 1, max 48) ---------------------------
+run "response_codes_omit" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { waf_allowed_response_codes_mode = "omit" }
+  assert {
+    condition     = output.waf_allowed_response_codes_mode == "omit"
+    error_message = "allow_all (omit) arm must render"
+  }
+}
+
+run "response_codes_list_min" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    waf_allowed_response_codes_mode = "list"
+    waf_allowed_response_codes      = [200]
+  }
+  assert {
+    condition     = output.waf_allowed_response_codes_mode == "list"
+    error_message = "allowed_response_codes list arm (min 1 entry) must render"
+  }
+}
+
+run "response_codes_list_max" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    waf_allowed_response_codes_mode = "list"
+    waf_allowed_response_codes      = [for i in range(48) : 200 + i]
+  }
+  assert {
+    condition     = length(var.waf_allowed_response_codes) == 48
+    error_message = "allowed_response_codes list arm (max 48 entries) must render"
+  }
+}
+
+# --- blocking_page_choice ----------------------------------------------------
+run "blocking_page_omit" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { waf_blocking_page_mode = "omit" }
+  assert {
+    condition     = output.waf_blocking_page_mode == "omit"
+    error_message = "use_default_blocking_page (omit) arm must render"
+  }
+}
+
+run "blocking_page_custom" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    waf_blocking_page_mode          = "custom"
+    waf_blocking_page               = "https://www.f5-sales-demo.com/blocked.html"
+    waf_blocking_page_response_code = "Forbidden"
+  }
+  assert {
+    condition     = output.waf_blocking_page_mode == "custom"
+    error_message = "custom blocking_page arm must render"
+  }
+}
+
+# --- bot_protection_choice (each action enum) --------------------------------
+run "bot_omit" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { waf_bot_mode = "omit" }
+  assert {
+    condition     = output.waf_bot_mode == "omit"
+    error_message = "default_bot_setting (omit) arm must render"
+  }
+}
+
+run "bot_custom_block" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    waf_bot_mode    = "custom"
+    waf_bot_actions = { good = "BLOCK", malicious = "BLOCK", suspicious = "BLOCK" }
+  }
+  assert {
+    condition     = output.waf_bot_mode == "custom"
+    error_message = "bot_protection_setting with BLOCK actions must render"
+  }
+}
+
+run "bot_custom_report" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    waf_bot_mode    = "custom"
+    waf_bot_actions = { good = "REPORT", malicious = "REPORT", suspicious = "REPORT" }
+  }
+  assert {
+    condition     = output.waf_bot_mode == "custom"
+    error_message = "bot_protection_setting with REPORT actions must render"
+  }
+}
+
+run "bot_custom_ignore" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    waf_bot_mode    = "custom"
+    waf_bot_actions = { good = "IGNORE", malicious = "IGNORE", suspicious = "IGNORE" }
+  }
+  assert {
+    condition     = output.waf_bot_mode == "custom"
+    error_message = "bot_protection_setting with IGNORE actions must render"
+  }
+}
+
+# --- anonymization_setting (custom pending provider fix) ---------------------
+run "anonymization_omit" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { waf_anonymization_mode = "omit" }
+  assert {
+    condition     = output.waf_anonymization_mode == "omit"
+    error_message = "default_anonymization (omit) arm must render"
+  }
+}
+
+run "anonymization_disable" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { waf_anonymization_mode = "disable" }
+  assert {
+    condition     = output.waf_anonymization_mode == "disable"
+    error_message = "disable_anonymization arm must render"
+  }
+}
+
+# --- enhance_with_ai_choice --------------------------------------------------
+run "ai_omit" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { waf_ai_mode = "omit" }
+  assert {
+    condition     = output.waf_ai_mode == "omit"
+    error_message = "ai omit arm must render"
+  }
+}
+
+run "ai_enable_high" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    waf_ai_mode        = "enable"
+    waf_ai_risk_action = "high"
+  }
+  assert {
+    condition     = output.waf_ai_mode == "enable"
+    error_message = "enable_ai_enhancements + mitigate_high_risk_action must render"
+  }
+}
+
+run "ai_enable_high_medium" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    waf_ai_mode        = "enable"
+    waf_ai_risk_action = "high_medium"
+  }
+  assert {
+    condition     = output.waf_ai_mode == "enable"
+    error_message = "enable_ai_enhancements + mitigate_high_medium_risk_action must render"
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -175,3 +175,114 @@ variable "traffic_gen_tool_tier" {
   type        = string
   default     = "standard"
 }
+
+# ---------------------------------------------------------------------------
+# WAF (app_firewall) exhaustive-coverage passthrough to modules/http-lb.
+# Defaults reproduce the current live config (0-change no-op). Validation lives
+# in the module; these root declarations are lean type+default passthroughs.
+# ---------------------------------------------------------------------------
+variable "waf_allowed_response_codes_mode" {
+  description = "allowed_response_codes_choice arm: omit or list."
+  type        = string
+  default     = "omit"
+}
+variable "waf_allowed_response_codes" {
+  description = "Response codes when waf_allowed_response_codes_mode=list (1-48)."
+  type        = list(number)
+  default     = [200]
+}
+variable "waf_blocking_page_mode" {
+  description = "blocking_page_choice arm: omit or custom."
+  type        = string
+  default     = "omit"
+}
+variable "waf_blocking_page" {
+  description = "Custom blocking page (URL/HTML, <=4096) when waf_blocking_page_mode=custom."
+  type        = string
+  default     = "https://www.f5-sales-demo.com/blocked.html"
+}
+variable "waf_blocking_page_response_code" {
+  description = "HTTP status enum name for the custom blocking page."
+  type        = string
+  default     = "Forbidden"
+}
+variable "waf_bot_mode" {
+  description = "Top-level bot_protection_choice arm: omit or custom."
+  type        = string
+  default     = "omit"
+}
+variable "waf_bot_actions" {
+  description = "Per-class bot actions (BLOCK/REPORT/IGNORE) when waf_bot_mode=custom."
+  type        = object({ good = string, malicious = string, suspicious = string })
+  default     = { good = "REPORT", malicious = "BLOCK", suspicious = "REPORT" }
+}
+variable "waf_anonymization_mode" {
+  description = "anonymization_setting arm: omit or disable (custom pending provider fix)."
+  type        = string
+  default     = "omit"
+}
+variable "waf_ai_mode" {
+  description = "enhance_with_ai_choice arm: omit (=disable, server default) or enable."
+  type        = string
+  default     = "omit"
+}
+variable "waf_ai_risk_action" {
+  description = "risk_score_action_choice when waf_ai_mode=enable: high or high_medium."
+  type        = string
+  default     = "high"
+}
+variable "waf_detection_mode" {
+  description = "detection_setting_choice arm: default or custom."
+  type        = string
+  default     = "default"
+}
+variable "waf_violation_mode" {
+  description = "detection_settings violation arm: default or custom."
+  type        = string
+  default     = "default"
+}
+variable "waf_disabled_violation_types" {
+  description = "Disabled violation types when waf_violation_mode=custom (<=40)."
+  type        = list(string)
+  default     = []
+}
+variable "waf_staging_mode" {
+  description = "detection_settings staging arm: disable, new, or new_and_updated."
+  type        = string
+  default     = "disable"
+}
+variable "waf_staging_period" {
+  description = "Staging period (days) for new/new_and_updated staging."
+  type        = number
+  default     = 7
+}
+variable "waf_suppression" {
+  description = "detection_settings false_positive_suppression: enable or disable."
+  type        = string
+  default     = "enable"
+}
+variable "waf_threat_campaigns" {
+  description = "detection_settings threat_campaign_choice: enable or disable."
+  type        = string
+  default     = "enable"
+}
+variable "waf_detection_bot_mode" {
+  description = "detection_settings nested bot_protection_choice arm: default or custom."
+  type        = string
+  default     = "default"
+}
+variable "waf_signature_accuracy" {
+  description = "detection_settings signature accuracy: only_high, high_medium, or high_medium_low."
+  type        = string
+  default     = "high_medium"
+}
+variable "waf_attack_type_mode" {
+  description = "detection_settings attack_type_setting arm: default or custom."
+  type        = string
+  default     = "default"
+}
+variable "waf_disabled_attack_types" {
+  description = "Disabled attack types when waf_attack_type_mode=custom (<=22)."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## Summary

Exhaustive coverage of the `xcsh_app_firewall` (WAF) option surface for the reference plan,
following the CSD/MUD lock-step pattern (the feature is the vehicle to harden the provider).

- **Module**: parameterizes every WAF oneof arm, enum value, and list min/max bound via `waf_*`
  variables. Defaults reproduce the live config exactly (0-change no-op). Suppressed
  server-default markers are omitted rather than emitted (emitting them drifts on import).
- **TDD**: 35 plan-level assertions across `tests/waf_top_level.tftest.hcl` and
  `tests/waf_detection.tftest.hcl` — one per arm/enum/bound (no tenant contact).
- **Live matrix**: `scripts/waf-pairs.py` (dependency-free AETG all-pairs generator —
  **309/309 pairs in 15 rows**, + every enum + every min/max bound + a maximal all-on +
  canonical = 23 variants) driven by `scripts/waf-matrix.sh` / `make waf-matrix`
  (apply → idempotent → round-trip `state rm`/`import`/`plan` per variant).

## Verification (live f5-sales-demo tenant)

- `terraform test`: **37 passed, 0 failed** (35 WAF + MUD/plan regression).
- `make waf-matrix`: **23/23 variants apply-idempotent + round-trip-import-clean**, canonical
  restored (`plan` = No changes). shellcheck + shfmt clean; `scripts/waf-pairs.py` ruff
  lint+format clean against the repo `.ruff.toml`.

## Findings surfaced by the matrix (and resolutions)

| Finding | Resolution |
| --- | --- |
| `detection_settings.violations_view` (server-computed catalog) drifts on import; suppression not applied at nested depth | Provider fix `terraform-provider-xcsh#1081`/**#1082** (nested-depth import suppression); module omits suppressed default markers |
| Custom `bot_protection_setting` → API silently normalizes to `default_bot_setting` without the Bot Defense add-on (guaranteed drift) | Excluded from the live matrix; still plan-tested for entitled tenants; documented |
| `custom_anonymization.anonymization_config` → generated provider Value Conversion Error | Omitted from the module; documented (separate provider codegen bug) |
| Signature staging + fully-maximal `detection_settings` → 400 BAD_REQUEST (invalid combination) | `maximal` uses `staging=disable`; staging independently covered by pairwise |

## Notes

Depends on provider PR #1082 for `detection_settings=custom` round-trip cleanliness (draft,
pending supervised release; local dev_override binary carries the fix and the live matrix passed
with it). CI is admin-gated on some secrets during VPN-only staging; correctness proven via the
local Terraform CLI (matrix output above).

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)
