### PR TITLE
SP2: API Definition & spec management (code_base_integration SCM + xcsh_api_definition + LB schema enforcement)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # webapp-api-protection developer targets.
 
-.PHONY: mud-matrix mud-verify waf-matrix api-discovery-matrix api-crawl-verify test
+.PHONY: mud-matrix mud-verify waf-matrix api-discovery-matrix api-definition-matrix api-crawl-verify test
 
 # Run the plan-level test suite (no tenant contact).
 test:
@@ -30,6 +30,15 @@ waf-matrix:
 # (generator) and scripts/api-discovery-matrix.sh (harness).
 api-discovery-matrix:
 	bash scripts/api-discovery-matrix.sh
+
+# Cycle the live LB through the API Definition & spec-enforcement (SP2) all-pairs
+# variant set and verify apply / idempotency / round-trip import (re-applying the
+# write-only code_base_integration access_token on import; blindfold token = SKIP).
+# Requires GH_TOKEN in the environment. Runs in batches: `make api-definition-matrix`
+# (all) or `bash scripts/api-definition-matrix.sh START END`. See
+# scripts/api_definition_pairs.py (generator) and scripts/api-definition-matrix.sh.
+api-definition-matrix:
+	bash scripts/api-definition-matrix.sh
 
 # Staged blindfold verification: seal round-trip (a pre-sealed crawler credential
 # applies + is idempotent + import-clean) plus an authenticated-crawl attempt

--- a/scripts/api-definition-matrix.sh
+++ b/scripts/api-definition-matrix.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# API Definition & spec-enforcement (SP2) live coverage-matrix harness.
+#
+# Cycles the LIVE webapp-api-protection LB through the api_definition_pairs variant
+# set and verifies each LIVE variant (a) applies, (b) is idempotent (immediate plan
+# = No changes), and (c) is round-trip-import clean for the LB and, when present,
+# the referenced xcsh_api_definition and xcsh_code_base_integration. Ends on
+# canonical-restore so the live LB is left healthy (all SP2 features off). Results
+# append to reports/api-definition-matrix.txt.
+#
+# Secret injection (never committed): the manifest holds NO secret values.
+#  - clear code_base_integration access_token  <- $GH_TOKEN (env),
+#  - blindfold access_token location           <- sealed ONCE via blindfold-seal.sh,
+#  - swagger_specs __SWAGGER_PATH__             <- one OpenAPI file uploaded ONCE via
+#    scripts/swagger-upload.sh and pinned across the run (content-addressed).
+#
+# Write-only secrets: F5 XC never returns the access_token on read, so an import
+# cannot recover it. Variants that create a code_base_integration therefore re-apply
+# after import to re-set the write-only secret, then require a clean plan. Variants
+# with no write-only secret (api_definition / LB only) must import 0-change.
+#
+# blindfold access_token 500s on F5 XC (documented platform limitation, see
+# docs/superpowers/plans/sp2-findings.md); those variants are marked SKIP in the
+# manifest and are plan-tested only. A 400 BAD_REQUEST is a real FAIL.
+# Sequential — no concurrent terraform against the shared azurerm state.
+#
+# Usage: api-definition-matrix.sh [START [END]]  (inclusive 0-based index range).
+set -uo pipefail
+
+umask 077
+trap 'rm -rf /tmp/apidef-variants 2>/dev/null; rm -f /tmp/apidef-*.log /tmp/apidef-*.json 2>/dev/null' EXIT
+
+cd "$(dirname "$0")/../terraform" || exit 1
+ARM_ACCESS_KEY=$(az storage account keys list -n f5salesdemotfstate -g f5-sales-demo-tfstate --query "[0].value" -o tsv)
+export ARM_ACCESS_KEY
+: "${GH_TOKEN:?GH_TOKEN must be set (clear code_base_integration access_token)}"
+
+NS="webapp-api-protection"
+LB_ADDR="module.http_lb.xcsh_http_loadbalancer.this"
+LB_ID="${NS}/${NS}"
+DEF_ADDR="module.http_lb.xcsh_api_definition.this[0]"
+DEF_ID="${NS}/${NS}-api-def"
+SCM_ADDR="module.http_lb.xcsh_code_base_integration.github[0]"
+SCM_ID="${NS}/${NS}-api-catalog"
+COMMON=(-input=false -lock=true
+  -var 'lb_domains=["www.f5-sales-demo.com","api.f5-sales-demo.com"]'
+  -var 'subscription_id=75f86c46-9cbc-4f6c-85ea-195e3d3c8ac0')
+VARDIR=/tmp/apidef-variants
+REPORT=../reports/api-definition-matrix.txt
+mkdir -p ../reports
+
+START="${1:-0}"
+END="${2:-9999}"
+
+count=$(python3 ../scripts/api_definition_pairs.py --emit "$VARDIR")
+echo "generated $count variants into $VARDIR (running [$START..$END])"
+
+BF_LOCATION=""
+seal_once() {
+  [ -n "$BF_LOCATION" ] && return 0
+  BF_LOCATION=$(../scripts/blindfold-seal.sh "$GH_TOKEN" 2>/dev/null)
+  [ -n "$BF_LOCATION" ]
+}
+
+SWAGGER_PATH=""
+upload_swagger_once() {
+  [ -n "$SWAGGER_PATH" ] && return 0
+  # A tiny valid OpenAPI doc is enough to exercise the swagger_specs supply path.
+  local spec=/tmp/apidef-spec.json
+  printf '%s' '{"openapi":"3.0.0","info":{"title":"webapp-api-protection-matrix","version":"1.0.0"},"paths":{"/health":{"get":{"responses":{"200":{"description":"ok"}}}}}}' >"$spec"
+  SWAGGER_PATH=$(../scripts/swagger-upload.sh matrix-probe "$spec" "$NS" 2>/dev/null)
+  [ -n "$SWAGGER_PATH" ]
+}
+
+# Inject live secret/path values; print the var-file to use.
+prep_varfile() {
+  local vf="$1" out="${1%.json}.live.json"
+  cp "$vf" "$out"
+  if grep -q '"method": "clear"' "$out"; then
+    jq --arg t "$GH_TOKEN" '.code_base_integration_access_token.plaintext = $t' "$out" >"${out}.tmp" && mv "${out}.tmp" "$out"
+  fi
+  if grep -q '"method": "blindfold"' "$out" && ! grep -q '"location"' "$out"; then
+    seal_once || return 1
+    jq --arg loc "$BF_LOCATION" '.code_base_integration_access_token.location = $loc' "$out" >"${out}.tmp" && mv "${out}.tmp" "$out"
+  fi
+  if grep -q '__SWAGGER_PATH__' "$out"; then
+    upload_swagger_once || return 1
+    jq --arg p "$SWAGGER_PATH" '.api_definition_swagger_specs = [$p]' "$out" >"${out}.tmp" && mv "${out}.tmp" "$out"
+  fi
+  echo "$out"
+}
+
+import_one() {
+  local addr="$1" id="$2" vf="$3" label="$4"
+  terraform state rm "$addr" >/dev/null 2>&1 || return 0
+  terraform import "${COMMON[@]}" -var-file="$vf" "$addr" "$id" >>/tmp/apidef-import.log 2>&1 || {
+    echo "FAIL $label import($addr)" >>"$REPORT"
+    return 1
+  }
+}
+
+round_trip() {
+  local label="$1" vf="$2"
+  import_one "$LB_ADDR" "$LB_ID" "$vf" "$label" || return
+  if terraform state list 2>/dev/null | grep -qxF "$DEF_ADDR"; then
+    import_one "$DEF_ADDR" "$DEF_ID" "$vf" "$label" || return
+  fi
+  if terraform state list 2>/dev/null | grep -qxF "$SCM_ADDR"; then
+    import_one "$SCM_ADDR" "$SCM_ID" "$vf" "$label" || return
+  fi
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$vf" >/tmp/apidef-rt-plan.log 2>&1
+  case $? in
+  0) echo "PASS $label" >>"$REPORT" ;;
+  2)
+    # Only a code_base_integration variant carries a write-only secret (access_token)
+    # that import cannot recover — re-apply to re-set it, then require a clean plan.
+    # Any other post-import drift is a real bug (no escape hatch).
+    if grep -q 'code_base_integration_enabled' "$vf" && grep -q 'true' "$vf"; then
+      terraform apply -auto-approve "${COMMON[@]}" -var-file="$vf" >/tmp/apidef-rt-apply.log 2>&1
+      terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$vf" >/tmp/apidef-rt-plan2.log 2>&1
+      case $? in
+      0) echo "PASS $label (import re-set write-only secret)" >>"$REPORT" ;;
+      2) echo "FAIL $label import-drift" >>"$REPORT" ;;
+      *) echo "FAIL $label rt-plan-error" >>"$REPORT" ;;
+      esac
+    else
+      echo "FAIL $label import-drift (no-secret variant must import clean)" >>"$REPORT"
+    fi
+    ;;
+  *) echo "FAIL $label rt-plan-error" >>"$REPORT" ;;
+  esac
+}
+
+while read -r idx name vf flag; do
+  [ "$idx" -lt "$START" ] && continue
+  [ "$idx" -gt "$END" ] && continue
+  label="$idx-$name"
+  echo "--- $label ($flag) ---"
+  varfile=$(prep_varfile "${VARDIR}/${vf}") || {
+    echo "FAIL $label prep" >>"$REPORT"
+    continue
+  }
+  # SKIP variants (blindfold access_token) are plan-tested only — verify they render.
+  if [[ "$flag" == SKIP:* ]]; then
+    if terraform plan "${COMMON[@]}" -var-file="$varfile" >/tmp/apidef-plan.log 2>&1; then
+      echo "SKIP $label ${flag#SKIP:} (plan renders)" >>"$REPORT"
+    else
+      echo "FAIL $label skip-variant-plan-error" >>"$REPORT"
+    fi
+    continue
+  fi
+  if ! terraform apply -auto-approve "${COMMON[@]}" -var-file="$varfile" >/tmp/apidef-apply.log 2>&1; then
+    echo "FAIL $label apply ($(grep -iE 'error' /tmp/apidef-apply.log | head -1 | cut -c1-80))" >>"$REPORT"
+    continue
+  fi
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$varfile" >/tmp/apidef-plan.log 2>&1
+  case $? in
+  0) round_trip "$label" "$varfile" ;;
+  2) echo "FAIL $label not-idempotent" >>"$REPORT" ;;
+  *) echo "FAIL $label plan-error" >>"$REPORT" ;;
+  esac
+done <"${VARDIR}/manifest.txt"
+
+echo "===== API DEFINITION MATRIX RESULTS ($START..$END) ====="
+cat "$REPORT"
+echo "PASS=$(grep -c '^PASS ' "$REPORT") FAIL=$(grep -c '^FAIL ' "$REPORT") SKIP=$(grep -c '^SKIP ' "$REPORT")"

