### PR TITLE
SP1: exhaustive API Discovery + Crawler + reusable clear/blindfold SecretType convention

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # webapp-api-protection developer targets.
 
-.PHONY: mud-matrix mud-verify waf-matrix test
+.PHONY: mud-matrix mud-verify waf-matrix api-discovery-matrix api-crawl-verify test
 
 # Run the plan-level test suite (no tenant contact).
 test:
@@ -22,3 +22,17 @@ mud-verify:
 # See scripts/waf_pairs.py (generator) and scripts/waf-matrix.sh (harness).
 waf-matrix:
 	bash scripts/waf-matrix.sh
+
+# Cycle the live LB through the API discovery/crawler all-pairs variant set and
+# verify apply / idempotency / round-trip import (re-applying write-only crawler
+# secrets on import). Runs in batches: `make api-discovery-matrix` (all) or
+# `bash scripts/api-discovery-matrix.sh START END`. See scripts/api_discovery_pairs.py
+# (generator) and scripts/api-discovery-matrix.sh (harness).
+api-discovery-matrix:
+	bash scripts/api-discovery-matrix.sh
+
+# Staged blindfold verification: seal round-trip (a pre-sealed crawler credential
+# applies + is idempotent + import-clean) plus an authenticated-crawl attempt
+# against a real origin app. See scripts/api-crawl-verify.sh.
+api-crawl-verify:
+	bash scripts/api-crawl-verify.sh

--- a/scripts/api-crawl-verify.sh
+++ b/scripts/api-crawl-verify.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Staged blindfold + API-crawler behavioral verification (live).
+#
+# A. Blindfold sealing works: provider::xcsh::blindfold seals a credential offline
+#    into a string:/// location (cleartext never leaves the machine).
+# B. Clear crawler applies live: the inline api_crawler with a clear_secret_info
+#    password is ACCEPTED by F5 XC and is idempotent — the working live secret path.
+# C. Blindfold crawler password: F5 XC returns a server-side 500 for
+#    blindfold_secret_info on the api_crawler login password (verified live,
+#    persistent). This is a PLATFORM limitation (the provider/module/function are
+#    correct); recorded as a KNOWN LIMITATION, not a failure. The blindfold arm is
+#    plan-tested (tests/api_secret.tftest.hcl). See docs/superpowers/plans/sp1-findings.md.
+# D. Discovery inventory (best-effort; the crawler runs asynchronously).
+#
+# Restores canonical (no crawler) at the end. Requires XCSH creds + init'd dir.
+set -uo pipefail
+
+umask 077
+trap 'rm -f /tmp/crawl-clear.tfvars.json /tmp/crawl-bf.tfvars.json /tmp/crawl-*.log /tmp/disco.json 2>/dev/null' EXIT
+
+cd "$(dirname "$0")/../terraform" || exit 1
+ARM_ACCESS_KEY=$(az storage account keys list -n f5salesdemotfstate -g f5-sales-demo-tfstate --query "[0].value" -o tsv)
+export ARM_ACCESS_KEY
+
+NS="webapp-api-protection"
+COMMON=(-input=false
+  -var 'lb_domains=["www.f5-sales-demo.com","api.f5-sales-demo.com"]'
+  -var 'subscription_id=75f86c46-9cbc-4f6c-85ea-195e3d3c8ac0')
+
+pass() { echo "PASS: $*"; }
+fail() { echo "FAIL: $*"; }
+info() { echo "INFO: $*"; }
+known() { echo "KNOWN-LIMITATION: $*"; }
+
+# --- A. blindfold sealing works ---------------------------------------------
+LOC=$(../scripts/blindfold-seal.sh "DvwaCrawl-Demo" 2>/dev/null)
+if [ -n "$LOC" ] && [ "${LOC#string:///}" != "$LOC" ]; then
+  pass "provider::xcsh::blindfold sealed a credential offline (${LOC:0:18}..., ${#LOC} chars)"
+else
+  fail "blindfold seal produced no valid location"
+fi
+
+# --- B. clear crawler applies live + idempotent ------------------------------
+cat >/tmp/crawl-clear.tfvars.json <<EOF
+{ "api_discovery_choice": "enable",
+  "api_crawler_domains": [{ "domain": "www.f5-sales-demo.com", "user": "admin" }],
+  "api_crawler_password": { "method": "clear", "plaintext": "password" } }
+EOF
+if terraform apply -auto-approve "${COMMON[@]}" -var-file=/tmp/crawl-clear.tfvars.json >/tmp/crawl-clear.log 2>&1; then
+  pass "F5 XC ACCEPTED the clear-secret crawler credential (apply succeeded)"
+  if terraform plan -detailed-exitcode "${COMMON[@]}" -var-file=/tmp/crawl-clear.tfvars.json >/tmp/crawl-clear-plan.log 2>&1; then
+    pass "clear crawler config is idempotent (plan = No changes)"
+  else
+    fail "clear crawler not idempotent"
+  fi
+else
+  fail "clear crawler apply failed: $(sed 's/\x1b\[[0-9;]*m//g' /tmp/crawl-clear.log | grep -iE 'error|status:' | head -1)"
+fi
+
+# --- C. blindfold crawler password: platform 500 (documented) ----------------
+cat >/tmp/crawl-bf.tfvars.json <<EOF
+{ "api_discovery_choice": "enable",
+  "api_crawler_domains": [{ "domain": "www.f5-sales-demo.com", "user": "admin" }],
+  "api_crawler_password": { "method": "blindfold", "location": $(jq -Rn --arg l "$LOC" '$l') } }
+EOF
+if terraform apply -auto-approve "${COMMON[@]}" -var-file=/tmp/crawl-bf.tfvars.json >/tmp/crawl-bf.log 2>&1; then
+  pass "F5 XC ACCEPTED the blindfold crawler credential (platform now supports it!)"
+else
+  code=$(sed 's/\x1b\[[0-9;]*m//g' /tmp/crawl-bf.log | grep -oiE 'status: [0-9]+' | head -1)
+  known "api_crawler password + blindfold_secret_info -> F5 XC ${code:-server error} (platform-side; clear works). Blindfold arm is plan-tested; see sp1-findings.md."
+fi
+
+# --- D. discovery inventory (best-effort) ------------------------------------
+CODE=$(curl -s -o /tmp/disco.json -w '%{http_code}' \
+  -H "Authorization: APIToken $XCSH_API_TOKEN" \
+  "$XCSH_API_URL/api/data/namespaces/$NS/api_endpoints" 2>/dev/null || echo "000")
+info "discovery inventory GET -> HTTP $CODE (crawler is async; endpoints populate over time)"
+
+# --- E. restore canonical ----------------------------------------------------
+if terraform apply -auto-approve "${COMMON[@]}" >/tmp/crawl-restore.log 2>&1; then
+  pass "restored canonical (no crawler)"
+else
+  fail "canonical restore failed — inspect state"
+fi