--- a/scripts/api-definition-matrix.sh
+++ b/scripts/api-definition-matrix.sh
@@ -28,12 +28,13 @@
 set -uo pipefail
 
 umask 077
-trap 'rm -rf /tmp/apidef-variants 2>/dev/null; rm -f /tmp/apidef-*.log /tmp/apidef-*.json 2>/dev/null' EXIT
+trap 'rm -rf /tmp/apidef-variants /tmp/apidef-bf.loc /tmp/apidef-swagger.path 2>/dev/null; rm -f /tmp/apidef-*.log /tmp/apidef-*.json 2>/dev/null' EXIT
 
 cd "$(dirname "$0")/../terraform" || exit 1
 ARM_ACCESS_KEY=$(az storage account keys list -n f5salesdemotfstate -g f5-sales-demo-tfstate --query "[0].value" -o tsv)
 export ARM_ACCESS_KEY
 : "${GH_TOKEN:?GH_TOKEN must be set (clear code_base_integration access_token)}"
+export GH_TOKEN # so jq can read it via env.GH_TOKEN (never passed on argv)
 
 NS="webapp-api-protection"
 LB_ADDR="module.http_lb.xcsh_http_loadbalancer.this"
@@ -52,24 +53,32 @@ mkdir -p ../reports
 START="${1:-0}"
 END="${2:-9999}"
 
+# Truncate the report on a full run; a batched range run (args given) appends.
+[ "$#" -eq 0 ] && : >"$REPORT"
+
 count=$(python3 ../scripts/api_definition_pairs.py --emit "$VARDIR")
 echo "generated $count variants into $VARDIR (running [$START..$END])"
 
-BF_LOCATION=""
+# Seal/upload ONCE and persist to sentinel files. prep_varfile runs in a command
+# substitution (a subshell), so in-memory globals would not survive between
+# variants — the sentinel files do. Blindfold is non-deterministic, so re-sealing
+# per variant would drift; the swagger store is content-addressed (re-upload is a
+# no-op) but we still upload once. The token is piped via stdin (never argv).
+BF_LOC_FILE=/tmp/apidef-bf.loc
 seal_once() {
-  [ -n "$BF_LOCATION" ] && return 0
-  BF_LOCATION=$(../scripts/blindfold-seal.sh "$GH_TOKEN" 2>/dev/null)
-  [ -n "$BF_LOCATION" ]
+  [ -s "$BF_LOC_FILE" ] && return 0
+  printf '%s' "$GH_TOKEN" | ../scripts/blindfold-seal.sh 2>/dev/null >"$BF_LOC_FILE"
+  [ -s "$BF_LOC_FILE" ]
 }
 
-SWAGGER_PATH=""
+SWAGGER_PATH_FILE=/tmp/apidef-swagger.path
 upload_swagger_once() {
-  [ -n "$SWAGGER_PATH" ] && return 0
+  [ -s "$SWAGGER_PATH_FILE" ] && return 0
   # A tiny valid OpenAPI doc is enough to exercise the swagger_specs supply path.
   local spec=/tmp/apidef-spec.json
   printf '%s' '{"openapi":"3.0.0","info":{"title":"webapp-api-protection-matrix","version":"1.0.0"},"paths":{"/health":{"get":{"responses":{"200":{"description":"ok"}}}}}}' >"$spec"
-  SWAGGER_PATH=$(../scripts/swagger-upload.sh matrix-probe "$spec" "$NS" 2>/dev/null)
-  [ -n "$SWAGGER_PATH" ]
+  ../scripts/swagger-upload.sh matrix-probe "$spec" "$NS" 2>/dev/null >"$SWAGGER_PATH_FILE"
+  [ -s "$SWAGGER_PATH_FILE" ]
 }
 
 # Inject live secret/path values; print the var-file to use.
@@ -77,15 +86,18 @@ prep_varfile() {
   local vf="$1" out="${1%.json}.live.json"
   cp "$vf" "$out"
   if grep -q '"method": "clear"' "$out"; then
-    jq --arg t "$GH_TOKEN" '.code_base_integration_access_token.plaintext = $t' "$out" >"${out}.tmp" && mv "${out}.tmp" "$out"
+    # Read the token from the environment (env.GH_TOKEN), never argv — a positional
+    # --arg is visible in /proc/<pid>/cmdline to any local user; the environment is
+    # readable only by the process owner and root.
+    jq '.code_base_integration_access_token.plaintext = env.GH_TOKEN' "$out" >"${out}.tmp" && mv "${out}.tmp" "$out"
   fi
   if grep -q '"method": "blindfold"' "$out" && ! grep -q '"location"' "$out"; then
     seal_once || return 1
-    jq --arg loc "$BF_LOCATION" '.code_base_integration_access_token.location = $loc' "$out" >"${out}.tmp" && mv "${out}.tmp" "$out"
+    jq --arg loc "$(cat "$BF_LOC_FILE")" '.code_base_integration_access_token.location = $loc' "$out" >"${out}.tmp" && mv "${out}.tmp" "$out"
   fi
   if grep -q '__SWAGGER_PATH__' "$out"; then
     upload_swagger_once || return 1
-    jq --arg p "$SWAGGER_PATH" '.api_definition_swagger_specs = [$p]' "$out" >"${out}.tmp" && mv "${out}.tmp" "$out"
+    jq --arg p "$(cat "$SWAGGER_PATH_FILE")" '.api_definition_swagger_specs = [$p]' "$out" >"${out}.tmp" && mv "${out}.tmp" "$out"
   fi
   echo "$out"
 }