--- a/scripts/api-discovery-matrix.sh
+++ b/scripts/api-discovery-matrix.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# API Discovery + Crawler live coverage-matrix harness.
+#
+# Cycles the LIVE webapp-api-protection LB through the api_discovery_pairs variant
+# set and verifies each variant is (a) applies, (b) idempotent (immediate plan =
+# No changes), and (c) round-trip-import clean for the LB
+# (module.http_lb.xcsh_http_loadbalancer.this) and, when present, the referenced
+# xcsh_api_discovery. Ends on canonical-restore so the live LB is left healthy
+# (bare enable_api_discovery {}). Results append to reports/api-discovery-matrix.txt.
+#
+# Write-only secrets: F5 XC does not return the crawler password on read, so an
+# import cannot recover it (verified live; mirrors the provider's certificate
+# blindfold test which ignores private_key on import). The round-trip therefore
+# re-applies after import to re-set the write-only secret, then requires a clean
+# plan. Variants without a crawler must import fully clean directly.
+#
+# Blindfold variants carry {method=blindfold} with no location; the harness seals
+# a fixed plaintext ONCE (scripts/blindfold-seal.sh) and pins that location across
+# the whole run (idempotent — provider::xcsh::blindfold is non-deterministic).
+#
+# Entitlement/permission-rejected arms are recorded SKIP (word/phrase signals only;
+# a bare status number like 403 is NOT matched). A 400 BAD_REQUEST is a real FAIL.
+# Sequential — no concurrent terraform against the shared azurerm state.
+#
+# Usage: api-discovery-matrix.sh [START [END]]  (inclusive 0-based index range).
+set -uo pipefail
+
+cd "$(dirname "$0")/../terraform" || exit 1
+ARM_ACCESS_KEY=$(az storage account keys list -n f5salesdemotfstate -g f5-sales-demo-tfstate --query "[0].value" -o tsv)
+export ARM_ACCESS_KEY
+
+NS="webapp-api-protection"
+LB_ADDR="module.http_lb.xcsh_http_loadbalancer.this"
+LB_ID="${NS}/${NS}"
+DISCO_ADDR="module.http_lb.xcsh_api_discovery.this[0]"
+DISCO_ID="${NS}/${NS}-api-discovery"
+COMMON=(-input=false -lock=true
+  -var 'lb_domains=["www.f5-sales-demo.com","api.f5-sales-demo.com"]'
+  -var 'subscription_id=75f86c46-9cbc-4f6c-85ea-195e3d3c8ac0')
+VARDIR=/tmp/api-variants
+REPORT=../reports/api-discovery-matrix.txt
+mkdir -p ../reports
+
+START="${1:-0}"
+END="${2:-9999}"
+SEAL_PLAINTEXT="Sp1-Cr@wl-Demo"
+GATED_RE='entitlement|not subscribed|not entitled|not enabled for|permission denied|unauthorized|AS_NOT_SUBSCRIBED|status: 401|status: 403'
+
+count=$(python3 ../scripts/api_discovery_pairs.py --emit "$VARDIR")
+echo "generated $count variants into $VARDIR (running [$START..$END])"
+
+BF_LOCATION=""
+seal_once() {
+  [ -n "$BF_LOCATION" ] && return 0
+  BF_LOCATION=$(../scripts/blindfold-seal.sh "$SEAL_PLAINTEXT" 2>/dev/null)
+  [ -n "$BF_LOCATION" ]
+}
+
+# Inject the pinned sealed location for blindfold variants; print the var-file to use.
+prep_varfile() {
+  local vf="$1" out
+  if grep -q '"method": "blindfold"' "$vf" && ! grep -q '"location"' "$vf"; then
+    seal_once || return 1
+    out="${vf%.json}.sealed.json"
+    jq --arg loc "$BF_LOCATION" '.api_crawler_password.location = $loc' "$vf" >"$out"
+    echo "$out"
+  else
+    echo "$vf"
+  fi
+}
+
+round_trip() {
+  local label="$1" vf="$2"
+  terraform state rm "$LB_ADDR" >/dev/null 2>&1 || {
+    echo "FAIL $label lb-state-rm" >>"$REPORT"
+    return
+  }
+  terraform import "${COMMON[@]}" -var-file="$vf" "$LB_ADDR" "$LB_ID" >/tmp/api-import.log 2>&1 || {
+    echo "FAIL $label lb-import" >>"$REPORT"
+    return
+  }
+  if terraform state list 2>/dev/null | grep -qxF "$DISCO_ADDR"; then
+    terraform state rm "$DISCO_ADDR" >/dev/null 2>&1
+    terraform import "${COMMON[@]}" -var-file="$vf" "$DISCO_ADDR" "$DISCO_ID" >>/tmp/api-import.log 2>&1 || {
+      echo "FAIL $label disco-import" >>"$REPORT"
+      return
+    }
+  fi
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$vf" >/tmp/api-rt-plan.log 2>&1
+  case $? in
+  0) echo "PASS $label" >>"$REPORT" ;;
+  2)
+    # Import cannot recover write-only secrets; re-apply to re-set from config, then
+    # the plan must be clean. Genuine (non-secret) drift stays dirty -> FAIL.
+    terraform apply -auto-approve "${COMMON[@]}" -var-file="$vf" >/tmp/api-rt-apply.log 2>&1
+    terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$vf" >/tmp/api-rt-plan2.log 2>&1
+    case $? in
+    0) echo "PASS $label (import re-set write-only secret)" >>"$REPORT" ;;
+    2) echo "FAIL $label import-drift" >>"$REPORT" ;;
+    *) echo "FAIL $label rt-plan-error" >>"$REPORT" ;;
+    esac
+    ;;
+  *) echo "FAIL $label rt-plan-error" >>"$REPORT" ;;
+  esac
+}
+
+while read -r idx name vf; do
+  [ "$idx" -lt "$START" ] && continue
+  [ "$idx" -gt "$END" ] && continue
+  label="$idx-$name"
+  echo "--- $label ---"
+  varfile=$(prep_varfile "${VARDIR}/${vf}") || {
+    echo "FAIL $label seal-prep" >>"$REPORT"
+    continue
+  }
+  if ! terraform apply -auto-approve "${COMMON[@]}" -var-file="$varfile" >/tmp/api-apply.log 2>&1; then
+    if grep -qiE "$GATED_RE" /tmp/api-apply.log; then
+      echo "SKIP $label gated-arm ($(grep -oiE "$GATED_RE" /tmp/api-apply.log | head -1))" >>"$REPORT"
+    else
+      echo "FAIL $label apply ($(grep -iE 'error' /tmp/api-apply.log | head -1 | cut -c1-80))" >>"$REPORT"
+    fi
+    continue
+  fi
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$varfile" >/tmp/api-plan.log 2>&1
+  case $? in
+  0) round_trip "$label" "$varfile" ;;
+  2) echo "FAIL $label not-idempotent" >>"$REPORT" ;;
+  *) echo "FAIL $label plan-error" >>"$REPORT" ;;
+  esac
+done <"${VARDIR}/manifest.txt"
+
+echo "===== API DISCOVERY MATRIX RESULTS ($START..$END) ====="
+cat "$REPORT"
+echo "PASS=$(grep -c '^PASS ' "$REPORT") FAIL=$(grep -c '^FAIL ' "$REPORT") SKIP=$(grep -c '^SKIP ' "$REPORT")"

--- a/scripts/api-discovery-matrix.sh
+++ b/scripts/api-discovery-matrix.sh
@@ -25,6 +25,11 @@
 # Usage: api-discovery-matrix.sh [START [END]]  (inclusive 0-based index range).
 set -uo pipefail
 
+# Variant files hold sealed secret locations (Blindfold ciphertext) and refresh
+# logs — create them owner-only and remove the sealed copies on exit.
+umask 077
+trap 'rm -f /tmp/api-variants/*.sealed.json /tmp/api-apply.log /tmp/api-plan.log /tmp/api-import.log /tmp/api-rt-plan.log /tmp/api-rt-plan2.log /tmp/api-rt-apply.log 2>/dev/null' EXIT
+
 cd "$(dirname "$0")/../terraform" || exit 1
 ARM_ACCESS_KEY=$(az storage account keys list -n f5salesdemotfstate -g f5-sales-demo-tfstate --query "[0].value" -o tsv)
 export ARM_ACCESS_KEY
@@ -114,7 +119,17 @@ while read -r idx name vf; do
     continue
   }
   if ! terraform apply -auto-approve "${COMMON[@]}" -var-file="$varfile" >/tmp/api-apply.log 2>&1; then
-    if grep -qiE "$GATED_RE" /tmp/api-apply.log; then
+    # Two documented, root-caused blockers are recorded SKIP (plan-tested, see
+    # docs/superpowers/plans/sp1-findings.md) rather than FAIL:
+    #  - custom_api_auth_discovery.api_discovery_ref.tenant unknown after apply
+    #    (provider #1080-class object-ref-tenant bug), and
+    #  - api_crawler password + blindfold_secret_info -> F5 XC 500 (platform-side;
+    #    clear works). Everything else: gated -> SKIP; otherwise a real FAIL.
+    if grep -qiE 'api_discovery_ref.tenant|invalid result object' /tmp/api-apply.log; then
+      echo "SKIP $label known-provider-tenant-bug (api_discovery_ref.tenant; plan-tested)" >>"$REPORT"
+    elif grep -q '"method": "blindfold"' "$varfile" && grep -qiE 'SERVER_ERROR|status: 500' /tmp/api-apply.log; then
+      echo "SKIP $label known-blindfold-crawler-platform-500 (clear works; plan-tested)" >>"$REPORT"
+    elif grep -qiE "$GATED_RE" /tmp/api-apply.log; then
       echo "SKIP $label gated-arm ($(grep -oiE "$GATED_RE" /tmp/api-apply.log | head -1))" >>"$REPORT"
     else
       echo "FAIL $label apply ($(grep -iE 'error' /tmp/api-apply.log | head -1 | cut -c1-80))" >>"$REPORT"

--- a/scripts/api_discovery_pairs.py
+++ b/scripts/api_discovery_pairs.py
@@ -38,8 +38,9 @@ DIMENSIONS = {
     "api_discovery_auth_mode": ["default", "custom"],
 }
 
-# A benign but real URL for the crawler target; F5 XC accepts the string at apply.
-_CRAWLER_DOMAIN = "https://api.f5-sales-demo.com"
+# The crawler `domain` is a bare FQDN (an LB-served domain), NOT a URL with scheme/
+# path — F5 XC rejects the URL form with 400 (verified live). Use a served domain.
+_CRAWLER_DOMAIN = "www.f5-sales-demo.com"
 _CRAWLER_USER = "apitester"
 _CRAWLER_PLAINTEXT = "Sp1-Cr@wl-Demo"  # demo credential; matrix files are gitignored
 

--- a/scripts/api_discovery_pairs.py
+++ b/scripts/api_discovery_pairs.py
@@ -98,10 +98,15 @@ def payloads(v: Mapping[str, object]) -> dict[str, object]:
         out["api_crawler_domains"] = [
             {"domain": _CRAWLER_DOMAIN, "user": _CRAWLER_USER}
         ]
-        out["api_crawler_password"] = {
-            "method": v.get("secret_method", "clear"),
-            "plaintext": _CRAWLER_PLAINTEXT,
-        }
+        if v.get("secret_method") == "blindfold":
+            # location is injected by the matrix harness (sealed once via
+            # scripts/blindfold-seal.sh) — the generator is offline and cannot seal.
+            out["api_crawler_password"] = {"method": "blindfold"}
+        else:
+            out["api_crawler_password"] = {
+                "method": "clear",
+                "plaintext": _CRAWLER_PLAINTEXT,
+            }
     else:
         out["api_crawler_domains"] = []
     if v.get("api_discovery_auth_mode") == "custom":

--- a/scripts/api_discovery_pairs.py
+++ b/scripts/api_discovery_pairs.py
@@ -131,16 +131,17 @@ def build() -> list[dict[str, object]]:
     for i, row in enumerate(all_pairs(DIMENSIONS)):
         variants.append({"name": f"pair-{i:03d}", "vars": payloads(row)})
 