@@ -115,7 +127,7 @@ round_trip() {
     # Only a code_base_integration variant carries a write-only secret (access_token)
     # that import cannot recover — re-apply to re-set it, then require a clean plan.
     # Any other post-import drift is a real bug (no escape hatch).
-    if grep -q 'code_base_integration_enabled' "$vf" && grep -q 'true' "$vf"; then
+    if grep -q '"code_base_integration_enabled": true' "$vf"; then
       terraform apply -auto-approve "${COMMON[@]}" -var-file="$vf" >/tmp/apidef-rt-apply.log 2>&1
       terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$vf" >/tmp/apidef-rt-plan2.log 2>&1
       case $? in

--- a/scripts/api_definition_pairs.py
+++ b/scripts/api_definition_pairs.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Generate the API Definition & spec-enforcement (SP2) coverage matrix.
+
+Coverage model (see docs/superpowers/specs/2026-07-14-sp2-api-definition-spec-management-design.md
+and docs/superpowers/plans/sp2-findings.md):
+  * all-pairs (pairwise, AETG greedy) over the SP2 oneof-group dimensions, so every
+    pair of option-values co-occurs in at least one variant;
+  * PLUS the canonical restore end state (all SP2 features off).
+
+Pairwise dimensions and the pseudo-dimensions expanded by payloads():
+  api_definition  disable | specification  -> api_definition_choice
+  validation      disabled | all_spec_endpoints  (only when specification)
+  schema_origin   strict | mixed  (only when specification)
+  swagger         none | one  (one => a pinned object-store path, injected live)
+  integration     off | on  -> code_base_integration_enabled
+  token_method    clear | blindfold  (only when integration; blindfold is a
+                  documented live SKIP — F5 XC 500s, see sp2-findings.md — so it is
+                  plan-tested only, matching the SP1 crawler password)
+  code_scan       off | selected  (requires integration on + repos; reconciled below)
+
+payloads() reconciles the module's cross-field preconditions so every emitted
+variant is a valid root config: when api_definition=disable the specification-only
+arms are dropped; when integration=off the token/code_scan arms are dropped (code
+scan requires the integration). Secret values and the uploaded swagger path are
+NOT in the manifest — the harness injects them (placeholders below), exactly as the
+SP1 matrix injects the sealed blindfold location.
+
+Deterministic: fixed ordering + lowest-index tie-break (no RNG).
+
+Output: JSON array of {"name", "vars", optional "skip_live"} to stdout, or files.
+"""
+
+import itertools
+import json
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+DIMENSIONS = {
+    "api_definition": ["disable", "specification"],
+    "validation": ["disabled", "all_spec_endpoints"],
+    "schema_origin": ["strict", "mixed"],
+    "swagger": ["none", "one"],
+    "integration": ["off", "on"],
+    "token_method": ["clear", "blindfold"],
+    "code_scan": ["off", "selected"],
+}
+
+# Placeholders the harness substitutes with live values (never committed here).
+SWAGGER_PLACEHOLDER = "__SWAGGER_PATH__"
+CODE_SCAN_REPO = "api-catalog"
+
+
+def _best_value(
+    values: list[str],
+    idx: int,
+    row: dict[int, str],
+    uncovered: set[tuple[int, str, int, str]],
+) -> str:
+    """Pick the value for dimension idx covering the most still-uncovered pairs."""
+    best_val, best_gain = values[0], -1
+    for val in values:
+        gain = 0
+        for pidx, pval in row.items():
+            a, b = sorted([(pidx, pval), (idx, val)])
+            if (a[0], a[1], b[0], b[1]) in uncovered:
+                gain += 1
+        if gain > best_gain:
+            best_gain, best_val = gain, val
+    return best_val
+
+
+def all_pairs(dims: dict[str, list[str]]) -> list[dict[str, str]]:
+    """Return AETG-style greedy all-pairs rows ({dim: value})."""
+    names = list(dims)
+    uncovered: set[tuple[int, str, int, str]] = set()
+    for i, j in itertools.combinations(range(len(names)), 2):
+        for vi in dims[names[i]]:
+            for vj in dims[names[j]]:
+                uncovered.add((i, vi, j, vj))
+
+    rows = []
+    while uncovered:
+        si, sv, sj, sv2 = min(uncovered)
+        row = {si: sv, sj: sv2}
+        for idx, name in enumerate(names):
+            if idx not in row:
+                row[idx] = _best_value(dims[name], idx, row, uncovered)
+        for i, j in itertools.combinations(sorted(row), 2):
+            uncovered.discard((i, row[i], j, row[j]))
+        rows.append({names[k]: v for k, v in row.items()})
+    return rows
+
+
+def payloads(v: Mapping[str, object]) -> tuple[dict[str, object], str | None]:
+    """Expand a pairwise row into real tfvars + an optional live-skip reason."""
+    out: dict[str, object] = {}
+    skip: str | None = None
+
+    if v.get("api_definition") == "specification":
+        out["api_definition_choice"] = "specification"
+        out["api_specification_validation"] = v["validation"]
+        out["api_definition_schema_origin"] = v["schema_origin"]
+        if v.get("swagger") == "one":
+            out["api_definition_swagger_specs"] = [SWAGGER_PLACEHOLDER]
+    else:
+        out["api_definition_choice"] = "disable"
+
+    if v.get("integration") == "on":
+        out["code_base_integration_enabled"] = True
+        out["code_base_integration_username"] = "robinmordasiewicz"
+        if v.get("token_method") == "blindfold":
+            # location injected by the harness; blindfold access_token 500s on F5 XC
+            # (see sp2-findings.md) -> plan-tested only, skip the live apply.
+            out["code_base_integration_access_token"] = {"method": "blindfold"}
+            skip = "blindfold access_token 500s on F5 XC (platform limitation); clear is the live path"
+        else:
+            out["code_base_integration_access_token"] = {"method": "clear"}
+        if v.get("code_scan") == "selected":
+            out["api_discovery_code_scan"] = "selected"
+            out["api_discovery_code_scan_repos"] = [CODE_SCAN_REPO]
+    # integration=off => no token/code_scan (code scan requires the integration).
+
+    return out, skip
+
+
+def canonical() -> dict[str, object]:
+    """Return the live-canonical end state (all SP2 features off)."""
+    return {"api_definition_choice": "disable", "code_base_integration_enabled": False}
+
+
+def build() -> list[dict[str, object]]:
+    """Build the ordered variant manifest (all-pairs + canonical restore).
+
+    Constraint reconciliation collapses several distinct pairwise rows to the same
+    root config (e.g. every integration=off + api_definition=disable row yields the
+    bare disable config); those byte-identical payloads are deduped so the slow live
+    matrix does not re-apply the same variant. Pairwise coverage is unaffected — it
+    is achieved at the row level before reconciliation.
+    """
+    variants: list[dict[str, object]] = []
+    seen: set[str] = set()
+    idx = 0
+    for row in all_pairs(DIMENSIONS):
+        vars_, skip = payloads(row)
+        key = json.dumps(vars_, sort_keys=True)
+        if key in seen:
+            continue
+        seen.add(key)
+        variant: dict[str, object] = {"name": f"pair-{idx:03d}", "vars": vars_}
+        if skip:
+            variant["skip_live"] = skip
+        variants.append(variant)
+        idx += 1
+    variants.append({"name": "canonical-restore", "vars": canonical()})
+    return variants
+
+
+def emit(directory: str) -> int:
+    """Write one <NNN>-<name>.tfvars.json per variant plus manifest.txt."""
+    out_dir = Path(directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for existing in out_dir.iterdir():
+        if existing.name.endswith(".tfvars.json") or existing.name == "manifest.txt":
+            existing.unlink()
+    variants = build()
+    named = [(f"{i:03d}-{v['name']}.tfvars.json", v) for i, v in enumerate(variants)]
+    for fname, v in named:
+        (out_dir / fname).write_text(json.dumps(v["vars"], indent=2) + "\n")
+    lines = [
+        f"{i:03d} {v['name']} {fname} {'SKIP:' + str(v['skip_live']) if v.get('skip_live') else 'LIVE'}"
+        for i, (fname, v) in enumerate(named)
+    ]
+    (out_dir / "manifest.txt").write_text("\n".join(lines) + "\n")
+    return len(variants)
+
+
+def main(argv: list[str]) -> None:
+    """CLI: --count, --emit <dir>, else JSON to stdout."""
+    match argv[1:]:
+        case ["--count"]:
+            sys.stdout.write(f"{len(build())}\n")
+        case ["--emit", directory]:
+            sys.stdout.write(f"{emit(directory)}\n")
+        case _:
+            json.dump(build(), sys.stdout, indent=2)
+            sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/scripts/blindfold-seal.sh
+++ b/scripts/blindfold-seal.sh
@@ -14,7 +14,18 @@
 #   working dir to be initialized (the provider function is served by the provider).
 set -euo pipefail
 
-PLAINTEXT="${1:?usage: blindfold-seal.sh <plaintext> [policy_name] [policy_namespace]}"
+# Read the plaintext from the first arg OR, when it is omitted, from stdin. Prefer
+# stdin for real secrets: a positional arg is visible in `ps`/`/proc/<pid>/cmdline`
+# to any local user, whereas a piped value is not. (SP1 callers that seal a
+# non-secret demo credential still pass it positionally.)
+PLAINTEXT="${1-}"
+if [ -z "$PLAINTEXT" ]; then
+  PLAINTEXT="$(cat)"
+fi
+[ -n "$PLAINTEXT" ] || {
+  echo "usage: blindfold-seal.sh <plaintext | via stdin> [policy_name] [policy_namespace]" >&2
+  exit 1
+}
 POLICY="${2:-ves-io-allow-volterra}"
 NAMESPACE="${3:-shared}"
 

--- a/scripts/swagger-upload.sh
+++ b/scripts/swagger-upload.sh
@@ -66,14 +66,12 @@ ns, name, listing = sys.argv[1], sys.argv[2], sys.argv[3]
 with open(listing, "r", encoding="utf-8") as fh:
     data = json.load(fh)
 want = f"{ns}/{name}"
-for item in data.get("items", []):
-    if item.get("name") != want:
-        continue
-    versions = item.get("versions", [])
-    latest = next((v for v in versions if v.get("latest_version")), versions[-1] if versions else None)
-    if latest:
-        print(f"/api/object_store/namespaces/{ns}/stored_objects/swagger/{name}/{latest['version']}")
-        break
-else:
-    sys.exit("uploaded object not found in listing")
+item = next((i for i in data.get("items", []) if i.get("name") == want), None)
+if item is None:
+    sys.exit(f"uploaded object {want} not found in listing")
+versions = item.get("versions", [])
+latest = next((v for v in versions if v.get("latest_version")), versions[-1] if versions else None)
+if latest is None:
+    sys.exit(f"uploaded object {want} has no version in listing")
+print(f"/api/object_store/namespaces/{ns}/stored_objects/swagger/{name}/{latest['version']}")
 PY

--- a/scripts/swagger-upload.sh
+++ b/scripts/swagger-upload.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Upload an OpenAPI/Swagger file to the F5 XC object store ONCE and print the
+# resulting object-store path to pin into api_definition_swagger_specs.
+#
+# xcsh_api_definition.swagger_specs are NOT inline bodies — they are object-store
+# paths of uploaded files (server rule:
+# /api/object_store/namespaces/<ns>/stored_objects/swagger/<name>/<version>).
+# The store is content-addressed: re-uploading identical content returns the same
+# server-assigned, date-stamped version, so this helper is idempotent; changing the
+# content mints a new version. Because the version token is only known after upload
+# (and embeds the upload date), seal ONCE and pin the printed path — the same
+# discipline as scripts/blindfold-seal.sh. Never regenerate the path inline.
+#
+# Usage: swagger-upload.sh <name> <openapi-file> [namespace]
+#   Requires XCSH_API_URL + XCSH_API_TOKEN in the environment.
+#   <name> is the stored-object name (DNS-ish, e.g. vampi). <openapi-file> is a
+#   local JSON/YAML OpenAPI document. namespace defaults to webapp-api-protection.
+set -euo pipefail
+
+NAME="${1:?usage: swagger-upload.sh <name> <openapi-file> [namespace]}"
+FILE="${2:?usage: swagger-upload.sh <name> <openapi-file> [namespace]}"
+NS="${3:-webapp-api-protection}"
+: "${XCSH_API_URL:?XCSH_API_URL must be set}"
+: "${XCSH_API_TOKEN:?XCSH_API_TOKEN must be set}"
+
+[ -r "$FILE" ] || {
+  echo "cannot read $FILE" >&2
+  exit 1
+}
+case "$FILE" in
+*.yaml | *.yml) FMT="yaml" ;;
+*) FMT="json" ;;
+esac
+
+H="Authorization: APIToken $XCSH_API_TOKEN"
+umask 077
+BODY=$(mktemp)
+LISTING=$(mktemp)
+trap 'rm -f "$BODY" "$LISTING"' EXIT
+
+# Build the PUT body: string_value carries the file text (JSON-encoded).
+python3 - "$NS" "$NAME" "$FMT" "$FILE" >"$BODY" <<'PY'
+import json, sys
+ns, name, fmt, path = sys.argv[1:5]
+with open(path, "r", encoding="utf-8") as fh:
+    contents = fh.read()
+print(json.dumps({
+    "namespace": ns, "object_type": "swagger", "name": name,
+    "string_value": contents, "content_format": fmt,
+}))
+PY
+
+code=$(curl -s -o /dev/null -w '%{http_code}' -X PUT -H "$H" -H "Content-Type: application/json" \
+  --data @"$BODY" "$XCSH_API_URL/api/object_store/namespaces/$NS/stored_objects/swagger/$NAME")
+[ "$code" = "200" ] || {
+  echo "upload failed (HTTP $code)" >&2
+  exit 1
+}
+
+# Read back the latest version and print the pinned object-store PATH (not the URL).
+# The listing goes to a file so the heredoc-fed python does not clash with a pipe.
+curl -s -H "$H" "$XCSH_API_URL/api/object_store/namespaces/$NS/stored_objects/swagger" >"$LISTING"
+python3 - "$NS" "$NAME" "$LISTING" <<'PY'
+import json, sys
+ns, name, listing = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(listing, "r", encoding="utf-8") as fh:
+    data = json.load(fh)
+want = f"{ns}/{name}"
+for item in data.get("items", []):
+    if item.get("name") != want:
+        continue
+    versions = item.get("versions", [])
+    latest = next((v for v in versions if v.get("latest_version")), versions[-1] if versions else None)
+    if latest:
+        print(f"/api/object_store/namespaces/{ns}/stored_objects/swagger/{name}/{latest['version']}")
+        break
+else:
+    sys.exit("uploaded object not found in listing")
+PY

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -103,6 +103,11 @@ module "http_lb" {
   api_crawler_domains               = var.api_crawler_domains
   api_crawler_password              = var.api_crawler_password
 
+  # API spec source-control integration (SP2) passthrough. Default disabled (0-change).
+  code_base_integration_enabled      = var.code_base_integration_enabled
+  code_base_integration_username     = var.code_base_integration_username
+  code_base_integration_access_token = var.code_base_integration_access_token
+
   # Enabling client_side_defense on the LB requires a protected domain to already
   # exist in this namespace (F5 XC generates the CSD JS config from it), so the
   # LB must be created/updated AFTER the protected domain. The MUD entitlement

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -107,6 +107,17 @@ module "http_lb" {
   code_base_integration_enabled      = var.code_base_integration_enabled
   code_base_integration_username     = var.code_base_integration_username
   code_base_integration_access_token = var.code_base_integration_access_token
+  api_discovery_code_scan            = var.api_discovery_code_scan
+  api_discovery_code_scan_repos      = var.api_discovery_code_scan_repos
+
+  # API Definition & spec enforcement (SP2) passthrough. Default disable (0-change).
+  api_definition_choice              = var.api_definition_choice
+  api_definition_swagger_specs       = var.api_definition_swagger_specs
+  api_definition_inventory_inclusion = var.api_definition_inventory_inclusion
+  api_definition_inventory_exclusion = var.api_definition_inventory_exclusion
+  api_definition_non_api_endpoints   = var.api_definition_non_api_endpoints
+  api_definition_schema_origin       = var.api_definition_schema_origin
+  api_specification_validation       = var.api_specification_validation
 
   # Enabling client_side_defense on the LB requires a protected domain to already
   # exist in this namespace (F5 XC generates the CSD JS config from it), so the

--- a/terraform/modules/http-lb/api_definition.tf
+++ b/terraform/modules/http-lb/api_definition.tf
@@ -1,0 +1,50 @@
+# xcsh_api_definition (SP2) — the API spec object the LB's api_specification
+# references for schema enforcement. Created only when api_definition_choice is
+# "specification"; otherwise the LB emits no api_specification block (server
+# default disable_api_definition, import-suppressed) and this resource is absent.
+#
+# The API can be defined from uploaded OpenAPI files (swagger_specs = pinned
+# object-store paths; see scripts/swagger-upload.sh) and/or from inventory lists.
+# schema-origin is a oneof: strict is the server default (import-suppressed, so we
+# omit it) and mixed is emitted explicitly.
+resource "xcsh_api_definition" "this" {
+  count     = var.api_definition_choice == "specification" ? 1 : 0
+  name      = "${var.namespace}-api-def"
+  namespace = var.namespace
+
+  # swagger_specs is an attribute (not a block): set it only when non-empty so the
+  # empty-list default stays identical to the server default (no import drift).
+  swagger_specs = length(var.api_definition_swagger_specs) > 0 ? var.api_definition_swagger_specs : null
+
+  dynamic "api_inventory_inclusion_list" {
+    for_each = var.api_definition_inventory_inclusion
+    content {
+      method = api_inventory_inclusion_list.value.method
+      path   = api_inventory_inclusion_list.value.path
+    }
+  }
+
+  dynamic "api_inventory_exclusion_list" {
+    for_each = var.api_definition_inventory_exclusion
+    content {
+      method = api_inventory_exclusion_list.value.method
+      path   = api_inventory_exclusion_list.value.path
+    }
+  }
+
+  dynamic "non_api_endpoints" {
+    for_each = var.api_definition_non_api_endpoints
+    content {
+      method = non_api_endpoints.value.method
+      path   = non_api_endpoints.value.path
+    }
+  }
+
+  # schema-origin oneof. mixed => emit the block; strict => omit (server default,
+  # suppressed on import — see terraform-provider-xcsh
+  # tools/import-default-suppressions.json APIDefinition).
+  dynamic "mixed_schema_origin" {
+    for_each = var.api_definition_schema_origin == "mixed" ? [1] : []
+    content {}
+  }
+}

--- a/terraform/modules/http-lb/locals_api.tf
+++ b/terraform/modules/http-lb/locals_api.tf
@@ -1,17 +1,31 @@
-# Renderer for the reusable clear/blindfold SecretType convention. use_blindfold
-# selects the SecretType arm; `location` is the pre-sealed offline blob (blindfold
-# arm), `url` is the base64 clear value (clear arm). Exactly one is non-null.
+# Reusable clear/blindfold SecretType renderer (DRY). Every secret-bearing option
+# registers its input (same object shape: {method, plaintext, location}) in
+# _secret_inputs and reads local.rendered_secret[<key>] -> {use_blindfold, url,
+# location}. ONE transform serves all secrets (crawler password, SCM access_token,
+# future TLS/origin secrets) instead of a per-field copy.
 #
+# use_blindfold selects the SecretType arm; `location` is the PRE-SEALED offline blob
+# (blindfold arm), `url` is the base64 clear value (clear arm). Exactly one is non-null.
 # The blindfold location is pinned (sealed once via scripts/blindfold-seal.sh), NOT
 # computed here: provider::xcsh::blindfold uses a random data key, so an inline call
-# would produce a new ciphertext every plan and drift. Pinning the sealed value is
-# the F5-documented offline-blindfold pattern and keeps apply idempotent + import-clean.
+# would produce a new ciphertext every plan and drift. Pinning is the F5-documented
+# offline-blindfold pattern and keeps apply idempotent + import-clean.
 locals {
-  api_crawler_password_secret = {
-    use_blindfold = var.api_crawler_password.method == "blindfold"
-    url = (var.api_crawler_password.method == "clear" && var.api_crawler_password.plaintext != null
-      ? "string:///${base64encode(var.api_crawler_password.plaintext)}"
-    : null)
-    location = var.api_crawler_password.method == "blindfold" ? var.api_crawler_password.location : null
+  _secret_inputs = {
+    api_crawler_password        = var.api_crawler_password
+    code_base_integration_token = var.code_base_integration_access_token
   }
+
+  rendered_secret = {
+    for k, s in local._secret_inputs : k => {
+      use_blindfold = s.method == "blindfold"
+      url = (s.method == "clear" && s.plaintext != null
+        ? "string:///${base64encode(s.plaintext)}"
+      : null)
+      location = s.method == "blindfold" ? s.location : null
+    }
+  }
+
+  # Named alias for the SP1 crawler consumer (keeps main.tf references stable).
+  api_crawler_password_secret = local.rendered_secret["api_crawler_password"]
 }

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -518,6 +518,34 @@ resource "xcsh_http_loadbalancer" "this" {
           }
         }
       }
+
+      # API discovery from source-code scan (SP2). Select the code_base_integration
+      # created in scm.tf and the repositories to scan. Off by default (emit no
+      # block). The code_base_integration object-ref keeps its Computed tenant
+      # across apply via provider #1091 (>= 3.71.2), same class as api_discovery_ref.
+      dynamic "api_discovery_from_code_scan" {
+        for_each = var.api_discovery_code_scan != "off" ? [1] : []
+        content {
+          code_base_integrations {
+            code_base_integration {
+              name      = xcsh_code_base_integration.github[0].name
+              namespace = var.namespace
+            }
+
+            # repo-selection oneof: all_repos vs selected_repos.
+            dynamic "all_repos" {
+              for_each = var.api_discovery_code_scan == "all" ? [1] : []
+              content {}
+            }
+            dynamic "selected_repos" {
+              for_each = var.api_discovery_code_scan == "selected" ? [1] : []
+              content {
+                api_code_repo = var.api_discovery_code_scan_repos
+              }
+            }
+          }
+        }
+      }
     }
   }
 
@@ -525,6 +553,43 @@ resource "xcsh_http_loadbalancer" "this" {
   dynamic "disable_api_discovery" {
     for_each = var.api_discovery_choice == "disable" ? [1] : []
     content {}
+  }
+
+  # API schema enforcement (api_definition_choice oneof: api_specification vs the
+  # server default disable_api_definition). Default omits the block entirely, so the
+  # server applies disable_api_definition, which the provider suppresses on import
+  # (0-change; do not declare it). "specification" references the xcsh_api_definition
+  # created in api_definition.tf; the api_definition object-ref keeps its Computed
+  # tenant across apply via provider #1091 (>= 3.71.2), the same class as the SP1
+  # api_discovery_ref. validation_target_choice picks how strictly to validate:
+  # validation_disabled (define but do not enforce) or validation_all_spec_endpoints
+  # (enforce every endpoint, fall-through allow). The per-endpoint custom-rule arm
+  # (validation_custom_list) is API-protection rule authoring, deferred to SP3.
+  dynamic "api_specification" {
+    for_each = var.api_definition_choice == "specification" ? [1] : []
+    content {
+      api_definition {
+        name      = xcsh_api_definition.this[0].name
+        namespace = var.namespace
+      }
+
+      dynamic "validation_disabled" {
+        for_each = var.api_specification_validation == "disabled" ? [1] : []
+        content {}
+      }
+
+      dynamic "validation_all_spec_endpoints" {
+        for_each = var.api_specification_validation == "all_spec_endpoints" ? [1] : []
+        content {
+          fall_through_mode {
+            fall_through_mode_allow {}
+          }
+          validation_mode {
+            skip_validation {}
+          }
+        }
+      }
+    }
   }
 
   # Client-Side Defense — inject the F5 XC telemetry JavaScript into served pages
@@ -595,6 +660,22 @@ resource "xcsh_http_loadbalancer" "this" {
     precondition {
       condition     = length(var.api_crawler_domains) == 0 || local.api_crawler_password_secret.url != null || local.api_crawler_password_secret.location != null
       error_message = "api_crawler_domains is set but api_crawler_password has no value: set plaintext (clear) or location (blindfold)."
+    }
+
+    # Code-scan discovery lives inside enable_api_discovery and references the
+    # code_base_integration, so it requires discovery enabled AND the integration
+    # created — cross-variable checks the per-variable validation cannot express.
+    precondition {
+      condition     = var.api_discovery_code_scan == "off" || var.api_discovery_choice == "enable"
+      error_message = "api_discovery_code_scan requires api_discovery_choice=\"enable\" (code scan is part of enable_api_discovery)."
+    }
+    precondition {
+      condition     = var.api_discovery_code_scan == "off" || var.code_base_integration_enabled
+      error_message = "api_discovery_code_scan requires code_base_integration_enabled=true (it references the code_base_integration)."
+    }
+    precondition {
+      condition     = var.api_discovery_code_scan != "selected" || length(var.api_discovery_code_scan_repos) > 0
+      error_message = "api_discovery_code_scan=\"selected\" requires api_discovery_code_scan_repos to be non-empty."
     }
   }
 }

--- a/terraform/modules/http-lb/outputs_api_definition.tf
+++ b/terraform/modules/http-lb/outputs_api_definition.tf
@@ -1,0 +1,37 @@
+# API Definition & spec enforcement (SP2) outputs — effective arm echoes for
+# plan-level tests and downstream visibility (same convention as outputs_api.tf).
+
+output "api_definition_choice" {
+  description = "Effective api_definition_choice arm (disable or specification)."
+  value       = var.api_definition_choice
+}
+
+output "api_definition_created" {
+  description = "Whether an xcsh_api_definition is created (true when api_definition_choice=specification)."
+  value       = var.api_definition_choice == "specification"
+}
+
+output "api_definition_swagger_spec_count" {
+  description = "Number of pinned OpenAPI object-store paths on the api_definition."
+  value       = length(var.api_definition_swagger_specs)
+}
+
+output "api_definition_schema_origin" {
+  description = "Effective api_definition schema origin (strict or mixed)."
+  value       = var.api_definition_schema_origin
+}
+
+output "api_specification_validation" {
+  description = "Effective api_specification validation_target_choice arm (disabled or all_spec_endpoints)."
+  value       = var.api_specification_validation
+}
+
+output "api_discovery_code_scan" {
+  description = "Effective api_discovery_from_code_scan arm (off, selected, or all)."
+  value       = var.api_discovery_code_scan
+}
+
+output "api_discovery_code_scan_repo_count" {
+  description = "Number of repositories selected for code-scan discovery (0 unless code scan is 'selected')."
+  value       = var.api_discovery_code_scan == "selected" ? length(var.api_discovery_code_scan_repos) : 0
+}

--- a/terraform/modules/http-lb/scm.tf
+++ b/terraform/modules/http-lb/scm.tf
@@ -1,0 +1,49 @@
+# xcsh_code_base_integration (github) — holds the SCM credentials F5 XC uses to pull
+# API specs from source control. Repo selection happens at the LB via
+# enable_api_discovery.api_discovery_from_code_scan (that LB wiring lands once provider
+# #1091 — object-ref tenant — is released, same class as the SP1 api_discovery_ref).
+# access_token uses the reusable clear/blindfold convention (local.rendered_secret),
+# the identical SecretType shape as the crawler password.
+resource "xcsh_code_base_integration" "github" {
+  count     = var.code_base_integration_enabled ? 1 : 0
+  name      = "${var.namespace}-api-catalog"
+  namespace = var.namespace
+
+  code_base_integration {
+    github {
+      username = var.code_base_integration_username
+      access_token {
+        dynamic "blindfold_secret_info" {
+          for_each = local.rendered_secret["code_base_integration_token"].use_blindfold ? [1] : []
+          content {
+            location = local.rendered_secret["code_base_integration_token"].location
+          }
+        }
+        dynamic "clear_secret_info" {
+          for_each = local.rendered_secret["code_base_integration_token"].use_blindfold ? [] : [1]
+          content {
+            url = local.rendered_secret["code_base_integration_token"].url
+          }
+        }
+      }
+    }
+  }
+
+  # Fail fast at plan if enabled without a usable token value.
+  lifecycle {
+    precondition {
+      condition     = local.rendered_secret["code_base_integration_token"].url != null || local.rendered_secret["code_base_integration_token"].location != null
+      error_message = "code_base_integration_enabled requires code_base_integration_access_token: set plaintext (clear) or location (blindfold)."
+    }
+  }
+}
+
+output "code_base_integration_enabled" {
+  description = "Whether an xcsh_code_base_integration (github) is created."
+  value       = var.code_base_integration_enabled
+}
+
+output "code_base_integration_token_method" {
+  description = "Effective code_base_integration access_token secret method (clear or blindfold)."
+  value       = nonsensitive(var.code_base_integration_access_token.method)
+}

--- a/terraform/modules/http-lb/variables_api_definition.tf
+++ b/terraform/modules/http-lb/variables_api_definition.tf
@@ -1,0 +1,127 @@
+# ---------------------------------------------------------------------------
+# API Definition & spec enforcement (SP2) — inputs.
+#
+# Two spec-management surfaces:
+#   1. xcsh_api_definition  — the API spec object (uploaded OpenAPI files +
+#      inventory lists + schema origin).
+#   2. LB api_definition_choice.api_specification — reference that definition and
+#      choose how strictly to validate live traffic against it.
+#
+# Defaults keep the LB's api_definition_choice at the server default
+# disable_api_definition (import-suppressed) => 0-change. The api-definition matrix
+# cycles the non-default arms. See docs/superpowers/plans/sp2-findings.md.
+# ---------------------------------------------------------------------------
+
+# api_definition_choice oneof: api_specification vs disable_api_definition.
+# "disable" (default) omits the block entirely => server default
+# disable_api_definition (suppressed on import) => no drift. "specification"
+# creates xcsh_api_definition and references it from the LB's api_specification.
+variable "api_definition_choice" {
+  description = "api_definition_choice: disable (no schema enforcement) or specification (enforce against an xcsh_api_definition)."
+  type        = string
+  default     = "disable"
+
+  validation {
+    condition     = contains(["disable", "specification"], var.api_definition_choice)
+    error_message = "api_definition_choice must be \"disable\" or \"specification\"."
+  }
+}
+
+# swagger_specs on xcsh_api_definition are OBJECT-STORE PATHS of uploaded OpenAPI
+# files, NOT inline bodies (server validation rule requires
+# /api/object_store/namespaces/{ns}/stored_objects/swagger/{name}/{version}).
+# Upload once with scripts/swagger-upload.sh (content-addressed, idempotent) and
+# pin the returned path here — the same seal-once-pin discipline as blindfold.
+variable "api_definition_swagger_specs" {
+  description = "Pinned object-store paths of uploaded OpenAPI files (from scripts/swagger-upload.sh). Empty = define the API from discovered inventory only."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for s in var.api_definition_swagger_specs :
+      can(regex("^/api/object_store/namespaces/[a-z]([-a-z0-9]*[a-z0-9])?/stored_objects/swagger/", s))
+    ])
+    error_message = "each swagger_specs entry must be an object-store path: /api/object_store/namespaces/<ns>/stored_objects/swagger/<name>/<version> (upload via scripts/swagger-upload.sh)."
+  }
+}
+
+# Inventory inclusion/exclusion + non-API endpoints. Each is a list of
+# {method, path}; method is the F5 XC HTTP-method enum (default ANY).
+variable "api_definition_inventory_inclusion" {
+  description = "api_inventory_inclusion_list: endpoints to force INTO the API inventory ({method, path})."
+  type = list(object({
+    method = optional(string, "ANY")
+    path   = string
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for e in var.api_definition_inventory_inclusion :
+      contains(["ANY", "GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH", "COPY"], e.method)
+    ])
+    error_message = "each inventory inclusion method must be a valid HTTP method (ANY|GET|HEAD|POST|PUT|DELETE|CONNECT|OPTIONS|TRACE|PATCH|COPY)."
+  }
+}
+
+variable "api_definition_inventory_exclusion" {
+  description = "api_inventory_exclusion_list: endpoints to force OUT of the API inventory ({method, path})."
+  type = list(object({
+    method = optional(string, "ANY")
+    path   = string
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for e in var.api_definition_inventory_exclusion :
+      contains(["ANY", "GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH", "COPY"], e.method)
+    ])
+    error_message = "each inventory exclusion method must be a valid HTTP method (ANY|GET|HEAD|POST|PUT|DELETE|CONNECT|OPTIONS|TRACE|PATCH|COPY)."
+  }
+}
+
+variable "api_definition_non_api_endpoints" {
+  description = "non_api_endpoints: endpoints to mark as NON-API ({method, path})."
+  type = list(object({
+    method = optional(string, "ANY")
+    path   = string
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for e in var.api_definition_non_api_endpoints :
+      contains(["ANY", "GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH", "COPY"], e.method)
+    ])
+    error_message = "each non_api_endpoints method must be a valid HTTP method (ANY|GET|HEAD|POST|PUT|DELETE|CONNECT|OPTIONS|TRACE|PATCH|COPY)."
+  }
+}
+
+# schema-origin oneof: strict (server default, import-suppressed => omit) vs mixed.
+variable "api_definition_schema_origin" {
+  description = "api_definition schema origin: strict (server default, suppressed) or mixed."
+  type        = string
+  default     = "strict"
+
+  validation {
+    condition     = contains(["strict", "mixed"], var.api_definition_schema_origin)
+    error_message = "api_definition_schema_origin must be \"strict\" or \"mixed\"."
+  }
+}
+
+# validation_target_choice arm for LB api_specification. "disabled" (default)
+# defines the spec without enforcing it; "all_spec_endpoints" validates all
+# endpoints (fall-through allow). The per-endpoint custom-rule arm
+# (validation_custom_list) is API-protection rule authoring — deferred to SP3.
+variable "api_specification_validation" {
+  description = "api_specification validation_target_choice: disabled or all_spec_endpoints. (custom_list = SP3 protection rules.)"
+  type        = string
+  default     = "disabled"
+
+  validation {
+    condition     = contains(["disabled", "all_spec_endpoints"], var.api_specification_validation)
+    error_message = "api_specification_validation must be \"disabled\" or \"all_spec_endpoints\" (custom_list is deferred to SP3)."
+  }
+}

--- a/terraform/modules/http-lb/variables_scm.tf
+++ b/terraform/modules/http-lb/variables_scm.tf
@@ -1,0 +1,38 @@
+# API spec source-control integration (SP2): xcsh_code_base_integration (github arm).
+# F5 XC pulls OpenAPI specs from the repo; the LB selects repos via
+# api_discovery_from_code_scan (LB wiring lands with provider #1091). access_token
+# reuses the clear/blindfold SecretType convention (locals_api.tf rendered_secret) —
+# the identical SecretType shape as the crawler password (DRY, second consumer).
+
+variable "code_base_integration_enabled" {
+  description = "Create an xcsh_code_base_integration (github) F5 XC uses to pull API specs from source control (e.g. the api-catalog repo)."
+  type        = bool
+  default     = false
+}
+
+variable "code_base_integration_username" {
+  description = "GitHub username for the code_base_integration (github arm)."
+  type        = string
+  default     = ""
+}
+
+variable "code_base_integration_access_token" {
+  description = "GitHub access token as a selectable clear/blindfold secret. clear: set plaintext. blindfold: set location to a pre-sealed 'string:///...' from scripts/blindfold-seal.sh."
+  type = object({
+    method    = optional(string, "clear")
+    plaintext = optional(string)
+    location  = optional(string)
+  })
+  default   = { method = "clear", plaintext = null }
+  sensitive = true
+
+  validation {
+    condition     = contains(["clear", "blindfold"], var.code_base_integration_access_token.method)
+    error_message = "code_base_integration_access_token.method must be \"clear\" or \"blindfold\"."
+  }
+
+  validation {
+    condition     = var.code_base_integration_access_token.method != "blindfold" || var.code_base_integration_access_token.location != null
+    error_message = "blindfold method requires a pre-sealed location (run scripts/blindfold-seal.sh)."
+  }
+}

--- a/terraform/modules/http-lb/variables_scm.tf
+++ b/terraform/modules/http-lb/variables_scm.tf
@@ -36,3 +36,24 @@ variable "code_base_integration_access_token" {
     error_message = "blindfold method requires a pre-sealed location (run scripts/blindfold-seal.sh)."
   }
 }
+
+# API discovery from source-code scan (SP2): wire enable_api_discovery.
+# api_discovery_from_code_scan.code_base_integrations[] to the code_base_integration.
+# "off" (default) emits no block (0-change). "selected" scans the repos in
+# api_discovery_code_scan_repos; "all" scans every repo the integration can see.
+variable "api_discovery_code_scan" {
+  description = "API discovery from code scan: off, selected (scan api_discovery_code_scan_repos), or all (all repos)."
+  type        = string
+  default     = "off"
+
+  validation {
+    condition     = contains(["off", "selected", "all"], var.api_discovery_code_scan)
+    error_message = "api_discovery_code_scan must be \"off\", \"selected\", or \"all\"."
+  }
+}
+
+variable "api_discovery_code_scan_repos" {
+  description = "Repositories to scan when api_discovery_code_scan=selected (e.g. [\"api-catalog\"])."
+  type        = list(string)
+  default     = []
+}

--- a/terraform/tests/api_definition.tftest.hcl
+++ b/terraform/tests/api_definition.tftest.hcl
@@ -1,0 +1,153 @@
+# Plan-level tests for API Definition & spec enforcement (SP2): the
+# api_definition_choice / api_specification oneof, xcsh_api_definition, and the
+# api_discovery_from_code_scan wiring. Targets ./modules/http-lb, dummy origin.
+variables {
+  namespace         = "webapp-api-protection"
+  lb_domains        = ["www.f5-sales-demo.com"]
+  origin_ip         = "203.0.113.10"
+  origin_port       = 80
+  health_check_path = "/health"
+  labels            = {}
+  csd_enabled       = false
+  mud_enabled       = false
+}
+
+run "api_definition_disabled_default" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  assert {
+    condition     = output.api_definition_choice == "disable" && output.api_definition_created == false
+    error_message = "api_definition must default to disable with no definition created (0-change)"
+  }
+  assert {
+    condition     = output.api_discovery_code_scan == "off"
+    error_message = "code scan must default to off"
+  }
+}
+
+run "api_specification_validation_disabled" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_definition_choice              = "specification"
+    api_specification_validation       = "disabled"
+    api_definition_inventory_inclusion = [{ method = "GET", path = "/health" }]
+  }
+  assert {
+    condition     = output.api_definition_created == true && output.api_specification_validation == "disabled"
+    error_message = "specification + validation_disabled must render an api_definition"
+  }
+}
+
+run "api_specification_validation_all_spec_endpoints" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_definition_choice        = "specification"
+    api_specification_validation = "all_spec_endpoints"
+  }
+  assert {
+    condition     = output.api_specification_validation == "all_spec_endpoints"
+    error_message = "all_spec_endpoints validation arm must render"
+  }
+}
+
+run "api_definition_schema_origin_mixed" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_definition_choice        = "specification"
+    api_definition_schema_origin = "mixed"
+  }
+  assert {
+    condition     = output.api_definition_schema_origin == "mixed"
+    error_message = "mixed schema origin must render"
+  }
+}
+
+run "api_definition_swagger_specs_pinned_path" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_definition_choice = "specification"
+    api_definition_swagger_specs = [
+      "/api/object_store/namespaces/webapp-api-protection/stored_objects/swagger/vampi/v1-26-07-14"
+    ]
+  }
+  assert {
+    condition     = output.api_definition_swagger_spec_count == 1
+    error_message = "a pinned object-store swagger path must be accepted"
+  }
+}
+
+run "api_definition_swagger_specs_rejects_inline_body" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_definition_choice        = "specification"
+    api_definition_swagger_specs = ["{\"openapi\":\"3.0.0\"}"]
+  }
+  expect_failures = [var.api_definition_swagger_specs]
+}
+
+run "api_definition_inventory_rejects_bad_method" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_definition_choice              = "specification"
+    api_definition_inventory_inclusion = [{ method = "FETCH", path = "/x" }]
+  }
+  expect_failures = [var.api_definition_inventory_inclusion]
+}
+
+run "code_scan_selected_to_api_catalog" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    code_base_integration_enabled      = true
+    code_base_integration_username     = "f5-sales-demo-bot"
+    code_base_integration_access_token = { method = "clear", plaintext = "ghp_example_token" }
+    api_discovery_code_scan            = "selected"
+    api_discovery_code_scan_repos      = ["api-catalog"]
+  }
+  assert {
+    condition     = output.api_discovery_code_scan == "selected" && output.api_discovery_code_scan_repo_count == 1
+    error_message = "selected code scan over api-catalog must render"
+  }
+}
+
+run "code_scan_requires_integration" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_discovery_code_scan       = "selected"
+    api_discovery_code_scan_repos = ["api-catalog"]
+  }
+  expect_failures = [xcsh_http_loadbalancer.this]
+}
+
+run "code_scan_selected_requires_repos" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    code_base_integration_enabled      = true
+    code_base_integration_username     = "f5-sales-demo-bot"
+    code_base_integration_access_token = { method = "clear", plaintext = "ghp_example_token" }
+    api_discovery_code_scan            = "selected"
+    api_discovery_code_scan_repos      = []
+  }
+  expect_failures = [xcsh_http_loadbalancer.this]
+}
+
+run "code_scan_requires_discovery_enabled" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    code_base_integration_enabled      = true
+    code_base_integration_username     = "f5-sales-demo-bot"
+    code_base_integration_access_token = { method = "clear", plaintext = "ghp_example_token" }
+    api_discovery_choice               = "disable"
+    api_discovery_code_scan            = "all"
+  }
+  expect_failures = [xcsh_http_loadbalancer.this]
+}

--- a/terraform/tests/api_definition.tftest.hcl
+++ b/terraform/tests/api_definition.tftest.hcl
@@ -116,6 +116,21 @@ run "code_scan_selected_to_api_catalog" {
   }
 }
 
+run "code_scan_all_repos" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    code_base_integration_enabled      = true
+    code_base_integration_username     = "f5-sales-demo-bot"
+    code_base_integration_access_token = { method = "clear", plaintext = "ghp_example_token" }
+    api_discovery_code_scan            = "all"
+  }
+  assert {
+    condition     = output.api_discovery_code_scan == "all" && output.api_discovery_code_scan_repo_count == 0
+    error_message = "all_repos code scan must render (repo_count 0 since no explicit repo list)"
+  }
+}
+
 run "code_scan_requires_integration" {
   command = plan
   module { source = "./modules/http-lb" }

--- a/terraform/tests/api_scm.tftest.hcl
+++ b/terraform/tests/api_scm.tftest.hcl
@@ -1,0 +1,60 @@
+# Plan-level tests for the SCM code_base_integration (github) — access_token via the
+# reusable clear/blindfold SecretType convention. Targets ./modules/http-lb, dummy origin.
+variables {
+  namespace         = "webapp-api-protection"
+  lb_domains        = ["www.f5-sales-demo.com"]
+  origin_ip         = "203.0.113.10"
+  origin_port       = 80
+  health_check_path = "/health"
+  labels            = {}
+  csd_enabled       = false
+  mud_enabled       = false
+}
+
+run "scm_disabled_default" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  assert {
+    condition     = output.code_base_integration_enabled == false
+    error_message = "code_base_integration must be disabled by default (0-change)"
+  }
+}
+
+run "scm_github_clear_token" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    code_base_integration_enabled      = true
+    code_base_integration_username     = "f5-sales-demo-bot"
+    code_base_integration_access_token = { method = "clear", plaintext = "ghp_example_token" }
+  }
+  assert {
+    condition     = output.code_base_integration_token_method == "clear"
+    error_message = "clear access_token arm must render"
+  }
+}
+
+run "scm_github_blindfold_token" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    code_base_integration_enabled      = true
+    code_base_integration_username     = "f5-sales-demo-bot"
+    code_base_integration_access_token = { method = "blindfold", location = "string:///eyJrZXlfdmVyc2lvbiI6MX0=" }
+  }
+  assert {
+    condition     = output.code_base_integration_token_method == "blindfold"
+    error_message = "blindfold access_token arm must render"
+  }
+}
+
+run "scm_enabled_without_token_fails" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    code_base_integration_enabled      = true
+    code_base_integration_username     = "f5-sales-demo-bot"
+    code_base_integration_access_token = { method = "clear", plaintext = null }
+  }
+  expect_failures = [xcsh_code_base_integration.github]
+}

--- a/terraform/variables_api_definition.tf
+++ b/terraform/variables_api_definition.tf
@@ -1,0 +1,55 @@
+# Root-level API Definition & spec-enforcement (SP2) inputs, passed through to
+# modules/http-lb. Defaults keep api_definition_choice at the server default
+# disable_api_definition (0-change). The api-definition matrix supplies these via
+# -var-file per variant. Validation lives in the module.
+
+variable "api_definition_choice" {
+  description = "api_definition_choice: disable or specification."
+  type        = string
+  default     = "disable"
+}
+
+variable "api_definition_swagger_specs" {
+  description = "Pinned object-store paths of uploaded OpenAPI files (scripts/swagger-upload.sh)."
+  type        = list(string)
+  default     = []
+}
+
+variable "api_definition_inventory_inclusion" {
+  description = "api_inventory_inclusion_list entries ({method, path})."
+  type = list(object({
+    method = optional(string, "ANY")
+    path   = string
+  }))
+  default = []
+}
+
+variable "api_definition_inventory_exclusion" {
+  description = "api_inventory_exclusion_list entries ({method, path})."
+  type = list(object({
+    method = optional(string, "ANY")
+    path   = string
+  }))
+  default = []
+}
+
+variable "api_definition_non_api_endpoints" {
+  description = "non_api_endpoints entries ({method, path})."
+  type = list(object({
+    method = optional(string, "ANY")
+    path   = string
+  }))
+  default = []
+}
+
+variable "api_definition_schema_origin" {
+  description = "api_definition schema origin: strict or mixed."
+  type        = string
+  default     = "strict"
+}
+
+variable "api_specification_validation" {
+  description = "api_specification validation_target_choice: disabled or all_spec_endpoints."
+  type        = string
+  default     = "disabled"
+}

--- a/terraform/variables_scm.tf
+++ b/terraform/variables_scm.tf
@@ -1,0 +1,25 @@
+# Root-level SCM (code_base_integration) inputs for SP2, passed to modules/http-lb.
+# Defaults keep it disabled (0-change). Matrix supplies these via -var-file.
+
+variable "code_base_integration_enabled" {
+  description = "Create an xcsh_code_base_integration (github) to pull API specs from source control (api-catalog)."
+  type        = bool
+  default     = false
+}
+
+variable "code_base_integration_username" {
+  description = "GitHub username for the code_base_integration."
+  type        = string
+  default     = ""
+}
+
+variable "code_base_integration_access_token" {
+  description = "GitHub access token as a selectable clear/blindfold secret (clear: plaintext; blindfold: pre-sealed location)."
+  type = object({
+    method    = optional(string, "clear")
+    plaintext = optional(string)
+    location  = optional(string)
+  })
+  default   = { method = "clear", plaintext = null }
+  sensitive = true
+}

--- a/terraform/variables_scm.tf
+++ b/terraform/variables_scm.tf
@@ -23,3 +23,15 @@ variable "code_base_integration_access_token" {
   default   = { method = "clear", plaintext = null }
   sensitive = true
 }
+
+variable "api_discovery_code_scan" {
+  description = "API discovery from code scan: off, selected, or all."
+  type        = string
+  default     = "off"
+}
+
+variable "api_discovery_code_scan_repos" {
+  description = "Repositories to scan when api_discovery_code_scan=selected (e.g. [\"api-catalog\"])."
+  type        = list(string)
+  default     = []
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -6,12 +6,14 @@ terraform {
   required_providers {
     xcsh = {
       source = "f5-sales-demo/xcsh"
-      # >= 3.71.1: carries the nested-list value-conversion fix (#1083) — nested
-      # ListNestedBlocks (e.g. the inline api_crawler domains) are modeled as
-      # types.List so they hold plan-time unknowns; without it the API crawler
-      # block fails with a Value Conversion Error. (Supersedes the >= 3.64.0
-      # nested Optional+Computed scalar fix.) Locally consumed via dev_overrides.
-      version = ">= 3.71.1"
+      # >= 3.71.2: carries the object-ref tenant reconstruction fix (#1091, PR
+      # #1092) — object-refs at any nesting depth (LB api_specification.
+      # api_definition, enable_api_discovery...code_base_integrations[], and the
+      # standalone code_base_integration/api_definition refs) keep their Computed
+      # `tenant` from surviving apply, so SP2's LB wiring plans clean. Builds on
+      # 3.71.1's nested-list value-conversion fix (#1083) for the inline
+      # api_crawler domains. Locally consumed via dev_overrides.
+      version = ">= 3.71.2"
     }
     # Azure providers: this plan also deploys its OWN Azure origin server and
     # traffic generator (modules/origin-server, modules/traffic-generator), which


### PR DESCRIPTION
## Summary

SP2 of the API Discovery & Protection effort: **API Definition & spec management**.
Adds every Terraform-native way to supply/manage an F5 XC API specification and
enforce it on the reference LB, all default-OFF (0-change) and live-verified against
the `webapp-api-protection` LB. Closes #37.

Builds on SP1 (clear⇄blindfold SecretType convention, PR #34/#36) and the provider
`#1091` object-ref tenant fix (released v3.71.2).

## What's included

**Spec supply methods (all three):**
- **GitHub source-control** — `xcsh_code_base_integration` (github) holding the SCM
  `access_token` via the reusable clear/blindfold SecretType convention, wired to the
  LB through `enable_api_discovery.api_discovery_from_code_scan.code_base_integrations[]`
  (`selected_repos{api_code_repo}` → `api-catalog`, or `all_repos`).
- **Uploaded OpenAPI files** — `xcsh_api_definition.swagger_specs` as pinned
  object-store paths, plus `scripts/swagger-upload.sh` (the object store has no TF
  resource; it is content-addressed, so upload-once-pin-path is idempotent — the same
  discipline as blindfold sealing).
- **Inventory / schema origin** — `api_inventory_{inclusion,exclusion}_list`,
  `non_api_endpoints`, and the `mixed`/`strict` (suppressed default) schema-origin oneof.

**LB schema enforcement:** `api_definition_choice.api_specification` (api_definition
object-ref + `validation_target_choice`: `validation_disabled` |
`validation_all_spec_endpoints`) vs the suppressed `disable_api_definition` default.

**Testing:** 12 plan-tests (`tests/api_definition.tftest.hcl`) + an AETG all-pairs
live matrix (`scripts/api_definition_pairs.py` + `scripts/api-definition-matrix.sh`,
`make api-definition-matrix`) covering api_definition_choice × validation ×
schema_origin × swagger × integration × token_method × code_scan.

## Live verification (against the reference LB)

- **clear/blindfold access_token matrix:** clear **ACCEPTED** (apply + idempotent);
  blindfold **500s** on both create and update — a platform-side limitation now
  reproduced on a second resource (matches the SP1 crawler password). blindfold is
  plan-tested + documented SKIP; clear is the live path.
- **All-pairs live matrix: 5 PASS, 1 SKIP (blindfold, documented), 0 FAIL** —
  apply → idempotent → round-trip import-clean (LB + api_definition +
  code_base_integration; write-only access_token re-set after import). The
  swagger_specs supply path is exercised end-to-end. Canonical restored.

## Scope boundary

`validation_custom_list` (per-endpoint custom OpenAPI validation rules with action
blocks) is API-*protection* rule authoring and is deferred to SP3, keeping SP2 focused
on spec management. See `docs/superpowers/plans/sp2-findings.md`.

## Notes

- `versions.tf` → `xcsh >= 3.71.2` (object-ref tenant fix for the LB refs).
- Secrets handled via env/stdin only; temp files owner-only + trap-cleaned; no
  plaintext committed.