-    # discovered_api_settings purge-duration bound (enable arm, no crawler).
-    variants.append(
+    # discovered_api_settings purge-duration bounds (server rule: 1..7 days).
+    variants.extend(
         {
-            "name": "bound-purge-duration",
+            "name": f"bound-purge-{label}",
             "vars": {
                 "api_discovery_choice": "enable",
                 "api_crawler_domains": [],
-                "api_discovery_purge_duration": 48,
+                "api_discovery_purge_duration": days,
             },
         }
+        for label, days in (("min", 1), ("max", 7))
     )
 
     variants.append({"name": "canonical-restore", "vars": canonical()})

--- a/scripts/api_discovery_pairs.py
+++ b/scripts/api_discovery_pairs.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Generate the API Discovery + Crawler coverage matrix as a JSON manifest.
+
+Coverage model (see docs/superpowers/specs/2026-07-13-sp1-api-discovery-crawler-blindfold-design.md):
+  * all-pairs (pairwise) over every api_discovery oneof-group dimension, so every
+    pair of option-values co-occurs in at least one variant (AETG-style greedy);
+  * PLUS an explicit case for the discovered_api_settings purge-duration bound;
+  * PLUS the canonical restore end state (bare enable_api_discovery {}).
+
+Pairwise dimensions include the two pseudo-dimensions `api_crawler` (none/one
+domain) and `secret_method` (clear/blindfold); these are expanded by payloads()
+into the real tfvars (api_crawler_domains + api_crawler_password) and removed, so
+every emitted variant is a valid, minimal root config.
+
+Deterministic: dimension/value ordering is fixed and the greedy tie-break is
+lowest-index, so the same manifest is produced on every run (no RNG).
+
+Output: JSON array of {"name": str, "vars": {tfvar: value}} to stdout.
+"""
+
+import itertools
+import json
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+# Pairwise dimensions. `api_crawler` and `secret_method` are pseudo-dimensions
+# expanded by payloads(); when api_discovery_choice=disable the enable-only arms
+# (crawler/learn/auth) are ignored by the module (harmless no-ops), so pairwise
+# still covers the enable space. secret_method is only meaningful when a crawler
+# domain exists, but pairwise over (api_crawler, secret_method) still guarantees
+# (one, clear) and (one, blindfold) both occur, exercising both SecretType arms live.
+DIMENSIONS = {
+    "api_discovery_choice": ["enable", "disable"],
+    "api_crawler": ["none", "one"],
+    "secret_method": ["clear", "blindfold"],
+    "api_discovery_learn_from_redirect": ["omit", "enable"],
+    "api_discovery_auth_mode": ["default", "custom"],
+}
+
+# A benign but real URL for the crawler target; F5 XC accepts the string at apply.
+_CRAWLER_DOMAIN = "https://api.f5-sales-demo.com"
+_CRAWLER_USER = "apitester"
+_CRAWLER_PLAINTEXT = "Sp1-Cr@wl-Demo"  # demo credential; matrix files are gitignored
+
+
+def _best_value(
+    values: list[str],
+    idx: int,
+    row: dict[int, str],
+    uncovered: set[tuple[int, str, int, str]],
+) -> str:
+    """Pick the value for dimension idx covering the most still-uncovered pairs.
+
+    Deterministic lowest-index tie-break: scan values in order and keep the first
+    that strictly improves on the best gain so far.
+    """
+    best_val, best_gain = values[0], -1
+    for val in values:
+        gain = 0
+        for pidx, pval in row.items():
+            a, b = sorted([(pidx, pval), (idx, val)])
+            if (a[0], a[1], b[0], b[1]) in uncovered:
+                gain += 1
+        if gain > best_gain:
+            best_gain, best_val = gain, val
+    return best_val
+
+
+def all_pairs(dims: dict[str, list[str]]) -> list[dict[str, str]]:
+    """Return AETG-style greedy all-pairs rows ({dim: value})."""
+    names = list(dims)
+    uncovered: set[tuple[int, str, int, str]] = set()
+    for i, j in itertools.combinations(range(len(names)), 2):
+        for vi in dims[names[i]]:
+            for vj in dims[names[j]]:
+                uncovered.add((i, vi, j, vj))
+
+    rows = []
+    while uncovered:
+        # Seed each row from a still-uncovered pair so it covers >=1 new pair
+        # (guarantees termination). Smallest tuple for determinism.
+        si, sv, sj, sv2 = min(uncovered)
+        row = {si: sv, sj: sv2}
+        for idx, name in enumerate(names):
+            if idx not in row:
+                row[idx] = _best_value(dims[name], idx, row, uncovered)
+        for i, j in itertools.combinations(sorted(row), 2):
+            uncovered.discard((i, row[i], j, row[j]))
+        rows.append({names[k]: v for k, v in row.items()})
+    return rows
+
+
+def payloads(v: Mapping[str, object]) -> dict[str, object]:
+    """Expand pseudo-dimensions into real tfvars for variant v."""
+    out: dict[str, object] = dict(v)
+    if v.get("api_crawler") == "one":
+        out["api_crawler_domains"] = [
+            {"domain": _CRAWLER_DOMAIN, "user": _CRAWLER_USER}
+        ]
+        out["api_crawler_password"] = {
+            "method": v.get("secret_method", "clear"),
+            "plaintext": _CRAWLER_PLAINTEXT,
+        }
+    else:
+        out["api_crawler_domains"] = []
+    if v.get("api_discovery_auth_mode") == "custom":
+        out["api_discovery_custom_auth_types"] = [
+            {"parameter_name": "X-API-Key", "parameter_type": "HEADER"}
+        ]
+    out.pop("api_crawler", None)
+    out.pop("secret_method", None)
+    return out
+
+
+def canonical() -> dict[str, object]:
+    """Return the live-canonical end state (bare enable_api_discovery, no crawler)."""
+    return {"api_discovery_choice": "enable", "api_crawler_domains": []}
+
+
+def build() -> list[dict[str, object]]:
+    """Build the full ordered variant manifest (all-pairs + purge bound + canonical)."""
+    variants: list[dict[str, object]] = []
+
+    for i, row in enumerate(all_pairs(DIMENSIONS)):
+        variants.append({"name": f"pair-{i:03d}", "vars": payloads(row)})
+
+    # discovered_api_settings purge-duration bound (enable arm, no crawler).
+    variants.append(
+        {
+            "name": "bound-purge-duration",
+            "vars": {
+                "api_discovery_choice": "enable",
+                "api_crawler_domains": [],
+                "api_discovery_purge_duration": 48,
+            },
+        }
+    )
+
+    variants.append({"name": "canonical-restore", "vars": canonical()})
+    return variants
+
+
+def emit(directory: str) -> int:
+    """Write one <NNN>-<name>.tfvars.json per variant plus manifest.txt (NNN name)."""
+    out_dir = Path(directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for existing in out_dir.iterdir():
+        if existing.name.endswith(".tfvars.json") or existing.name == "manifest.txt":
+            existing.unlink()
+    variants = build()
+    named = [(f"{i:03d}-{v['name']}.tfvars.json", v) for i, v in enumerate(variants)]
+    for fname, v in named:
+        (out_dir / fname).write_text(json.dumps(v["vars"], indent=2) + "\n")
+    lines = [f"{i:03d} {v['name']} {fname}" for i, (fname, v) in enumerate(named)]
+    (out_dir / "manifest.txt").write_text("\n".join(lines) + "\n")
+    return len(variants)
+
+
+def main(argv: list[str]) -> None:
+    """CLI: --count prints the variant count, --emit <dir> writes files, else JSON to stdout."""
+    match argv[1:]:
+        case ["--count"]:
+            sys.stdout.write(f"{len(build())}\n")
+        case ["--emit", directory]:
+            sys.stdout.write(f"{emit(directory)}\n")
+        case _:
+            json.dump(build(), sys.stdout, indent=2)
+            sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/scripts/blindfold-seal.sh
+++ b/scripts/blindfold-seal.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Seal a secret with F5 XC Blindfold ONCE (offline) and print the resulting
+# "string:///..." location to pin into config.
+#
+# provider::xcsh::blindfold uses a random data key, so it returns a DIFFERENT
+# ciphertext every call. Calling it inline in Terraform config would therefore
+# re-seal on every plan and drift (non-idempotent). The correct, F5-documented
+# pattern is to seal ONCE offline and pin the resulting location — that is what
+# this helper produces. Feed the output into api_crawler_password.location (or any
+# blindfold_secret_info.location).
+#
+# Usage: blindfold-seal.sh <plaintext> [policy_name] [policy_namespace]
+#   Requires XCSH_API_URL + XCSH_API_TOKEN in the environment, and the terraform/
+#   working dir to be initialized (the provider function is served by the provider).
+set -euo pipefail
+
+PLAINTEXT="${1:?usage: blindfold-seal.sh <plaintext> [policy_name] [policy_namespace]}"
+POLICY="${2:-ves-io-allow-volterra}"
+NAMESPACE="${3:-shared}"
+
+cd "$(dirname "$0")/../terraform"
+
+# Escape backslashes and double quotes for safe embedding in the HCL string literal.
+esc=${PLAINTEXT//\\/\\\\}
+esc=${esc//\"/\\\"}
+
+expr="provider::xcsh::blindfold(base64encode(\"${esc}\"), \"${POLICY}\", \"${NAMESPACE}\")"
+printf '%s\n' "$expr" | terraform console 2>/dev/null | tr -d '"' | grep '^string:///' | tail -1

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -93,6 +93,16 @@ module "http_lb" {
   mud_mitigation                  = var.mud_mitigation
   mud_challenge_mode              = var.mud_challenge_mode
 
+  # API Discovery & Crawler (SP1) passthrough. Defaults keep enable_api_discovery {}
+  # bare (0-change). The api-discovery matrix cycles the non-default arms.
+  api_discovery_choice              = var.api_discovery_choice
+  api_discovery_learn_from_redirect = var.api_discovery_learn_from_redirect
+  api_discovery_purge_duration      = var.api_discovery_purge_duration
+  api_discovery_auth_mode           = var.api_discovery_auth_mode
+  api_discovery_custom_auth_types   = var.api_discovery_custom_auth_types
+  api_crawler_domains               = var.api_crawler_domains
+  api_crawler_password              = var.api_crawler_password
+
   # Enabling client_side_defense on the LB requires a protected domain to already
   # exist in this namespace (F5 XC generates the CSD JS config from it), so the
   # LB must be created/updated AFTER the protected domain. The MUD entitlement

--- a/terraform/modules/http-lb/locals_api.tf
+++ b/terraform/modules/http-lb/locals_api.tf
@@ -1,0 +1,17 @@
+# Renderer for the reusable clear/blindfold SecretType convention. use_blindfold
+# selects the SecretType arm; `location` is the offline-sealed blob (blindfold
+# arm), `url` is the base64 clear value (clear arm). Exactly one is non-null when
+# plaintext is set. The provider::xcsh::blindfold call sits in the untaken branch
+# of the conditional for the clear arm, so a clear-method plan never contacts the
+# tenant; the blindfold arm calls the provider function (needs XCSH creds).
+locals {
+  api_crawler_password_secret = {
+    use_blindfold = var.api_crawler_password.method == "blindfold"
+    url = (var.api_crawler_password.method == "clear" && var.api_crawler_password.plaintext != null
+      ? "string:///${base64encode(var.api_crawler_password.plaintext)}"
+    : null)
+    location = (var.api_crawler_password.method == "blindfold" && var.api_crawler_password.plaintext != null
+      ? provider::xcsh::blindfold(base64encode(var.api_crawler_password.plaintext), var.api_crawler_password.blindfold_policy_name, var.api_crawler_password.blindfold_policy_namespace)
+    : null)
+  }
+}

--- a/terraform/modules/http-lb/locals_api.tf
+++ b/terraform/modules/http-lb/locals_api.tf
@@ -1,17 +1,17 @@
 # Renderer for the reusable clear/blindfold SecretType convention. use_blindfold
-# selects the SecretType arm; `location` is the offline-sealed blob (blindfold
-# arm), `url` is the base64 clear value (clear arm). Exactly one is non-null when
-# plaintext is set. The provider::xcsh::blindfold call sits in the untaken branch
-# of the conditional for the clear arm, so a clear-method plan never contacts the
-# tenant; the blindfold arm calls the provider function (needs XCSH creds).
+# selects the SecretType arm; `location` is the pre-sealed offline blob (blindfold
+# arm), `url` is the base64 clear value (clear arm). Exactly one is non-null.
+#
+# The blindfold location is pinned (sealed once via scripts/blindfold-seal.sh), NOT
+# computed here: provider::xcsh::blindfold uses a random data key, so an inline call
+# would produce a new ciphertext every plan and drift. Pinning the sealed value is
+# the F5-documented offline-blindfold pattern and keeps apply idempotent + import-clean.
 locals {
   api_crawler_password_secret = {
     use_blindfold = var.api_crawler_password.method == "blindfold"
     url = (var.api_crawler_password.method == "clear" && var.api_crawler_password.plaintext != null
       ? "string:///${base64encode(var.api_crawler_password.plaintext)}"
     : null)
-    location = (var.api_crawler_password.method == "blindfold" && var.api_crawler_password.plaintext != null
-      ? provider::xcsh::blindfold(base64encode(var.api_crawler_password.plaintext), var.api_crawler_password.blindfold_policy_name, var.api_crawler_password.blindfold_policy_namespace)
-    : null)
+    location = var.api_crawler_password.method == "blindfold" ? var.api_crawler_password.location : null
   }
 }

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -434,31 +434,37 @@ resource "xcsh_http_loadbalancer" "this" {
   # no api_crawler_domains are set we emit NO api_crawler block, so the rendered
   # config is identical to the bare form (server default disable_api_crawler,
   # suppressed on import) — a 0-change no-op.
-  enable_api_discovery {
-    # Inline API crawler (api_crawler oneof: api_crawler_config vs disable_api_crawler).
-    # The password uses the reusable clear/blindfold SecretType convention
-    # (locals_api.tf): exactly one of blindfold_secret_info / clear_secret_info.
-    dynamic "api_crawler" {
-      for_each = length(var.api_crawler_domains) > 0 ? [1] : []
-      content {
-        api_crawler_config {
-          dynamic "domains" {
-            for_each = var.api_crawler_domains
-            content {
-              domain = domains.value.domain
-              simple_login {
-                user = domains.value.user
-                password {
-                  dynamic "blindfold_secret_info" {
-                    for_each = local.api_crawler_password_secret.use_blindfold ? [1] : []
-                    content {
-                      location = local.api_crawler_password_secret.location
+  # api_discovery_choice oneof: enable_api_discovery vs disable_api_discovery.
+  # Default (enable, no inner arms) renders an empty enable_api_discovery {} —
+  # identical to the prior bare form, so a normal apply is a 0-change no-op.
+  dynamic "enable_api_discovery" {
+    for_each = var.api_discovery_choice == "enable" ? [1] : []
+    content {
+      # Inline API crawler (api_crawler oneof: api_crawler_config vs disable_api_crawler).
+      # The password uses the reusable clear/blindfold SecretType convention
+      # (locals_api.tf): exactly one of blindfold_secret_info / clear_secret_info.
+      dynamic "api_crawler" {
+        for_each = length(var.api_crawler_domains) > 0 ? [1] : []
+        content {
+          api_crawler_config {
+            dynamic "domains" {
+              for_each = var.api_crawler_domains
+              content {
+                domain = domains.value.domain
+                simple_login {
+                  user = domains.value.user
+                  password {
+                    dynamic "blindfold_secret_info" {
+                      for_each = local.api_crawler_password_secret.use_blindfold ? [1] : []
+                      content {
+                        location = local.api_crawler_password_secret.location
+                      }
                     }
-                  }
-                  dynamic "clear_secret_info" {
-                    for_each = local.api_crawler_password_secret.use_blindfold ? [] : [1]
-                    content {
-                      url = local.api_crawler_password_secret.url
+                    dynamic "clear_secret_info" {
+                      for_each = local.api_crawler_password_secret.use_blindfold ? [] : [1]
+                      content {
+                        url = local.api_crawler_password_secret.url
+                      }
                     }
                   }
                 }
@@ -467,7 +473,28 @@ resource "xcsh_http_loadbalancer" "this" {
           }
         }
       }
+
+      # learn_from_redirect_traffic oneof. omit => emit NEITHER arm (server default
+      # disable_learn_from_redirect_traffic is import-suppressed). enable => emit enable arm.
+      dynamic "enable_learn_from_redirect_traffic" {
+        for_each = var.api_discovery_learn_from_redirect == "enable" ? [1] : []
+        content {}
+      }
+
+      # discovered_api_settings — omitted entirely unless a purge duration is set.
+      dynamic "discovered_api_settings" {
+        for_each = var.api_discovery_purge_duration != null ? [1] : []
+        content {
+          purge_duration_for_inactive_discovered_apis = var.api_discovery_purge_duration
+        }
+      }
     }
+  }
+
+  # disable_api_discovery — the other arm of api_discovery_choice.
+  dynamic "disable_api_discovery" {
+    for_each = var.api_discovery_choice == "disable" ? [1] : []
+    content {}
   }
 
   # Client-Side Defense — inject the F5 XC telemetry JavaScript into served pages

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -381,6 +381,24 @@ resource "xcsh_user_identification" "mud" {
   }
 }
 
+# Standalone API discovery object holding custom auth types. Created only when
+# api_discovery_auth_mode=custom, and referenced by the LB's enable_api_discovery
+# custom_api_auth_discovery.api_discovery_ref. When default, we create nothing and
+# emit no arm (server default default_api_auth_discovery is import-suppressed).
+resource "xcsh_api_discovery" "this" {
+  count     = var.api_discovery_auth_mode == "custom" ? 1 : 0
+  name      = "${var.namespace}-api-discovery"
+  namespace = var.namespace
+
+  dynamic "custom_auth_types" {
+    for_each = var.api_discovery_custom_auth_types
+    content {
+      parameter_name = custom_auth_types.value.parameter_name
+      parameter_type = custom_auth_types.value.parameter_type
+    }
+  }
+}
+
 resource "xcsh_http_loadbalancer" "this" {
   name      = "webapp-api-protection"
   namespace = var.namespace
@@ -486,6 +504,18 @@ resource "xcsh_http_loadbalancer" "this" {
         for_each = var.api_discovery_purge_duration != null ? [1] : []
         content {
           purge_duration_for_inactive_discovered_apis = var.api_discovery_purge_duration
+        }
+      }
+
+      # api-auth-discovery oneof: omit (suppressed default_api_auth_discovery) or
+      # custom_api_auth_discovery referencing the standalone xcsh_api_discovery.
+      dynamic "custom_api_auth_discovery" {
+        for_each = var.api_discovery_auth_mode == "custom" ? [1] : []
+        content {
+          api_discovery_ref {
+            name      = xcsh_api_discovery.this[0].name
+            namespace = var.namespace
+          }
         }
       }
     }

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -429,7 +429,46 @@ resource "xcsh_http_loadbalancer" "this" {
   # (default_api_auth_discovery, disable_learn_from_redirect_traffic) on the
   # import path. That suppression was added in lock-step — see
   # terraform-provider-xcsh tools/import-default-suppressions.json (HTTPLoadBalancer).
-  enable_api_discovery {}
+  #
+  # SP1 extends this from a bare toggle to full discovery/crawler coverage. When
+  # no api_crawler_domains are set we emit NO api_crawler block, so the rendered
+  # config is identical to the bare form (server default disable_api_crawler,
+  # suppressed on import) — a 0-change no-op.
+  enable_api_discovery {
+    # Inline API crawler (api_crawler oneof: api_crawler_config vs disable_api_crawler).
+    # The password uses the reusable clear/blindfold SecretType convention
+    # (locals_api.tf): exactly one of blindfold_secret_info / clear_secret_info.
+    dynamic "api_crawler" {
+      for_each = length(var.api_crawler_domains) > 0 ? [1] : []
+      content {
+        api_crawler_config {
+          dynamic "domains" {
+            for_each = var.api_crawler_domains
+            content {
+              domain = domains.value.domain
+              simple_login {
+                user = domains.value.user
+                password {
+                  dynamic "blindfold_secret_info" {
+                    for_each = local.api_crawler_password_secret.use_blindfold ? [1] : []
+                    content {
+                      location = local.api_crawler_password_secret.location
+                    }
+                  }
+                  dynamic "clear_secret_info" {
+                    for_each = local.api_crawler_password_secret.use_blindfold ? [] : [1]
+                    content {
+                      url = local.api_crawler_password_secret.url
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
 
   # Client-Side Defense — inject the F5 XC telemetry JavaScript into served pages
   # to detect Magecart/formjacking/skimming (client_side_defense oneof vs the

--- a/terraform/modules/http-lb/outputs_api.tf
+++ b/terraform/modules/http-lb/outputs_api.tf
@@ -19,3 +19,18 @@ output "api_crawler_domain_count" {
   description = "Number of authenticated domains configured for the inline API crawler."
   value       = length(var.api_crawler_domains)
 }
+
+output "api_discovery_choice" {
+  description = "Effective api_discovery_choice arm (enable or disable)."
+  value       = var.api_discovery_choice
+}
+
+output "api_discovery_learn_from_redirect" {
+  description = "Effective learn-from-redirect arm (omit or enable)."
+  value       = var.api_discovery_learn_from_redirect
+}
+
+output "api_discovery_purge_duration" {
+  description = "Effective discovered_api_settings purge duration (null when omitted)."
+  value       = var.api_discovery_purge_duration
+}

--- a/terraform/modules/http-lb/outputs_api.tf
+++ b/terraform/modules/http-lb/outputs_api.tf
@@ -1,0 +1,21 @@
+# API Discovery & Crawler (SP1) outputs — effective arm echoes for plan-level
+# tests and downstream visibility, matching the waf_*_mode output convention.
+
+# method/use_blindfold are the arm selector and a bool — not secret. The
+# api_crawler_password variable is sensitive to protect `plaintext`, which taints
+# these derived values; nonsensitive() strips the taint from the non-secret parts
+# only (plaintext, url, location are never exposed).
+output "api_crawler_password_method" {
+  description = "Effective api_crawler_password secret method (clear or blindfold)."
+  value       = nonsensitive(var.api_crawler_password.method)
+}
+
+output "api_crawler_password_use_blindfold" {
+  description = "Whether the crawler password renders the blindfold_secret_info arm (true) or clear_secret_info (false)."
+  value       = nonsensitive(local.api_crawler_password_secret.use_blindfold)
+}
+
+output "api_crawler_domain_count" {
+  description = "Number of authenticated domains configured for the inline API crawler."
+  value       = length(var.api_crawler_domains)
+}

--- a/terraform/modules/http-lb/outputs_api.tf
+++ b/terraform/modules/http-lb/outputs_api.tf
@@ -34,3 +34,13 @@ output "api_discovery_purge_duration" {
   description = "Effective discovered_api_settings purge duration (null when omitted)."
   value       = var.api_discovery_purge_duration
 }
+
+output "api_discovery_auth_mode" {
+  description = "Effective api-auth-discovery arm (default or custom)."
+  value       = var.api_discovery_auth_mode
+}
+
+output "api_discovery_custom_auth_type_count" {
+  description = "Number of custom auth types on the referenced xcsh_api_discovery (0 when auth mode is default)."
+  value       = var.api_discovery_auth_mode == "custom" ? length(var.api_discovery_custom_auth_types) : 0
+}

--- a/terraform/modules/http-lb/variables_api.tf
+++ b/terraform/modules/http-lb/variables_api.tf
@@ -7,16 +7,20 @@
 # Reusable clear/blindfold SecretType input shape. This exact object type + the
 # locals renderer (locals_api.tf) + the dynamic blindfold/clear blocks are the
 # DRY convention reused for every secret-bearing option (crawler password now;
-# SCM access_token / TLS keys later). method=clear emits clear_secret_info{url};
-# method=blindfold seals plaintext OFFLINE via provider::xcsh::blindfold and emits
-# blindfold_secret_info{location} (cleartext never leaves the machine).
+# SCM access_token / TLS keys later).
+#   method=clear      -> clear_secret_info { url = "string:///<base64 plaintext>" }
+#   method=blindfold  -> blindfold_secret_info { location = <pre-sealed value> }
+# IMPORTANT: provider::xcsh::blindfold seals with a random data key, so calling it
+# inline every plan would re-seal and drift (non-idempotent). Blindfold secrets are
+# therefore sealed ONCE, offline, and the resulting "string:///..." location is
+# pinned here (produced by scripts/blindfold-seal.sh). This is the F5-documented
+# offline-blindfold pattern and is idempotent + import-clean.
 variable "api_crawler_password" {
-  description = "API crawler login password as a selectable clear/blindfold secret."
+  description = "API crawler login password. clear: set plaintext. blindfold: set location to a pre-sealed 'string:///...' value from scripts/blindfold-seal.sh."
   type = object({
-    method                     = optional(string, "clear")
-    plaintext                  = optional(string)
-    blindfold_policy_namespace = optional(string, "shared")
-    blindfold_policy_name      = optional(string, "ves-io-allow-volterra")
+    method    = optional(string, "clear")
+    plaintext = optional(string) # clear arm
+    location  = optional(string) # blindfold arm: pre-sealed string:///...
   })
   default   = { method = "clear", plaintext = null }
   sensitive = true
@@ -24,6 +28,11 @@ variable "api_crawler_password" {
   validation {
     condition     = contains(["clear", "blindfold"], var.api_crawler_password.method)
     error_message = "api_crawler_password.method must be \"clear\" or \"blindfold\"."
+  }
+
+  validation {
+    condition     = var.api_crawler_password.method != "blindfold" || var.api_crawler_password.location != null
+    error_message = "blindfold method requires a pre-sealed location (run scripts/blindfold-seal.sh)."
   }
 }
 

--- a/terraform/modules/http-lb/variables_api.tf
+++ b/terraform/modules/http-lb/variables_api.tf
@@ -69,3 +69,34 @@ variable "api_discovery_purge_duration" {
   type        = number
   default     = null
 }
+
+# api-auth-discovery oneof. default = server default default_api_auth_discovery
+# (import-suppressed, so we emit NEITHER arm). custom = create a standalone
+# xcsh_api_discovery object and reference it via custom_api_auth_discovery.api_discovery_ref.
+variable "api_discovery_auth_mode" {
+  description = "enable_api_discovery auth-discovery: default (suppressed server default) or custom (custom_auth_types via a referenced xcsh_api_discovery)."
+  type        = string
+  default     = "default"
+
+  validation {
+    condition     = contains(["default", "custom"], var.api_discovery_auth_mode)
+    error_message = "api_discovery_auth_mode must be \"default\" or \"custom\"."
+  }
+}
+
+variable "api_discovery_custom_auth_types" {
+  description = "Custom auth types for the referenced xcsh_api_discovery when api_discovery_auth_mode=custom."
+  type = list(object({
+    parameter_name = string
+    parameter_type = string
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for t in var.api_discovery_custom_auth_types :
+      contains(["QUERY_PARAMETER", "HEADER", "COOKIE"], t.parameter_type)
+    ])
+    error_message = "each parameter_type must be QUERY_PARAMETER, HEADER, or COOKIE."
+  }
+}

--- a/terraform/modules/http-lb/variables_api.tf
+++ b/terraform/modules/http-lb/variables_api.tf
@@ -35,3 +35,37 @@ variable "api_crawler_domains" {
   }))
   default = []
 }
+
+# api_discovery_choice oneof: enable_api_discovery vs disable_api_discovery.
+# Default "enable" reproduces the current bare enable_api_discovery {} (0-change).
+variable "api_discovery_choice" {
+  description = "api_discovery_choice: enable (learn the API schema) or disable."
+  type        = string
+  default     = "enable"
+
+  validation {
+    condition     = contains(["enable", "disable"], var.api_discovery_choice)
+    error_message = "api_discovery_choice must be \"enable\" or \"disable\"."
+  }
+}
+
+# learn_from_redirect_traffic oneof. omit = server default disable_learn_from_redirect_traffic
+# (import-suppressed, so we emit NEITHER arm); enable = enable_learn_from_redirect_traffic.
+variable "api_discovery_learn_from_redirect" {
+  description = "enable_api_discovery learn-from-redirect: omit (server default disable, suppressed) or enable."
+  type        = string
+  default     = "omit"
+
+  validation {
+    condition     = contains(["omit", "enable"], var.api_discovery_learn_from_redirect)
+    error_message = "api_discovery_learn_from_redirect must be \"omit\" or \"enable\"."
+  }
+}
+
+# discovered_api_settings.purge_duration_for_inactive_discovered_apis. null = omit the
+# discovered_api_settings block entirely (server default, no drift).
+variable "api_discovery_purge_duration" {
+  description = "Days to purge inactive discovered APIs (discovered_api_settings.purge_duration_for_inactive_discovered_apis). null = omit."
+  type        = number
+  default     = null
+}

--- a/terraform/modules/http-lb/variables_api.tf
+++ b/terraform/modules/http-lb/variables_api.tf
@@ -1,0 +1,37 @@
+# ---------------------------------------------------------------------------
+# API Discovery & Crawler (SP1) — inputs. Defaults reproduce the current bare
+# enable_api_discovery {} (0-change / import-clean); non-default arms are cycled
+# by the api-discovery matrix. See docs/superpowers/specs + plans (local).
+# ---------------------------------------------------------------------------
+
+# Reusable clear/blindfold SecretType input shape. This exact object type + the
+# locals renderer (locals_api.tf) + the dynamic blindfold/clear blocks are the
+# DRY convention reused for every secret-bearing option (crawler password now;
+# SCM access_token / TLS keys later). method=clear emits clear_secret_info{url};
+# method=blindfold seals plaintext OFFLINE via provider::xcsh::blindfold and emits
+# blindfold_secret_info{location} (cleartext never leaves the machine).
+variable "api_crawler_password" {
+  description = "API crawler login password as a selectable clear/blindfold secret."
+  type = object({
+    method                     = optional(string, "clear")
+    plaintext                  = optional(string)
+    blindfold_policy_namespace = optional(string, "shared")
+    blindfold_policy_name      = optional(string, "ves-io-allow-volterra")
+  })
+  default   = { method = "clear", plaintext = null }
+  sensitive = true
+
+  validation {
+    condition     = contains(["clear", "blindfold"], var.api_crawler_password.method)
+    error_message = "api_crawler_password.method must be \"clear\" or \"blindfold\"."
+  }
+}
+
+variable "api_crawler_domains" {
+  description = "Authenticated domains for the inline API crawler (enable_api_discovery.api_crawler.api_crawler_config). Empty = no crawler (server default disable_api_crawler, suppressed on import)."
+  type = list(object({
+    domain = string
+    user   = string
+  }))
+  default = []
+}

--- a/terraform/modules/http-lb/variables_api.tf
+++ b/terraform/modules/http-lb/variables_api.tf
@@ -72,11 +72,18 @@ variable "api_discovery_learn_from_redirect" {
 }
 
 # discovered_api_settings.purge_duration_for_inactive_discovered_apis. null = omit the
-# discovered_api_settings block entirely (server default, no drift).
+# discovered_api_settings block entirely (server default, no drift). Server validation
+# rule ves.io.schema.rules.uint32 gte=1 lte=7, so mirror it here to fail fast at plan
+# instead of a live 400 BAD_REQUEST.
 variable "api_discovery_purge_duration" {
-  description = "Days to purge inactive discovered APIs (discovered_api_settings.purge_duration_for_inactive_discovered_apis). null = omit."
+  description = "Days (1-7) to purge inactive discovered APIs (discovered_api_settings.purge_duration_for_inactive_discovered_apis). null = omit."
   type        = number
   default     = null
+
+  validation {
+    condition     = var.api_discovery_purge_duration == null || (var.api_discovery_purge_duration >= 1 && var.api_discovery_purge_duration <= 7)
+    error_message = "api_discovery_purge_duration must be between 1 and 7 (days), or null to omit."
+  }
 }
 
 # api-auth-discovery oneof. default = server default default_api_auth_discovery

--- a/terraform/tests/api_discovery.tftest.hcl
+++ b/terraform/tests/api_discovery.tftest.hcl
@@ -50,3 +50,26 @@ run "discovery_purge_duration" {
     error_message = "discovered_api_settings purge duration must render"
   }
 }
+
+run "discovery_auth_mode_default" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  assert {
+    condition     = output.api_discovery_auth_mode == "default"
+    error_message = "default api_discovery_auth_mode must be the suppressed default arm"
+  }
+}
+
+run "discovery_auth_mode_custom" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_discovery_auth_mode         = "custom"
+    api_discovery_custom_auth_types = [{ parameter_name = "X-API-Key", parameter_type = "HEADER" }]
+  }
+  assert {
+    condition     = output.api_discovery_custom_auth_type_count == 1
+    error_message = "custom_api_auth_discovery with a custom auth type must render"
+  }
+}
+

--- a/terraform/tests/api_discovery.tftest.hcl
+++ b/terraform/tests/api_discovery.tftest.hcl
@@ -1,0 +1,52 @@
+# Plan-level tests: every api_discovery_choice arm + nested discovery sub-option
+# renders a valid provider value. Targets ./modules/http-lb with a dummy origin
+# (no tenant contact). Defaults reproduce the bare enable_api_discovery {} block.
+variables {
+  namespace         = "webapp-api-protection"
+  lb_domains        = ["www.f5-sales-demo.com"]
+  origin_ip         = "203.0.113.10"
+  origin_port       = 80
+  health_check_path = "/health"
+  labels            = {}
+  csd_enabled       = false
+  mud_enabled       = false
+}
+
+run "discovery_default_is_enable" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  assert {
+    condition     = output.api_discovery_choice == "enable"
+    error_message = "default api_discovery_choice must be enable (0-change)"
+  }
+}
+
+run "discovery_disable_arm" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { api_discovery_choice = "disable" }
+  assert {
+    condition     = output.api_discovery_choice == "disable"
+    error_message = "disable_api_discovery arm must render"
+  }
+}
+
+run "discovery_learn_from_redirect_enable" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { api_discovery_learn_from_redirect = "enable" }
+  assert {
+    condition     = output.api_discovery_learn_from_redirect == "enable"
+    error_message = "enable_learn_from_redirect_traffic arm must render"
+  }
+}
+
+run "discovery_purge_duration" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { api_discovery_purge_duration = 48 }
+  assert {
+    condition     = output.api_discovery_purge_duration == 48
+    error_message = "discovered_api_settings purge duration must render"
+  }
+}

--- a/terraform/tests/api_discovery.tftest.hcl
+++ b/terraform/tests/api_discovery.tftest.hcl
@@ -44,11 +44,20 @@ run "discovery_learn_from_redirect_enable" {
 run "discovery_purge_duration" {
   command = plan
   module { source = "./modules/http-lb" }
-  variables { api_discovery_purge_duration = 48 }
+  variables { api_discovery_purge_duration = 7 }
   assert {
-    condition     = output.api_discovery_purge_duration == 48
+    condition     = output.api_discovery_purge_duration == 7
     error_message = "discovered_api_settings purge duration must render"
   }
+}
+
+# Server rule is 1..7 days; an out-of-range value must fail validation (fail fast at
+# plan) rather than reach the API as a 400 BAD_REQUEST.
+run "discovery_purge_duration_out_of_range" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { api_discovery_purge_duration = 48 }
+  expect_failures = [var.api_discovery_purge_duration]
 }
 
 run "discovery_auth_mode_default" {

--- a/terraform/tests/api_secret.tftest.hcl
+++ b/terraform/tests/api_secret.tftest.hcl
@@ -30,3 +30,24 @@ run "clear_secret_selects_clear_arm" {
     error_message = "crawler domain must render"
   }
 }
+
+# Blindfold arm: exercises the provider::xcsh::blindfold function against the live
+# tenant (fetches the public key + secret policy, seals offline). Proves the
+# blindfold_secret_info arm renders a valid string:/// sealed location. Requires
+# XCSH creds even at plan (the function contacts the API).
+run "blindfold_secret_selects_blindfold_arm" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_crawler_domains  = [{ domain = "https://www.f5-sales-demo.com/dvwa/", user = "admin" }]
+    api_crawler_password = { method = "blindfold", plaintext = "password" }
+  }
+  assert {
+    condition     = output.api_crawler_password_use_blindfold == true
+    error_message = "blindfold method must select the blindfold arm"
+  }
+  assert {
+    condition     = output.api_crawler_password_method == "blindfold"
+    error_message = "effective method must be blindfold"
+  }
+}

--- a/terraform/tests/api_secret.tftest.hcl
+++ b/terraform/tests/api_secret.tftest.hcl
@@ -31,16 +31,15 @@ run "clear_secret_selects_clear_arm" {
   }
 }
 
-# Blindfold arm: exercises the provider::xcsh::blindfold function against the live
-# tenant (fetches the public key + secret policy, seals offline). Proves the
-# blindfold_secret_info arm renders a valid string:/// sealed location. Requires
-# XCSH creds even at plan (the function contacts the API).
+# Blindfold arm: uses a PRE-SEALED location (offline-sealed once via
+# scripts/blindfold-seal.sh). Renders blindfold_secret_info { location } and is
+# idempotent (the location is pinned, not re-sealed each plan). Offline test.
 run "blindfold_secret_selects_blindfold_arm" {
   command = plan
   module { source = "./modules/http-lb" }
   variables {
     api_crawler_domains  = [{ domain = "https://www.f5-sales-demo.com/dvwa/", user = "admin" }]
-    api_crawler_password = { method = "blindfold", plaintext = "password" }
+    api_crawler_password = { method = "blindfold", location = "string:///eyJrZXlfdmVyc2lvbiI6MX0=" }
   }
   assert {
     condition     = output.api_crawler_password_use_blindfold == true
@@ -50,4 +49,16 @@ run "blindfold_secret_selects_blindfold_arm" {
     condition     = output.api_crawler_password_method == "blindfold"
     error_message = "effective method must be blindfold"
   }
+}
+
+# blindfold without a pre-sealed location must fail validation (fail fast rather
+# than render an empty/invalid secret block).
+run "blindfold_requires_location" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_crawler_domains  = [{ domain = "https://www.f5-sales-demo.com/dvwa/", user = "admin" }]
+    api_crawler_password = { method = "blindfold" }
+  }
+  expect_failures = [var.api_crawler_password]
 }

--- a/terraform/tests/api_secret.tftest.hcl
+++ b/terraform/tests/api_secret.tftest.hcl
@@ -1,0 +1,32 @@
+# Plan-level tests for the reusable clear/blindfold SecretType convention, first
+# consumed by the inline API crawler credential (enable_api_discovery.api_crawler.
+# api_crawler_config.domains[].simple_login.password). Targets ./modules/http-lb
+# with a dummy origin. A successful plan proves the dynamic secret block builds a
+# valid provider value; asserts pin the effective arm via module outputs.
+variables {
+  namespace         = "webapp-api-protection"
+  lb_domains        = ["www.f5-sales-demo.com"]
+  origin_ip         = "203.0.113.10"
+  origin_port       = 80
+  health_check_path = "/health"
+  labels            = {}
+  csd_enabled       = false
+  mud_enabled       = false
+}
+
+run "clear_secret_selects_clear_arm" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_crawler_domains  = [{ domain = "https://api.f5-sales-demo.com", user = "tester" }]
+    api_crawler_password = { method = "clear", plaintext = "s3cret" }
+  }
+  assert {
+    condition     = output.api_crawler_password_use_blindfold == false
+    error_message = "clear method must not select the blindfold arm"
+  }
+  assert {
+    condition     = output.api_crawler_domain_count == 1
+    error_message = "crawler domain must render"
+  }
+}

--- a/terraform/variables_api.tf
+++ b/terraform/variables_api.tf
@@ -1,0 +1,57 @@
+# Root-level API Discovery & Crawler (SP1) inputs, passed through to modules/http-lb.
+# Defaults mirror the module and reproduce the current bare enable_api_discovery {}
+# (0-change). The api-discovery matrix supplies these via -var-file per variant.
+
+variable "api_discovery_choice" {
+  description = "api_discovery_choice: enable or disable."
+  type        = string
+  default     = "enable"
+}
+
+variable "api_discovery_learn_from_redirect" {
+  description = "enable_api_discovery learn-from-redirect: omit or enable."
+  type        = string
+  default     = "omit"
+}
+
+variable "api_discovery_purge_duration" {
+  description = "discovered_api_settings purge duration (days); null = omit."
+  type        = number
+  default     = null
+}
+
+variable "api_discovery_auth_mode" {
+  description = "api-auth-discovery: default or custom."
+  type        = string
+  default     = "default"
+}
+
+variable "api_discovery_custom_auth_types" {
+  description = "Custom auth types when api_discovery_auth_mode=custom."
+  type = list(object({
+    parameter_name = string
+    parameter_type = string
+  }))
+  default = []
+}
+
+variable "api_crawler_domains" {
+  description = "Authenticated domains for the inline API crawler; empty = no crawler."
+  type = list(object({
+    domain = string
+    user   = string
+  }))
+  default = []
+}
+
+variable "api_crawler_password" {
+  description = "API crawler login password as a selectable clear/blindfold secret."
+  type = object({
+    method                     = optional(string, "clear")
+    plaintext                  = optional(string)
+    blindfold_policy_namespace = optional(string, "shared")
+    blindfold_policy_name      = optional(string, "ves-io-allow-volterra")
+  })
+  default   = { method = "clear", plaintext = null }
+  sensitive = true
+}

--- a/terraform/variables_api.tf
+++ b/terraform/variables_api.tf
@@ -45,12 +45,11 @@ variable "api_crawler_domains" {
 }
 
 variable "api_crawler_password" {
-  description = "API crawler login password as a selectable clear/blindfold secret."
+  description = "API crawler login password. clear: set plaintext. blindfold: set location to a pre-sealed 'string:///...' from scripts/blindfold-seal.sh."
   type = object({
-    method                     = optional(string, "clear")
-    plaintext                  = optional(string)
-    blindfold_policy_namespace = optional(string, "shared")
-    blindfold_policy_name      = optional(string, "ves-io-allow-volterra")
+    method    = optional(string, "clear")
+    plaintext = optional(string)
+    location  = optional(string)
   })
   default   = { method = "clear", plaintext = null }
   sensitive = true

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,14 +1,17 @@
 terraform {
-  required_version = ">= 1.5"
+  # >= 1.8 for provider-defined functions (provider::xcsh::blindfold, used by
+  # scripts/blindfold-seal.sh to seal API-crawler / SecretType credentials).
+  required_version = ">= 1.8"
 
   required_providers {
     xcsh = {
       source = "f5-sales-demo/xcsh"
-      # >= 3.64.0: first release carrying the nested Optional+Computed scalar
-      # fix (http_health_check.use_http2 no longer unknown-after-apply). Resources
-      # http_loadbalancer, origin_pool, app_firewall (WAF), api_definition are all
-      # generated. Locally the provider is consumed via dev_overrides (ignores this).
-      version = ">= 3.64.0"
+      # >= 3.71.1: carries the nested-list value-conversion fix (#1083) — nested
+      # ListNestedBlocks (e.g. the inline api_crawler domains) are modeled as
+      # types.List so they hold plan-time unknowns; without it the API crawler
+      # block fails with a Value Conversion Error. (Supersedes the >= 3.64.0
+      # nested Optional+Computed scalar fix.) Locally consumed via dev_overrides.
+      version = ">= 3.71.1"
     }
     # Azure providers: this plan also deploys its OWN Azure origin server and
     # traffic generator (modules/origin-server, modules/traffic-generator), which

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Python unit tests."""

--- a/tests/test_api_discovery_pairs.py
+++ b/tests/test_api_discovery_pairs.py
@@ -11,14 +11,14 @@ def test_covers_all_pairs() -> None:
     names = list(DIMENSIONS)
     required: set[tuple[str, str, str, str]] = set()
     for i, ka in enumerate(names):
-        for kb in names[i + 1:]:
+        for kb in names[i + 1 :]:
             for va in DIMENSIONS[ka]:
                 for vb in DIMENSIONS[kb]:
                     required.add((ka, va, kb, vb))
     covered: set[tuple[str, str, str, str]] = set()
     for row in rows:
         for i, ka in enumerate(names):
-            for kb in names[i + 1:]:
+            for kb in names[i + 1 :]:
                 covered.add((ka, row[ka], kb, row[kb]))
     assert required <= covered
 
@@ -33,7 +33,10 @@ def test_both_secret_arms_exercised_with_a_crawler() -> None:
     methods: set[str] = set()
     for variant in build():
         variant_vars = cast("dict[str, Any]", variant["vars"])
-        if variant_vars.get("api_crawler_domains") and "api_crawler_password" in variant_vars:
+        if (
+            variant_vars.get("api_crawler_domains")
+            and "api_crawler_password" in variant_vars
+        ):
             methods.add(variant_vars["api_crawler_password"]["method"])
     assert {"clear", "blindfold"} <= methods
 

--- a/tests/test_api_discovery_pairs.py
+++ b/tests/test_api_discovery_pairs.py
@@ -1,0 +1,49 @@
+"""Unit tests for the API Discovery all-pairs generator."""
+
+from typing import Any, cast
+
+from api_discovery_pairs import DIMENSIONS, all_pairs, build, payloads
+
+
+def test_covers_all_pairs() -> None:
+    """Every unordered pair of option-values co-occurs in at least one row."""
+    rows = all_pairs(DIMENSIONS)
+    names = list(DIMENSIONS)
+    required: set[tuple[str, str, str, str]] = set()
+    for i, ka in enumerate(names):
+        for kb in names[i + 1:]:
+            for va in DIMENSIONS[ka]:
+                for vb in DIMENSIONS[kb]:
+                    required.add((ka, va, kb, vb))
+    covered: set[tuple[str, str, str, str]] = set()
+    for row in rows:
+        for i, ka in enumerate(names):
+            for kb in names[i + 1:]:
+                covered.add((ka, row[ka], kb, row[kb]))
+    assert required <= covered
+
+
+def test_deterministic() -> None:
+    """The manifest is byte-stable across runs (no RNG)."""
+    assert build() == build()
+
+
+def test_both_secret_arms_exercised_with_a_crawler() -> None:
+    """A crawler variant exists for both clear and blindfold (proves both arms run live)."""
+    methods: set[str] = set()
+    for variant in build():
+        variant_vars = cast("dict[str, Any]", variant["vars"])
+        if variant_vars.get("api_crawler_domains") and "api_crawler_password" in variant_vars:
+            methods.add(variant_vars["api_crawler_password"]["method"])
+    assert {"clear", "blindfold"} <= methods
+
+
+def test_payloads_strip_pseudo_dimensions() -> None:
+    """Pseudo-dimensions never leak into emitted tfvars."""
+    out = payloads({"api_crawler": "one", "secret_method": "blindfold"})
+    assert "api_crawler" not in out
+    assert "secret_method" not in out
+    assert out["api_crawler_password"] == {
+        "method": "blindfold",
+        "plaintext": "Sp1-Cr@wl-Demo",
+    }

--- a/tests/test_api_discovery_pairs.py
+++ b/tests/test_api_discovery_pairs.py
@@ -39,11 +39,14 @@ def test_both_secret_arms_exercised_with_a_crawler() -> None:
 
 
 def test_payloads_strip_pseudo_dimensions() -> None:
-    """Pseudo-dimensions never leak into emitted tfvars."""
+    """Pseudo-dimensions never leak; blindfold omits plaintext (harness seals location)."""
     out = payloads({"api_crawler": "one", "secret_method": "blindfold"})
     assert "api_crawler" not in out
     assert "secret_method" not in out
-    assert out["api_crawler_password"] == {
-        "method": "blindfold",
+    assert out["api_crawler_password"] == {"method": "blindfold"}
+
+    clear = payloads({"api_crawler": "one", "secret_method": "clear"})
+    assert clear["api_crawler_password"] == {
+        "method": "clear",
         "plaintext": "Sp1-Cr@wl-Demo",
     }


### PR DESCRIPTION
Closes #33. SP1 of the API Discovery & Protection effort.

## What
Exhaustive API Discovery + Crawler coverage on the reference LB, and a reusable,
DRY **clear⇄blindfold SecretType convention** (the cross-cutting "properly use
blindfold options" capability) proven first on the crawler login credential.

## Delivered
- **Reusable SecretType convention** (`variables_api.tf` object + `locals_api.tf`
  renderer + dynamic `blindfold_secret_info`/`clear_secret_info` blocks). Both arms
  plan-tested. Blindfold is sealed **once** offline via `scripts/blindfold-seal.sh`
  and the `string:///` location is **pinned** — `provider::xcsh::blindfold` uses a
  random data key, so an inline call would re-seal every plan and drift; pinning is
  idempotent and matches the F5 offline-blindfold docs.
- **API discovery parameterized**: `api_discovery_choice` (enable/disable),
  learn-from-redirect, `discovered_api_settings` (purge 1..7, validated), inline
  `api_crawler` (bare-FQDN domain + clear/blindfold password), standalone
  `xcsh_api_discovery` + `custom_api_auth_discovery` ref. Defaults reproduce the bare
  `enable_api_discovery {}` — **0-change** verified on the live LB.
- **Provider #1083 fix shipped** as **v3.71.1** (nested `ListNestedBlock` → `types.List`
  so it holds plan-time unknowns; unblocks the crawler `domains` block). `versions.tf`
  now requires `>= 3.71.1`.
- All-pairs generator (`scripts/api_discovery_pairs.py` + 4 unit tests), live matrix
  harness (`scripts/api-discovery-matrix.sh`, `make api-discovery-matrix`), staged
  behavioral verify (`scripts/api-crawl-verify.sh`, `make api-crawl-verify`).

## Verification
- Plan-level TDD: `api_secret.tftest.hcl` 3/3, `api_discovery.tftest.hcl` 7/7.
- Live matrix: discovery enable/disable, learn-from-redirect, purge (1..7), the inline
  **clear** crawler, and standalone `xcsh_api_discovery` are apply-idempotent +
  round-trip-import clean (write-only crawler secret re-applied on import).
- Behavioral: blindfold function seals live; clear crawler applies + idempotent.

## Known limitations (documented, not masked — recorded as SKIP with reasons)
- **custom_api_auth_discovery** live-apply is blocked by a provider object-ref
  `tenant` bug (#1080 class) — filed as **#1091**. Plan-tested; excluded from live
  matrix pending the fix.
- **api_crawler password + blindfold** returns an F5 XC **500** (platform-side; clear
  works). The blindfold convention/function are correct; the crawler's live secret
  path is clear. Surfaced for F5 platform follow-up.

## Provider PRs
- #1088 (#1083 fix) → auto-regen #1090 → **v3.71.1** released.
- #1091 filed (object-ref tenant, follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)