### PR TITLE
SP3: API Protection (rate limiting + sensitive data/data guard + api_protection_rules + OpenAPI validation)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # webapp-api-protection developer targets.
 
-.PHONY: mud-matrix mud-verify waf-matrix api-discovery-matrix api-definition-matrix api-crawl-verify test
+.PHONY: mud-matrix mud-verify waf-matrix api-discovery-matrix api-definition-matrix api-protection-matrix api-crawl-verify test
 
 # Run the plan-level test suite (no tenant contact).
 test:
@@ -39,6 +39,14 @@ api-discovery-matrix:
 # scripts/api_definition_pairs.py (generator) and scripts/api-definition-matrix.sh.
 api-definition-matrix:
 	bash scripts/api-definition-matrix.sh
+
+# Cycle the live LB through the API Protection (SP3) all-pairs variant set (rate
+# limiting, sensitive data / data guard, api_protection_rules, validation_custom_list)
+# and verify apply / idempotency / round-trip import. Runs in batches:
+# `make api-protection-matrix` (all) or `bash scripts/api-protection-matrix.sh START END`.
+# See scripts/api_protection_pairs.py (generator) and scripts/api-protection-matrix.sh.
+api-protection-matrix:
+	bash scripts/api-protection-matrix.sh
 
 # Staged blindfold verification: seal round-trip (a pre-sealed crawler credential
 # applies + is idempotent + import-clean) plus an authenticated-crawl attempt

--- a/scripts/api-protection-matrix.sh
+++ b/scripts/api-protection-matrix.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# API Protection (SP3) live coverage-matrix harness.
+#
+# Cycles the LIVE webapp-api-protection LB through the api_protection_pairs variant
+# set and verifies each variant (a) applies, (b) is idempotent (immediate plan =
+# No changes), and (c) is round-trip-import clean for the LB and, when present, the
+# standalone xcsh_sensitive_data_policy and xcsh_api_definition. Ends on
+# canonical-restore so the live LB is left healthy (all SP3 features off). Results
+# append to reports/api-protection-matrix.txt.
+#
+# No secrets are involved (unlike SP2's access_token), so there is no injection and
+# no write-only-secret re-apply gate — every variant must import 0-change. An arm
+# that F5 XC rejects on staging (400/500) is recorded SKIP (word/phrase signals; a
+# bare status number is not matched) rather than FAIL. Sequential — no concurrent
+# terraform against the shared azurerm state.
+#
+# Usage: api-protection-matrix.sh [START [END]]  (inclusive 0-based index range).
+set -uo pipefail
+
+umask 077
+trap 'rm -rf /tmp/apiprot-variants 2>/dev/null; rm -f /tmp/apiprot-*.log 2>/dev/null' EXIT
+
+cd "$(dirname "$0")/../terraform" || exit 1
+ARM_ACCESS_KEY=$(az storage account keys list -n f5salesdemotfstate -g f5-sales-demo-tfstate --query "[0].value" -o tsv)
+export ARM_ACCESS_KEY
+
+NS="webapp-api-protection"
+LB_ADDR="module.http_lb.xcsh_http_loadbalancer.this"
+LB_ID="${NS}/${NS}"
+SDP_ADDR="module.http_lb.xcsh_sensitive_data_policy.this[0]"
+SDP_ID="${NS}/${NS}-sensitive-data"
+DEF_ADDR="module.http_lb.xcsh_api_definition.this[0]"
+DEF_ID="${NS}/${NS}-api-def"
+COMMON=(-input=false -lock=true
+  -var 'lb_domains=["www.f5-sales-demo.com","api.f5-sales-demo.com"]'
+  -var 'subscription_id=75f86c46-9cbc-4f6c-85ea-195e3d3c8ac0')
+VARDIR=/tmp/apiprot-variants
+REPORT=../reports/api-protection-matrix.txt
+mkdir -p ../reports
+
+START="${1:-0}"
+END="${2:-9999}"
+GATED_RE='entitlement|not subscribed|not entitled|not enabled for|permission denied|unauthorized|AS_NOT_SUBSCRIBED|status: 401|status: 403'
+
+# Truncate the report on a full run; a batched range run (args given) appends.
+[ "$#" -eq 0 ] && : >"$REPORT"
+
+count=$(python3 ../scripts/api_protection_pairs.py --emit "$VARDIR")
+echo "generated $count variants into $VARDIR (running [$START..$END])"
+
+import_one() {
+  local addr="$1" id="$2" vf="$3" label="$4"
+  terraform state list 2>/dev/null | grep -qxF "$addr" || return 0
+  terraform state rm "$addr" >/dev/null 2>&1 || return 0
+  terraform import "${COMMON[@]}" -var-file="$vf" "$addr" "$id" >>/tmp/apiprot-import.log 2>&1 || {
+    echo "FAIL $label import($addr)" >>"$REPORT"
+    return 1
+  }
+}
+
+round_trip() {
+  local label="$1" vf="$2"
+  # Import the LB first (always in state), then any standalone resources present.
+  terraform state rm "$LB_ADDR" >/dev/null 2>&1 || {
+    echo "FAIL $label lb-state-rm" >>"$REPORT"
+    return
+  }
+  terraform import "${COMMON[@]}" -var-file="$vf" "$LB_ADDR" "$LB_ID" >/tmp/apiprot-import.log 2>&1 || {
+    echo "FAIL $label lb-import" >>"$REPORT"
+    return
+  }
+  import_one "$SDP_ADDR" "$SDP_ID" "$vf" "$label" || return
+  import_one "$DEF_ADDR" "$DEF_ID" "$vf" "$label" || return
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$vf" >/tmp/apiprot-rt-plan.log 2>&1
+  case $? in
+  0) echo "PASS $label" >>"$REPORT" ;;
+  2) echo "FAIL $label import-drift (no-secret variant must import clean)" >>"$REPORT" ;;
+  *) echo "FAIL $label rt-plan-error" >>"$REPORT" ;;
+  esac
+}
+
+while read -r idx name vf _flag; do
+  [ "$idx" -lt "$START" ] && continue
+  [ "$idx" -gt "$END" ] && continue
+  label="$idx-$name"
+  echo "--- $label ---"
+  varfile="${VARDIR}/${vf}"
+  if ! terraform apply -auto-approve "${COMMON[@]}" -var-file="$varfile" >/tmp/apiprot-apply.log 2>&1; then
+    if grep -qiE "$GATED_RE" /tmp/apiprot-apply.log; then
+      echo "SKIP $label gated-arm ($(grep -oiE "$GATED_RE" /tmp/apiprot-apply.log | head -1))" >>"$REPORT"
+    else
+      echo "FAIL $label apply ($(grep -iE 'error' /tmp/apiprot-apply.log | head -1 | cut -c1-80))" >>"$REPORT"
+    fi
+    continue
+  fi
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$varfile" >/tmp/apiprot-plan.log 2>&1
+  case $? in
+  0) round_trip "$label" "$varfile" ;;
+  2) echo "FAIL $label not-idempotent" >>"$REPORT" ;;
+  *) echo "FAIL $label plan-error" >>"$REPORT" ;;
+  esac
+done <"${VARDIR}/manifest.txt"
+
+echo "===== API PROTECTION MATRIX RESULTS ($START..$END) ====="
+cat "$REPORT"
+echo "PASS=$(grep -c '^PASS ' "$REPORT") FAIL=$(grep -c '^FAIL ' "$REPORT") SKIP=$(grep -c '^SKIP ' "$REPORT")"

--- a/scripts/api_protection_pairs.py
+++ b/scripts/api_protection_pairs.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Generate the API Protection (SP3) coverage matrix.
+
+Coverage model (see docs/superpowers/specs/2026-07-14-sp3-api-protection-design.md
+and docs/superpowers/plans/sp3-findings.md):
+  * all-pairs (pairwise, AETG greedy) over the SP3 capability dimensions, so every
+    pair of option-values co-occurs in at least one variant;
+  * PLUS the canonical restore end state (all SP3 features off).
+
+Pairwise dimensions:
+  rate_limit      disable | rate_limit  -> rate_limit_choice (inline request limiter)
+  client_matcher  any | ip_prefix | ip_threat  (applied to api_protection_rules)
+  sensitive_data  default | custom  (custom => standalone xcsh_sensitive_data_policy)
+  data_guard      off | on
+  api_protection  off | allow | deny
+  validation      off | custom_list  (on => api_definition specification + custom_list;
+                  SP2 already matrix-covered validation_disabled/all_spec_endpoints)
+
+payloads() reconciles the module's constraints so every emitted variant is a valid
+root config, and dedups byte-identical payloads (slow live matrix). Secret-free —
+no injection needed (unlike SP2's access_token). Deterministic (no RNG).
+
+Output: JSON array of {"name", "vars"} to stdout, or files via --emit.
+"""
+
+import itertools
+import json
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+DIMENSIONS = {
+    "rate_limit": ["disable", "rate_limit"],
+    "client_matcher": ["any", "ip_prefix", "ip_threat"],
+    "sensitive_data": ["default", "custom"],
+    "data_guard": ["off", "on"],
+    "api_protection": ["off", "allow", "deny"],
+    "validation": ["off", "custom_list"],
+}
+
+
+def _best_value(
+    values: list[str],
+    idx: int,
+    row: dict[int, str],
+    uncovered: set[tuple[int, str, int, str]],
+) -> str:
+    """Pick the value for dimension idx covering the most still-uncovered pairs."""
+    best_val, best_gain = values[0], -1
+    for val in values:
+        gain = 0
+        for pidx, pval in row.items():
+            a, b = sorted([(pidx, pval), (idx, val)])
+            if (a[0], a[1], b[0], b[1]) in uncovered:
+                gain += 1
+        if gain > best_gain:
+            best_gain, best_val = gain, val
+    return best_val
+
+
+def all_pairs(dims: dict[str, list[str]]) -> list[dict[str, str]]:
+    """Return AETG-style greedy all-pairs rows ({dim: value})."""
+    names = list(dims)
+    uncovered: set[tuple[int, str, int, str]] = set()
+    for i, j in itertools.combinations(range(len(names)), 2):
+        for vi in dims[names[i]]:
+            for vj in dims[names[j]]:
+                uncovered.add((i, vi, j, vj))
+
+    rows = []
+    while uncovered:
+        si, sv, sj, sv2 = min(uncovered)
+        row = {si: sv, sj: sv2}
+        for idx, name in enumerate(names):
+            if idx not in row:
+                row[idx] = _best_value(dims[name], idx, row, uncovered)
+        for i, j in itertools.combinations(sorted(row), 2):
+            uncovered.discard((i, row[i], j, row[j]))
+        rows.append({names[k]: v for k, v in row.items()})
+    return rows
+
+
+def payloads(v: Mapping[str, object]) -> dict[str, object]:
+    """Expand a pairwise row into real tfvars."""
+    out: dict[str, object] = {}
+
+    if v.get("rate_limit") == "rate_limit":
+        out["rate_limit_choice"] = "rate_limit"
+        out["rate_limit_total_number"] = 500
+        out["rate_limit_unit"] = "MINUTE"
+
+    # client_matcher is only observable when api_protection rules exist, but set it
+    # per the pairwise row so (client_matcher x api_protection) pairs are covered.
+    if v.get("client_matcher") == "ip_prefix":
+        out["client_matcher"] = {"mode": "ip_prefix", "ip_prefixes": ["10.0.0.0/8"]}
+    elif v.get("client_matcher") == "ip_threat":
+        out["client_matcher"] = {"mode": "ip_threat", "ip_threat_categories": ["BOTNETS"]}
+
+    if v.get("sensitive_data") == "custom":
+        out["sensitive_data_policy_enabled"] = True
+        out["sensitive_data_policy_choice"] = "custom"
+        out["sensitive_data_compliances"] = ["GDPR", "PCI_DSS"]
+
+    if v.get("data_guard") == "on":
+        out["data_guard_rules"] = [
+            {"domain_mode": "any", "path": "/api/pay", "apply": True}
+        ]
+
+    if v.get("api_protection") in ("allow", "deny"):
+        out["api_protection_rules"] = [
+            {"path": "/api/admin", "methods": ["POST"], "action": v["api_protection"]}
+        ]
+
+    if v.get("validation") == "custom_list":
+        out["api_definition_choice"] = "specification"
+        out["api_specification_validation"] = "custom_list"
+        out["validation_custom_rules"] = [
+            {"path": "/api/health", "methods": ["GET"], "action": "report"}
+        ]
+
+    return out
+
+
+def canonical() -> dict[str, object]:
+    """Return the live-canonical end state (all SP3 features off)."""
+    return {"rate_limit_choice": "disable", "api_definition_choice": "disable"}
+
+
+def build() -> list[dict[str, object]]:
+    """Build the ordered variant manifest (all-pairs + canonical restore), deduped."""
+    variants: list[dict[str, object]] = []
+    seen: set[str] = set()
+    idx = 0
+    for row in all_pairs(DIMENSIONS):
+        vars_ = payloads(row)
+        key = json.dumps(vars_, sort_keys=True)
+        if key in seen:
+            continue
+        seen.add(key)
+        variants.append({"name": f"pair-{idx:03d}", "vars": vars_})
+        idx += 1
+    variants.append({"name": "canonical-restore", "vars": canonical()})
+    return variants
+
+
+def emit(directory: str) -> int:
+    """Write one <NNN>-<name>.tfvars.json per variant plus manifest.txt."""
+    out_dir = Path(directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for existing in out_dir.iterdir():
+        if existing.name.endswith(".tfvars.json") or existing.name == "manifest.txt":
+            existing.unlink()
+    variants = build()
+    named = [(f"{i:03d}-{v['name']}.tfvars.json", v) for i, v in enumerate(variants)]
+    for fname, v in named:
+        (out_dir / fname).write_text(json.dumps(v["vars"], indent=2) + "\n")
+    lines = [f"{i:03d} {v['name']} {fname} LIVE" for i, (fname, v) in enumerate(named)]
+    (out_dir / "manifest.txt").write_text("\n".join(lines) + "\n")
+    return len(variants)
+
+
+def main(argv: list[str]) -> None:
+    """CLI: --count, --emit <dir>, else JSON to stdout."""
+    match argv[1:]:
+        case ["--count"]:
+            sys.stdout.write(f"{len(build())}\n")
+        case ["--emit", directory]:
+            sys.stdout.write(f"{emit(directory)}\n")
+        case _:
+            json.dump(build(), sys.stdout, indent=2)
+            sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/scripts/api_protection_pairs.py
+++ b/scripts/api_protection_pairs.py
@@ -94,7 +94,10 @@ def payloads(v: Mapping[str, object]) -> dict[str, object]:
     if v.get("client_matcher") == "ip_prefix":
         out["client_matcher"] = {"mode": "ip_prefix", "ip_prefixes": ["10.0.0.0/8"]}
     elif v.get("client_matcher") == "ip_threat":
-        out["client_matcher"] = {"mode": "ip_threat", "ip_threat_categories": ["BOTNETS"]}
+        out["client_matcher"] = {
+            "mode": "ip_threat",
+            "ip_threat_categories": ["BOTNETS"],
+        }
 
     if v.get("sensitive_data") == "custom":
         out["sensitive_data_policy_choice"] = "custom"

--- a/scripts/api_protection_pairs.py
+++ b/scripts/api_protection_pairs.py
@@ -97,7 +97,6 @@ def payloads(v: Mapping[str, object]) -> dict[str, object]:
         out["client_matcher"] = {"mode": "ip_threat", "ip_threat_categories": ["BOTNETS"]}
 
     if v.get("sensitive_data") == "custom":
-        out["sensitive_data_policy_enabled"] = True
         out["sensitive_data_policy_choice"] = "custom"
         out["sensitive_data_compliances"] = ["GDPR", "PCI_DSS"]
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -126,7 +126,6 @@ module "http_lb" {
   rate_limit_unit                    = var.rate_limit_unit
   rate_limit_period_multiplier       = var.rate_limit_period_multiplier
   rate_limit_burst_multiplier        = var.rate_limit_burst_multiplier
-  sensitive_data_policy_enabled      = var.sensitive_data_policy_enabled
   sensitive_data_compliances         = var.sensitive_data_compliances
   sensitive_data_disabled_predefined = var.sensitive_data_disabled_predefined
   sensitive_data_policy_choice       = var.sensitive_data_policy_choice

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -119,6 +119,21 @@ module "http_lb" {
   api_definition_schema_origin       = var.api_definition_schema_origin
   api_specification_validation       = var.api_specification_validation
 
+  # API Protection (SP3) passthrough. Defaults keep every control off/suppressed (0-change).
+  client_matcher                     = var.client_matcher
+  rate_limit_choice                  = var.rate_limit_choice
+  rate_limit_total_number            = var.rate_limit_total_number
+  rate_limit_unit                    = var.rate_limit_unit
+  rate_limit_period_multiplier       = var.rate_limit_period_multiplier
+  rate_limit_burst_multiplier        = var.rate_limit_burst_multiplier
+  sensitive_data_policy_enabled      = var.sensitive_data_policy_enabled
+  sensitive_data_compliances         = var.sensitive_data_compliances
+  sensitive_data_disabled_predefined = var.sensitive_data_disabled_predefined
+  sensitive_data_policy_choice       = var.sensitive_data_policy_choice
+  data_guard_rules                   = var.data_guard_rules
+  api_protection_rules               = var.api_protection_rules
+  validation_custom_rules            = var.validation_custom_rules
+
   # Enabling client_side_defense on the LB requires a protected domain to already
   # exist in this namespace (F5 XC generates the CSD JS config from it), so the
   # LB must be created/updated AFTER the protected domain. The MUD entitlement

--- a/terraform/modules/http-lb/locals_client_matcher.tf
+++ b/terraform/modules/http-lb/locals_client_matcher.tf
@@ -1,0 +1,15 @@
+# Shared client-matcher renderer (SP3, DRY). Consumers (api_protection_rules,
+# api_rate_limit rules) read local.rendered_client_matcher and emit the matching
+# dynamic arm. mode selects exactly one of any_client / ip_prefix_list /
+# ip_threat_category_list; the non-selected arms render nothing.
+locals {
+  rendered_client_matcher = {
+    use_any       = var.client_matcher.mode == "any"
+    use_ip_prefix = var.client_matcher.mode == "ip_prefix"
+    use_ip_threat = var.client_matcher.mode == "ip_threat"
+
+    ip_prefixes          = var.client_matcher.ip_prefixes
+    invert               = var.client_matcher.invert
+    ip_threat_categories = var.client_matcher.ip_threat_categories
+  }
+}

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -620,6 +620,14 @@ resource "xcsh_http_loadbalancer" "this" {
                 dynamic "validation_mode_active" {
                   for_each = contains(["block", "report"], open_api_validation_rules.value.action) ? [1] : []
                   content {
+                    # request_validation_properties has SizeAtLeast(1): validate the
+                    # common request properties against the OpenAPI spec.
+                    request_validation_properties = [
+                      "PROPERTY_QUERY_PARAMETERS",
+                      "PROPERTY_PATH_PARAMETERS",
+                      "PROPERTY_HTTP_HEADERS",
+                      "PROPERTY_HTTP_BODY",
+                    ]
                     dynamic "enforcement_block" {
                       for_each = open_api_validation_rules.value.action == "block" ? [1] : []
                       content {}
@@ -715,6 +723,9 @@ resource "xcsh_http_loadbalancer" "this" {
       dynamic "api_endpoint_rules" {
         for_each = var.api_protection_rules
         content {
+          metadata {
+            name = "api-protection-${api_endpoint_rules.key}"
+          }
           api_endpoint_path = api_endpoint_rules.value.path
 
           dynamic "any_domain" {
@@ -724,7 +735,11 @@ resource "xcsh_http_loadbalancer" "this" {
           specific_domain = api_endpoint_rules.value.domain_mode == "specific" ? api_endpoint_rules.value.domain : null
 
           api_endpoint_method {
-            methods = api_endpoint_rules.value.methods
+            # invert_matcher is a server-defaulted Optional bool: omitting it makes
+            # the provider report "was null, now false" (Optional-scalar-not-Computed
+            # codegen gap — see sp3-findings.md). Set it explicitly (non-inverted).
+            invert_matcher = false
+            methods        = api_endpoint_rules.value.methods
           }
 
           action {

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -592,6 +592,27 @@ resource "xcsh_http_loadbalancer" "this" {
     }
   }
 
+  # Rate limiting (SP3, rate_limit_choice oneof: rate_limit vs the server default
+  # disable_rate_limit). Default omits the block — the server applies
+  # disable_rate_limit, which the provider suppresses on import (0-change; do not
+  # declare it). "rate_limit" emits the self-contained inline request rate limiter:
+  # no IP allow-list (no_ip_allowed_list) and no policy refs (no_policies), so the
+  # rate_limiter spec alone defines the limit. The per-endpoint api_rate_limit arm
+  # and the standalone xcsh_rate_limiter_policy are deferred (see sp3-findings.md).
+  dynamic "rate_limit" {
+    for_each = var.rate_limit_choice == "rate_limit" ? [1] : []
+    content {
+      no_ip_allowed_list {}
+      no_policies {}
+      rate_limiter {
+        total_number      = var.rate_limit_total_number
+        unit              = var.rate_limit_unit
+        period_multiplier = var.rate_limit_period_multiplier
+        burst_multiplier  = var.rate_limit_burst_multiplier
+      }
+    }
+  }
+
   # Client-Side Defense — inject the F5 XC telemetry JavaScript into served pages
   # to detect Magecart/formjacking/skimming (client_side_defense oneof vs the
   # server default disable_client_side_defense). Requires the CSD tenant addon

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -613,6 +613,52 @@ resource "xcsh_http_loadbalancer" "this" {
     }
   }
 
+  # Sensitive-data protection (SP3, sensitive_data_policy_choice oneof: custom
+  # sensitive_data_policy vs the server default default_sensitive_data_policy).
+  # Default omits the block (default_sensitive_data_policy is import-suppressed;
+  # 0-change). "custom" references the standalone xcsh_sensitive_data_policy; the
+  # object-ref keeps its Computed tenant across apply via provider #1091.
+  dynamic "sensitive_data_policy" {
+    for_each = var.sensitive_data_policy_choice == "custom" ? [1] : []
+    content {
+      sensitive_data_policy_ref {
+        name      = xcsh_sensitive_data_policy.this[0].name
+        namespace = var.namespace
+      }
+    }
+  }
+
+  # Data Guard — mask sensitive values (credit-card/SSN/...) in responses per
+  # domain + path. Omitted when the list is empty (0-change). domain matcher is a
+  # oneof (any_domain | exact_value | suffix_value); action is apply_data_guard vs
+  # skip_data_guard. The deeper sensitive_data_disclosure_rules (per-endpoint body
+  # field masking) are deferred this cycle — see sp3-findings.md.
+  dynamic "data_guard_rules" {
+    for_each = var.data_guard_rules
+    content {
+      metadata {
+        name = "data-guard-${data_guard_rules.key}"
+      }
+      dynamic "any_domain" {
+        for_each = data_guard_rules.value.domain_mode == "any" ? [1] : []
+        content {}
+      }
+      exact_value  = data_guard_rules.value.domain_mode == "exact" ? data_guard_rules.value.domain : null
+      suffix_value = data_guard_rules.value.domain_mode == "suffix" ? data_guard_rules.value.domain : null
+      path {
+        path = data_guard_rules.value.path
+      }
+      dynamic "apply_data_guard" {
+        for_each = data_guard_rules.value.apply ? [1] : []
+        content {}
+      }
+      dynamic "skip_data_guard" {
+        for_each = data_guard_rules.value.apply ? [] : [1]
+        content {}
+      }
+    }
+  }
+
   # Client-Side Defense — inject the F5 XC telemetry JavaScript into served pages
   # to detect Magecart/formjacking/skimming (client_side_defense oneof vs the
   # server default disable_client_side_defense). Requires the CSD tenant addon

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -562,9 +562,9 @@ resource "xcsh_http_loadbalancer" "this" {
   # created in api_definition.tf; the api_definition object-ref keeps its Computed
   # tenant across apply via provider #1091 (>= 3.71.2), the same class as the SP1
   # api_discovery_ref. validation_target_choice picks how strictly to validate:
-  # validation_disabled (define but do not enforce) or validation_all_spec_endpoints
-  # (enforce every endpoint, fall-through allow). The per-endpoint custom-rule arm
-  # (validation_custom_list) is API-protection rule authoring, deferred to SP3.
+  # validation_disabled (define but do not enforce), validation_all_spec_endpoints
+  # (enforce every endpoint, fall-through allow), or validation_custom_list (SP3:
+  # per-endpoint OpenAPI validation rules with a fall-through-allow default).
   dynamic "api_specification" {
     for_each = var.api_definition_choice == "specification" ? [1] : []
     content {
@@ -586,6 +586,52 @@ resource "xcsh_http_loadbalancer" "this" {
           }
           validation_mode {
             skip_validation {}
+          }
+        }
+      }
+
+      # validation_custom_list (SP3): per-endpoint rules + fall-through allow for
+      # unlisted endpoints. Each rule matches an api_endpoint (method/path) and
+      # applies action_block | action_report | action_skip.
+      dynamic "validation_custom_list" {
+        for_each = var.api_specification_validation == "custom_list" ? [1] : []
+        content {
+          fall_through_mode {
+            fall_through_mode_allow {}
+          }
+          dynamic "open_api_validation_rules" {
+            for_each = var.validation_custom_rules
+            content {
+              metadata {
+                name = "validation-rule-${open_api_validation_rules.key}"
+              }
+              any_domain {}
+              api_endpoint {
+                methods = open_api_validation_rules.value.methods
+                path    = open_api_validation_rules.value.path
+              }
+              # action via validation_mode: skip = skip_validation; block/report =
+              # validation_mode_active with enforcement_block / enforcement_report.
+              validation_mode {
+                dynamic "skip_validation" {
+                  for_each = open_api_validation_rules.value.action == "skip" ? [1] : []
+                  content {}
+                }
+                dynamic "validation_mode_active" {
+                  for_each = contains(["block", "report"], open_api_validation_rules.value.action) ? [1] : []
+                  content {
+                    dynamic "enforcement_block" {
+                      for_each = open_api_validation_rules.value.action == "block" ? [1] : []
+                      content {}
+                    }
+                    dynamic "enforcement_report" {
+                      for_each = open_api_validation_rules.value.action == "report" ? [1] : []
+                      content {}
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -659,6 +659,62 @@ resource "xcsh_http_loadbalancer" "this" {
     }
   }
 
+  # API protection rules (SP3) — allow/deny access to specific API endpoints,
+  # scoped by the shared client-matcher. Omitted when the list is empty (0-change).
+  # client_matcher is emitted only for the ip_prefix / ip_threat modes; "any" omits
+  # it (server default any_client) to stay import-clean.
+  dynamic "api_protection_rules" {
+    for_each = length(var.api_protection_rules) > 0 ? [1] : []
+    content {
+      dynamic "api_endpoint_rules" {
+        for_each = var.api_protection_rules
+        content {
+          api_endpoint_path = api_endpoint_rules.value.path
+
+          dynamic "any_domain" {
+            for_each = api_endpoint_rules.value.domain_mode == "any" ? [1] : []
+            content {}
+          }
+          specific_domain = api_endpoint_rules.value.domain_mode == "specific" ? api_endpoint_rules.value.domain : null
+
+          api_endpoint_method {
+            methods = api_endpoint_rules.value.methods
+          }
+
+          action {
+            dynamic "allow" {
+              for_each = api_endpoint_rules.value.action == "allow" ? [1] : []
+              content {}
+            }
+            dynamic "deny" {
+              for_each = api_endpoint_rules.value.action == "deny" ? [1] : []
+              content {}
+            }
+          }
+
+          dynamic "client_matcher" {
+            for_each = local.rendered_client_matcher.use_any ? [] : [1]
+            content {
+              dynamic "ip_prefix_list" {
+                for_each = local.rendered_client_matcher.use_ip_prefix ? [1] : []
+                content {
+                  ip_prefixes  = local.rendered_client_matcher.ip_prefixes
+                  invert_match = local.rendered_client_matcher.invert
+                }
+              }
+              dynamic "ip_threat_category_list" {
+                for_each = local.rendered_client_matcher.use_ip_threat ? [1] : []
+                content {
+                  ip_threat_categories = local.rendered_client_matcher.ip_threat_categories
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
   # Client-Side Defense — inject the F5 XC telemetry JavaScript into served pages
   # to detect Magecart/formjacking/skimming (client_side_defense oneof vs the
   # server default disable_client_side_defense). Requires the CSD tenant addon

--- a/terraform/modules/http-lb/outputs_api_protection.tf
+++ b/terraform/modules/http-lb/outputs_api_protection.tf
@@ -13,7 +13,7 @@ output "rate_limit_choice" {
 
 output "sensitive_data_policy_created" {
   description = "Whether a standalone xcsh_sensitive_data_policy is created."
-  value       = var.sensitive_data_policy_enabled
+  value       = var.sensitive_data_policy_choice == "custom"
 }
 
 output "sensitive_data_policy_choice" {

--- a/terraform/modules/http-lb/outputs_api_protection.tf
+++ b/terraform/modules/http-lb/outputs_api_protection.tf
@@ -10,3 +10,18 @@ output "rate_limit_choice" {
   description = "Effective rate_limit_choice arm (disable or rate_limit)."
   value       = var.rate_limit_choice
 }
+
+output "sensitive_data_policy_created" {
+  description = "Whether a standalone xcsh_sensitive_data_policy is created."
+  value       = var.sensitive_data_policy_enabled
+}
+
+output "sensitive_data_policy_choice" {
+  description = "Effective sensitive_data_policy_choice arm (default or custom)."
+  value       = var.sensitive_data_policy_choice
+}
+
+output "data_guard_rule_count" {
+  description = "Number of data_guard_rules configured."
+  value       = length(var.data_guard_rules)
+}

--- a/terraform/modules/http-lb/outputs_api_protection.tf
+++ b/terraform/modules/http-lb/outputs_api_protection.tf
@@ -5,3 +5,8 @@ output "client_matcher_mode" {
   description = "Effective shared client-matcher mode (any, ip_prefix, or ip_threat)."
   value       = var.client_matcher.mode
 }
+
+output "rate_limit_choice" {
+  description = "Effective rate_limit_choice arm (disable or rate_limit)."
+  value       = var.rate_limit_choice
+}

--- a/terraform/modules/http-lb/outputs_api_protection.tf
+++ b/terraform/modules/http-lb/outputs_api_protection.tf
@@ -25,3 +25,8 @@ output "data_guard_rule_count" {
   description = "Number of data_guard_rules configured."
   value       = length(var.data_guard_rules)
 }
+
+output "api_protection_rule_count" {
+  description = "Number of api_protection_rules (api_endpoint_rules) configured."
+  value       = length(var.api_protection_rules)
+}

--- a/terraform/modules/http-lb/outputs_api_protection.tf
+++ b/terraform/modules/http-lb/outputs_api_protection.tf
@@ -1,0 +1,7 @@
+# API Protection (SP3) outputs — effective arm echoes for plan-level tests and
+# downstream visibility (same convention as outputs_api.tf / outputs_api_definition.tf).
+
+output "client_matcher_mode" {
+  description = "Effective shared client-matcher mode (any, ip_prefix, or ip_threat)."
+  value       = var.client_matcher.mode
+}

--- a/terraform/modules/http-lb/sensitive_data_policy.tf
+++ b/terraform/modules/http-lb/sensitive_data_policy.tf
@@ -1,11 +1,12 @@
 # xcsh_sensitive_data_policy (SP3) — the standalone policy the LB's
-# sensitive_data_policy_choice=custom references. Created only when
-# sensitive_data_policy_enabled. compliances / disabled_predefined_data_types are
-# set only when non-empty so the empty-list default matches the server default
+# sensitive_data_policy_choice=custom references. Created iff that same choice is
+# "custom" (single knob, mirroring api_definition.tf), so the resource and the LB
+# reference can never desync. compliances / disabled_predefined_data_types are set
+# only when non-empty so the empty-list default matches the server default
 # (import-clean). custom_data_types (object-refs to xcsh_custom_data_type) are
 # deferred this cycle — see docs/superpowers/plans/sp3-findings.md.
 resource "xcsh_sensitive_data_policy" "this" {
-  count     = var.sensitive_data_policy_enabled ? 1 : 0
+  count     = var.sensitive_data_policy_choice == "custom" ? 1 : 0
   name      = "${var.namespace}-sensitive-data"
   namespace = var.namespace
 

--- a/terraform/modules/http-lb/sensitive_data_policy.tf
+++ b/terraform/modules/http-lb/sensitive_data_policy.tf
@@ -1,0 +1,14 @@
+# xcsh_sensitive_data_policy (SP3) — the standalone policy the LB's
+# sensitive_data_policy_choice=custom references. Created only when
+# sensitive_data_policy_enabled. compliances / disabled_predefined_data_types are
+# set only when non-empty so the empty-list default matches the server default
+# (import-clean). custom_data_types (object-refs to xcsh_custom_data_type) are
+# deferred this cycle — see docs/superpowers/plans/sp3-findings.md.
+resource "xcsh_sensitive_data_policy" "this" {
+  count     = var.sensitive_data_policy_enabled ? 1 : 0
+  name      = "${var.namespace}-sensitive-data"
+  namespace = var.namespace
+
+  compliances                    = length(var.sensitive_data_compliances) > 0 ? var.sensitive_data_compliances : null
+  disabled_predefined_data_types = length(var.sensitive_data_disabled_predefined) > 0 ? var.sensitive_data_disabled_predefined : null
+}

--- a/terraform/modules/http-lb/variables_api_definition.tf
+++ b/terraform/modules/http-lb/variables_api_definition.tf
@@ -113,15 +113,45 @@ variable "api_definition_schema_origin" {
 
 # validation_target_choice arm for LB api_specification. "disabled" (default)
 # defines the spec without enforcing it; "all_spec_endpoints" validates all
-# endpoints (fall-through allow). The per-endpoint custom-rule arm
-# (validation_custom_list) is API-protection rule authoring — deferred to SP3.
+# endpoints (fall-through allow); "custom_list" (SP3) applies per-endpoint OpenAPI
+# validation rules (validation_custom_rules) with a fall-through-allow default.
 variable "api_specification_validation" {
-  description = "api_specification validation_target_choice: disabled or all_spec_endpoints. (custom_list = SP3 protection rules.)"
+  description = "api_specification validation_target_choice: disabled, all_spec_endpoints, or custom_list."
   type        = string
   default     = "disabled"
 
   validation {
-    condition     = contains(["disabled", "all_spec_endpoints"], var.api_specification_validation)
-    error_message = "api_specification_validation must be \"disabled\" or \"all_spec_endpoints\" (custom_list is deferred to SP3)."
+    condition     = contains(["disabled", "all_spec_endpoints", "custom_list"], var.api_specification_validation)
+    error_message = "api_specification_validation must be \"disabled\", \"all_spec_endpoints\", or \"custom_list\"."
+  }
+}
+
+# Per-endpoint OpenAPI validation rules for the custom_list arm (SP3). Each rule
+# targets an api_endpoint (method + path) with an action: block (enforce), report
+# (monitor), or skip (exempt). fall-through for unlisted endpoints is allow.
+variable "validation_custom_rules" {
+  description = "validation_custom_list.open_api_validation_rules: list of {path, methods, action block|report|skip}."
+  type = list(object({
+    path    = string
+    methods = optional(list(string), ["ANY"])
+    action  = optional(string, "report")
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for r in var.validation_custom_rules : contains(["block", "report", "skip"], r.action)
+    ])
+    error_message = "each validation_custom_rules action must be block, report, or skip."
+  }
+
+  validation {
+    condition = alltrue([
+      for r in var.validation_custom_rules : alltrue([
+        for m in r.methods :
+        contains(["ANY", "GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH", "COPY"], m)
+      ])
+    ])
+    error_message = "each validation_custom_rules method must be a valid HTTP method."
   }
 }

--- a/terraform/modules/http-lb/variables_api_protection_rules.tf
+++ b/terraform/modules/http-lb/variables_api_protection_rules.tf
@@ -1,0 +1,47 @@
+# API protection rules (SP3) — api_protection_rules.api_endpoint_rules[]: allow or
+# deny access to specific API endpoints, optionally scoped by the shared
+# client-matcher (var.client_matcher). Omitted when the list is empty (0-change).
+# Each rule: {path, domain (any|specific), methods, action allow|deny}. The shared
+# client-matcher applies to every rule (module-level client scope).
+variable "api_protection_rules" {
+  description = "api_protection_rules.api_endpoint_rules: list of {path, domain_mode any|specific, domain, methods, action allow|deny}."
+  type = list(object({
+    path        = string
+    domain_mode = optional(string, "any")
+    domain      = optional(string)
+    methods     = optional(list(string), ["ANY"])
+    action      = optional(string, "allow")
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for r in var.api_protection_rules : contains(["any", "specific"], r.domain_mode)
+    ])
+    error_message = "each api_protection_rules domain_mode must be any or specific."
+  }
+
+  validation {
+    condition = alltrue([
+      for r in var.api_protection_rules : r.domain_mode == "any" || r.domain != null
+    ])
+    error_message = "api_protection_rules with domain_mode specific require a domain."
+  }
+
+  validation {
+    condition = alltrue([
+      for r in var.api_protection_rules : contains(["allow", "deny"], r.action)
+    ])
+    error_message = "each api_protection_rules action must be allow or deny."
+  }
+
+  validation {
+    condition = alltrue([
+      for r in var.api_protection_rules : alltrue([
+        for m in r.methods :
+        contains(["ANY", "GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH", "COPY"], m)
+      ])
+    ])
+    error_message = "each api_protection_rules method must be a valid HTTP method."
+  }
+}

--- a/terraform/modules/http-lb/variables_client_matcher.tf
+++ b/terraform/modules/http-lb/variables_client_matcher.tf
@@ -1,0 +1,39 @@
+# Shared client-matcher (SP3) — reused by api_protection_rules and api_rate_limit
+# rules (DRY). One input + one renderer (locals_client_matcher.tf) + a dynamic block
+# each consumer emits. Covers the common arms:
+#   any (any_client, default) | ip_prefix (ip_prefix_list) | ip_threat (ip_threat_category_list)
+# The deep/rare arms (asn_matcher/asn_list, tls_fingerprint_matcher, client_selector
+# label-expressions) are deferred — see docs/superpowers/plans/sp3-findings.md.
+variable "client_matcher" {
+  description = "Shared client matcher. mode=any (any client), ip_prefix (IP prefix list), or ip_threat (IP threat category list)."
+  type = object({
+    mode                 = optional(string, "any")
+    ip_prefixes          = optional(list(string), [])
+    invert               = optional(bool, false)
+    ip_threat_categories = optional(list(string), [])
+  })
+  default = { mode = "any" }
+
+  validation {
+    condition     = contains(["any", "ip_prefix", "ip_threat"], var.client_matcher.mode)
+    error_message = "client_matcher.mode must be \"any\", \"ip_prefix\", or \"ip_threat\"."
+  }
+
+  validation {
+    condition = alltrue([
+      for c in var.client_matcher.ip_threat_categories :
+      contains(["SPAM_SOURCES", "WINDOWS_EXPLOITS", "WEB_ATTACKS", "BOTNETS", "SCANNERS", "REPUTATION", "PHISHING", "PROXY", "MOBILE_THREATS", "TOR_PROXY", "DENIAL_OF_SERVICE", "NETWORK"], c)
+    ])
+    error_message = "each ip_threat_categories value must be a valid F5 XC IP threat category."
+  }
+
+  validation {
+    condition     = var.client_matcher.mode != "ip_prefix" || length(var.client_matcher.ip_prefixes) > 0
+    error_message = "client_matcher.mode=ip_prefix requires ip_prefixes."
+  }
+
+  validation {
+    condition     = var.client_matcher.mode != "ip_threat" || length(var.client_matcher.ip_threat_categories) > 0
+    error_message = "client_matcher.mode=ip_threat requires ip_threat_categories."
+  }
+}

--- a/terraform/modules/http-lb/variables_rate_limit.tf
+++ b/terraform/modules/http-lb/variables_rate_limit.tf
@@ -1,0 +1,62 @@
+# Rate limiting (SP3) — LB rate_limit_choice. Default "disable" = server default
+# disable_rate_limit (import-suppressed) => omit the block => 0-change.
+#
+# "rate_limit" emits the self-contained inline request rate limiter
+# (rate_limit.rate_limiter) with no IP-allow-list and no policy refs. The
+# per-endpoint api_rate_limit arm and the standalone xcsh_rate_limiter_policy
+# (server-scoped, references a separate xcsh_rate_limiter) are advanced paths
+# deferred this cycle — see docs/superpowers/plans/sp3-findings.md.
+variable "rate_limit_choice" {
+  description = "rate_limit_choice: disable (server default, suppressed) or rate_limit (inline request rate limiter)."
+  type        = string
+  default     = "disable"
+
+  validation {
+    condition     = contains(["disable", "rate_limit"], var.rate_limit_choice)
+    error_message = "rate_limit_choice must be \"disable\" or \"rate_limit\"."
+  }
+}
+
+variable "rate_limit_total_number" {
+  description = "rate_limit.rate_limiter.total_number: max requests per period."
+  type        = number
+  default     = 100
+
+  validation {
+    condition     = var.rate_limit_total_number >= 1
+    error_message = "rate_limit_total_number must be >= 1."
+  }
+}
+
+variable "rate_limit_unit" {
+  description = "rate_limit.rate_limiter.unit: SECOND, MINUTE, HOUR, or DAY."
+  type        = string
+  default     = "MINUTE"
+
+  validation {
+    condition     = contains(["SECOND", "MINUTE", "HOUR", "DAY"], var.rate_limit_unit)
+    error_message = "rate_limit_unit must be SECOND, MINUTE, HOUR, or DAY."
+  }
+}
+
+variable "rate_limit_period_multiplier" {
+  description = "rate_limit.rate_limiter.period_multiplier: the period is period_multiplier x unit."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.rate_limit_period_multiplier >= 1
+    error_message = "rate_limit_period_multiplier must be >= 1."
+  }
+}
+
+variable "rate_limit_burst_multiplier" {
+  description = "rate_limit.rate_limiter.burst_multiplier: allowed burst is burst_multiplier x total_number."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.rate_limit_burst_multiplier >= 1
+    error_message = "rate_limit_burst_multiplier must be >= 1."
+  }
+}

--- a/terraform/modules/http-lb/variables_sensitive_data.tf
+++ b/terraform/modules/http-lb/variables_sensitive_data.tf
@@ -5,12 +5,6 @@
 # (omitted when empty). custom_data_types on the policy are object-refs to separate
 # xcsh_custom_data_type objects — deferred this cycle (see sp3-findings.md).
 
-variable "sensitive_data_policy_enabled" {
-  description = "Create a standalone xcsh_sensitive_data_policy (compliances + disabled predefined types) for the custom sensitive_data_policy_choice arm."
-  type        = bool
-  default     = false
-}
-
 variable "sensitive_data_compliances" {
   description = "Compliance frameworks to monitor on the sensitive_data_policy (GDPR, HIPAA, PCI_DSS, ...)."
   type        = list(string)

--- a/terraform/modules/http-lb/variables_sensitive_data.tf
+++ b/terraform/modules/http-lb/variables_sensitive_data.tf
@@ -1,0 +1,72 @@
+# Sensitive data & data guard (SP3). The LB sensitive_data_policy_choice defaults to
+# the server default default_sensitive_data_policy (import-suppressed => omit =>
+# 0-change); "custom" references the standalone xcsh_sensitive_data_policy created
+# here. data_guard_rules and sensitive_data_disclosure_rules are optional lists
+# (omitted when empty). custom_data_types on the policy are object-refs to separate
+# xcsh_custom_data_type objects — deferred this cycle (see sp3-findings.md).
+
+variable "sensitive_data_policy_enabled" {
+  description = "Create a standalone xcsh_sensitive_data_policy (compliances + disabled predefined types) for the custom sensitive_data_policy_choice arm."
+  type        = bool
+  default     = false
+}
+
+variable "sensitive_data_compliances" {
+  description = "Compliance frameworks to monitor on the sensitive_data_policy (GDPR, HIPAA, PCI_DSS, ...)."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for c in var.sensitive_data_compliances :
+      contains(["GDPR", "CCPA", "PIPEDA", "LGPD", "DPA_UK", "PDPA_SG", "APPI", "HIPAA", "CPRA_2023", "CPA_CO", "SOC2", "PCI_DSS", "ISO_IEC_27001", "ISO_IEC_27701", "EPRIVACY_DIRECTIVE", "GLBA", "SOX"], c)
+    ])
+    error_message = "each sensitive_data_compliances value must be a valid F5 XC compliance framework."
+  }
+}
+
+variable "sensitive_data_disabled_predefined" {
+  description = "Predefined sensitive-data types to disable (not shown as sensitive in API discovery)."
+  type        = list(string)
+  default     = []
+}
+
+# sensitive_data_policy_choice: "default" (server default_sensitive_data_policy,
+# suppressed => omit) or "custom" (reference the xcsh_sensitive_data_policy above).
+variable "sensitive_data_policy_choice" {
+  description = "sensitive_data_policy_choice: default (suppressed) or custom (reference the standalone policy)."
+  type        = string
+  default     = "default"
+
+  validation {
+    condition     = contains(["default", "custom"], var.sensitive_data_policy_choice)
+    error_message = "sensitive_data_policy_choice must be \"default\" or \"custom\"."
+  }
+}
+
+# data_guard_rules: mask sensitive data (e.g. credit-card / SSN) in responses per
+# domain + path. domain = any | exact | suffix; action = apply | skip.
+variable "data_guard_rules" {
+  description = "data_guard_rules: list of {domain_mode any|exact|suffix, domain, path, apply}."
+  type = list(object({
+    domain_mode = optional(string, "any")
+    domain      = optional(string)
+    path        = string
+    apply       = optional(bool, true)
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for r in var.data_guard_rules : contains(["any", "exact", "suffix"], r.domain_mode)
+    ])
+    error_message = "each data_guard_rules domain_mode must be any, exact, or suffix."
+  }
+
+  validation {
+    condition = alltrue([
+      for r in var.data_guard_rules : r.domain_mode == "any" || r.domain != null
+    ])
+    error_message = "data_guard_rules with domain_mode exact/suffix require a domain."
+  }
+}

--- a/terraform/tests/api_protection.tftest.hcl
+++ b/terraform/tests/api_protection.tftest.hcl
@@ -90,3 +90,61 @@ run "rate_limit_rejects_bad_unit" {
   }
   expect_failures = [var.rate_limit_unit]
 }
+
+# --- Sensitive data & data guard (Tasks 4-5) ---
+run "sensitive_data_default" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  assert {
+    condition     = output.sensitive_data_policy_choice == "default" && output.sensitive_data_policy_created == false
+    error_message = "sensitive data must default to the suppressed default policy (0-change)"
+  }
+}
+
+run "sensitive_data_custom_policy" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    sensitive_data_policy_enabled = true
+    sensitive_data_policy_choice  = "custom"
+    sensitive_data_compliances    = ["GDPR", "PCI_DSS"]
+  }
+  assert {
+    condition     = output.sensitive_data_policy_created == true && output.sensitive_data_policy_choice == "custom"
+    error_message = "custom sensitive_data_policy must render + create the standalone policy"
+  }
+}
+
+run "sensitive_data_rejects_bad_compliance" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    sensitive_data_policy_enabled = true
+    sensitive_data_compliances    = ["NOT_A_FRAMEWORK"]
+  }
+  expect_failures = [var.sensitive_data_compliances]
+}
+
+run "data_guard_rules_render" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    data_guard_rules = [
+      { domain_mode = "any", path = "/api/pay", apply = true },
+      { domain_mode = "suffix", domain = "f5-sales-demo.com", path = "/api/ssn", apply = false },
+    ]
+  }
+  assert {
+    condition     = output.data_guard_rule_count == 2
+    error_message = "data_guard_rules must render"
+  }
+}
+
+run "data_guard_exact_requires_domain" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    data_guard_rules = [{ domain_mode = "exact", path = "/x" }]
+  }
+  expect_failures = [var.data_guard_rules]
+}

--- a/terraform/tests/api_protection.tftest.hcl
+++ b/terraform/tests/api_protection.tftest.hcl
@@ -1,0 +1,56 @@
+# Plan-level tests for API Protection (SP3): shared client-matcher, rate limiting,
+# sensitive data / data guard, api_protection_rules, validation_custom_list.
+# Targets ./modules/http-lb with a dummy origin.
+variables {
+  namespace         = "webapp-api-protection"
+  lb_domains        = ["www.f5-sales-demo.com"]
+  origin_ip         = "203.0.113.10"
+  origin_port       = 80
+  health_check_path = "/health"
+  labels            = {}
+  csd_enabled       = false
+  mud_enabled       = false
+}
+
+# --- Shared client-matcher (Task 1) ---
+run "client_matcher_any_default" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  assert {
+    condition     = output.client_matcher_mode == "any"
+    error_message = "client_matcher must default to any"
+  }
+}
+
+run "client_matcher_ip_prefix" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    client_matcher = { mode = "ip_prefix", ip_prefixes = ["10.0.0.0/8"], invert = false }
+  }
+  assert {
+    condition     = output.client_matcher_mode == "ip_prefix"
+    error_message = "ip_prefix client_matcher must render"
+  }
+}
+
+run "client_matcher_ip_threat" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    client_matcher = { mode = "ip_threat", ip_threat_categories = ["SPAM_SOURCES", "BOTNETS"] }
+  }
+  assert {
+    condition     = output.client_matcher_mode == "ip_threat"
+    error_message = "ip_threat client_matcher must render"
+  }
+}
+
+run "client_matcher_rejects_bad_mode" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    client_matcher = { mode = "asn" }
+  }
+  expect_failures = [var.client_matcher]
+}

--- a/terraform/tests/api_protection.tftest.hcl
+++ b/terraform/tests/api_protection.tftest.hcl
@@ -195,3 +195,32 @@ run "api_protection_rejects_bad_action" {
   }
   expect_failures = [var.api_protection_rules]
 }
+
+# --- OpenAPI validation custom_list (Task 7 — SP2 deferral) ---
+run "validation_custom_list_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_definition_choice        = "specification"
+    api_specification_validation = "custom_list"
+    validation_custom_rules = [
+      { path = "/api/health", methods = ["GET"], action = "report" },
+      { path = "/api/admin", methods = ["POST"], action = "block" },
+    ]
+  }
+  assert {
+    condition     = output.api_specification_validation == "custom_list"
+    error_message = "validation_custom_list arm must render"
+  }
+}
+
+run "validation_custom_rules_reject_bad_action" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_definition_choice        = "specification"
+    api_specification_validation = "custom_list"
+    validation_custom_rules      = [{ path = "/x", action = "quarantine" }]
+  }
+  expect_failures = [var.validation_custom_rules]
+}

--- a/terraform/tests/api_protection.tftest.hcl
+++ b/terraform/tests/api_protection.tftest.hcl
@@ -105,9 +105,8 @@ run "sensitive_data_custom_policy" {
   command = plan
   module { source = "./modules/http-lb" }
   variables {
-    sensitive_data_policy_enabled = true
-    sensitive_data_policy_choice  = "custom"
-    sensitive_data_compliances    = ["GDPR", "PCI_DSS"]
+    sensitive_data_policy_choice = "custom"
+    sensitive_data_compliances   = ["GDPR", "PCI_DSS"]
   }
   assert {
     condition     = output.sensitive_data_policy_created == true && output.sensitive_data_policy_choice == "custom"
@@ -119,8 +118,8 @@ run "sensitive_data_rejects_bad_compliance" {
   command = plan
   module { source = "./modules/http-lb" }
   variables {
-    sensitive_data_policy_enabled = true
-    sensitive_data_compliances    = ["NOT_A_FRAMEWORK"]
+    sensitive_data_policy_choice = "custom"
+    sensitive_data_compliances   = ["NOT_A_FRAMEWORK"]
   }
   expect_failures = [var.sensitive_data_compliances]
 }

--- a/terraform/tests/api_protection.tftest.hcl
+++ b/terraform/tests/api_protection.tftest.hcl
@@ -54,3 +54,39 @@ run "client_matcher_rejects_bad_mode" {
   }
   expect_failures = [var.client_matcher]
 }
+
+# --- Rate limiting (Task 3) ---
+run "rate_limit_disabled_default" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  assert {
+    condition     = output.rate_limit_choice == "disable"
+    error_message = "rate_limit must default to disable (0-change)"
+  }
+}
+
+run "rate_limit_inline_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limit_choice            = "rate_limit"
+    rate_limit_total_number      = 500
+    rate_limit_unit              = "MINUTE"
+    rate_limit_period_multiplier = 1
+    rate_limit_burst_multiplier  = 2
+  }
+  assert {
+    condition     = output.rate_limit_choice == "rate_limit"
+    error_message = "inline rate_limit arm must render"
+  }
+}
+
+run "rate_limit_rejects_bad_unit" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limit_choice = "rate_limit"
+    rate_limit_unit   = "WEEK"
+  }
+  expect_failures = [var.rate_limit_unit]
+}

--- a/terraform/tests/api_protection.tftest.hcl
+++ b/terraform/tests/api_protection.tftest.hcl
@@ -148,3 +148,50 @@ run "data_guard_exact_requires_domain" {
   }
   expect_failures = [var.data_guard_rules]
 }
+
+# --- API protection rules (Task 6) ---
+run "api_protection_rules_default_empty" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  assert {
+    condition     = output.api_protection_rule_count == 0
+    error_message = "api_protection_rules must default to empty (0-change)"
+  }
+}
+
+run "api_protection_allow_and_deny" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_protection_rules = [
+      { path = "/api/health", domain_mode = "any", methods = ["GET"], action = "allow" },
+      { path = "/api/admin", domain_mode = "specific", domain = "api.f5-sales-demo.com", methods = ["POST", "DELETE"], action = "deny" },
+    ]
+  }
+  assert {
+    condition     = output.api_protection_rule_count == 2
+    error_message = "allow + deny api_protection_rules must render"
+  }
+}
+
+run "api_protection_with_ip_threat_matcher" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    client_matcher       = { mode = "ip_threat", ip_threat_categories = ["BOTNETS", "TOR_PROXY"] }
+    api_protection_rules = [{ path = "/api/pay", action = "deny" }]
+  }
+  assert {
+    condition     = output.api_protection_rule_count == 1 && output.client_matcher_mode == "ip_threat"
+    error_message = "api_protection_rules with ip_threat client-matcher must render"
+  }
+}
+
+run "api_protection_rejects_bad_action" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_protection_rules = [{ path = "/x", action = "block" }]
+  }
+  expect_failures = [var.api_protection_rules]
+}

--- a/terraform/variables_api_protection.tf
+++ b/terraform/variables_api_protection.tf
@@ -1,0 +1,102 @@
+# Root-level API Protection (SP3) inputs, passed through to modules/http-lb.
+# Defaults mirror the module and keep every control off/suppressed (0-change). The
+# api-protection matrix supplies these via -var-file per variant. Validation lives
+# in the module.
+
+variable "client_matcher" {
+  description = "Shared client matcher (any | ip_prefix | ip_threat) for api_protection_rules."
+  type = object({
+    mode                 = optional(string, "any")
+    ip_prefixes          = optional(list(string), [])
+    invert               = optional(bool, false)
+    ip_threat_categories = optional(list(string), [])
+  })
+  default = { mode = "any" }
+}
+
+variable "rate_limit_choice" {
+  description = "rate_limit_choice: disable or rate_limit."
+  type        = string
+  default     = "disable"
+}
+
+variable "rate_limit_total_number" {
+  description = "rate_limit.rate_limiter.total_number."
+  type        = number
+  default     = 100
+}
+
+variable "rate_limit_unit" {
+  description = "rate_limit.rate_limiter.unit (SECOND|MINUTE|HOUR|DAY)."
+  type        = string
+  default     = "MINUTE"
+}
+
+variable "rate_limit_period_multiplier" {
+  description = "rate_limit.rate_limiter.period_multiplier."
+  type        = number
+  default     = 1
+}
+
+variable "rate_limit_burst_multiplier" {
+  description = "rate_limit.rate_limiter.burst_multiplier."
+  type        = number
+  default     = 1
+}
+
+variable "sensitive_data_policy_enabled" {
+  description = "Create a standalone xcsh_sensitive_data_policy."
+  type        = bool
+  default     = false
+}
+
+variable "sensitive_data_compliances" {
+  description = "Compliance frameworks on the sensitive_data_policy."
+  type        = list(string)
+  default     = []
+}
+
+variable "sensitive_data_disabled_predefined" {
+  description = "Predefined sensitive-data types to disable."
+  type        = list(string)
+  default     = []
+}
+
+variable "sensitive_data_policy_choice" {
+  description = "sensitive_data_policy_choice: default or custom."
+  type        = string
+  default     = "default"
+}
+
+variable "data_guard_rules" {
+  description = "data_guard_rules: list of {domain_mode any|exact|suffix, domain, path, apply}."
+  type = list(object({
+    domain_mode = optional(string, "any")
+    domain      = optional(string)
+    path        = string
+    apply       = optional(bool, true)
+  }))
+  default = []
+}
+
+variable "api_protection_rules" {
+  description = "api_protection_rules: list of {path, domain_mode any|specific, domain, methods, action allow|deny}."
+  type = list(object({
+    path        = string
+    domain_mode = optional(string, "any")
+    domain      = optional(string)
+    methods     = optional(list(string), ["ANY"])
+    action      = optional(string, "allow")
+  }))
+  default = []
+}
+
+variable "validation_custom_rules" {
+  description = "validation_custom_list.open_api_validation_rules: list of {path, methods, action block|report|skip}."
+  type = list(object({
+    path    = string
+    methods = optional(list(string), ["ANY"])
+    action  = optional(string, "report")
+  }))
+  default = []
+}

--- a/terraform/variables_api_protection.tf
+++ b/terraform/variables_api_protection.tf
@@ -44,12 +44,6 @@ variable "rate_limit_burst_multiplier" {
   default     = 1
 }
 
-variable "sensitive_data_policy_enabled" {
-  description = "Create a standalone xcsh_sensitive_data_policy."
-  type        = bool
-  default     = false
-}
-
 variable "sensitive_data_compliances" {
   description = "Compliance frameworks on the sensitive_data_policy."
   type        = list(string)

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -6,14 +6,16 @@ terraform {
   required_providers {
     xcsh = {
       source = "f5-sales-demo/xcsh"
-      # >= 3.71.2: carries the object-ref tenant reconstruction fix (#1091, PR
-      # #1092) — object-refs at any nesting depth (LB api_specification.
-      # api_definition, enable_api_discovery...code_base_integrations[], and the
-      # standalone code_base_integration/api_definition refs) keep their Computed
-      # `tenant` from surviving apply, so SP2's LB wiring plans clean. Builds on
-      # 3.71.1's nested-list value-conversion fix (#1083) for the inline
-      # api_crawler domains. Locally consumed via dev_overrides.
-      version = ">= 3.71.2"
+      # >= 3.71.3: SP3 API-Protection read-back fix (provider #1095, PR #1096).
+      # api_protection_rules / validation_custom_list with a concrete client_matcher
+      # arm (ip_prefix / ip_threat) previously failed apply ("inconsistent result":
+      # server-echoed client_matcher.any_client{} + api_endpoint_method.invert_matcher)
+      # and drifted on import (any_client / any_ip / skip_response_validation server-
+      # default oneof base markers). 3.71.3 threads prior-state into reconstructed
+      # spine blocks + nested-list elements and suppresses those markers on import, so
+      # the SP3 matrix is 13/13 idempotent + round-trip-import clean. Builds on 3.71.2's
+      # object-ref tenant reconstruction (#1091). Locally consumed via dev_overrides.
+      version = ">= 3.71.3"
     }
     # Azure providers: this plan also deploys its OWN Azure origin server and
     # traffic generator (modules/origin-server, modules/traffic-generator), which

--- a/tests/test_api_protection_pairs.py
+++ b/tests/test_api_protection_pairs.py
@@ -1,0 +1,62 @@
+"""Unit tests for the API Protection (SP3) all-pairs generator."""
+
+import json
+from typing import Any, cast
+
+from api_protection_pairs import DIMENSIONS, all_pairs, build, payloads
+
+
+def test_covers_all_pairs() -> None:
+    """Every unordered pair of option-values co-occurs in at least one row."""
+    rows = all_pairs(DIMENSIONS)
+    names = list(DIMENSIONS)
+    required: set[tuple[str, str, str, str]] = set()
+    for i, ka in enumerate(names):
+        for kb in names[i + 1 :]:
+            for va in DIMENSIONS[ka]:
+                for vb in DIMENSIONS[kb]:
+                    required.add((ka, va, kb, vb))
+    covered: set[tuple[str, str, str, str]] = set()
+    for row in rows:
+        for i, ka in enumerate(names):
+            for kb in names[i + 1 :]:
+                covered.add((ka, row[ka], kb, row[kb]))
+    assert required <= covered
+
+
+def test_deterministic() -> None:
+    """The manifest is byte-stable across runs (no RNG)."""
+    assert build() == build()
+
+
+def test_dedup_no_identical_payloads() -> None:
+    """Emitted variant payloads are unique (constraint reconciliation is deduped)."""
+    keys = [
+        json.dumps(cast("dict[str, Any]", v["vars"]), sort_keys=True) for v in build()
+    ]
+    assert len(keys) == len(set(keys))
+
+
+def test_custom_list_validation_covered() -> None:
+    """At least one variant exercises the validation_custom_list arm."""
+    assert any(
+        cast("dict[str, Any]", v["vars"]).get("api_specification_validation")
+        == "custom_list"
+        for v in build()
+    )
+
+
+def test_canonical_restore_is_last_and_off() -> None:
+    """The final variant restores canonical (all SP3 off)."""
+    last = build()[-1]
+    assert last["name"] == "canonical-restore"
+    variant_vars = cast("dict[str, Any]", last["vars"])
+    assert variant_vars["rate_limit_choice"] == "disable"
+    assert variant_vars["api_definition_choice"] == "disable"
+
+
+def test_payloads_reconciles_api_protection_action() -> None:
+    """api_protection allow/deny maps to a single rule with that action."""
+    out = payloads({"api_protection": "deny", "client_matcher": "any"})
+    rules = cast("list[dict[str, Any]]", out["api_protection_rules"])
+    assert rules[0]["action"] == "deny"


### PR DESCRIPTION
## Summary

SP3 — **API Protection** for the `webapp-api-protection` HTTP LoadBalancer module, delivering four capability areas plus a shared client-matcher, exhaustively parameterized, plan-tested, and live-verified all-pairs against the f5-sales-demo staging tenant.

Closes #41.

## What's delivered

1. **Rate limiting** — `rate_limit_choice` (`disable` server default | `rate_limit` inline request rate limiter: total/unit/period/burst, `no_ip_allowed_list` + `no_policies`).
2. **Sensitive data & data guard** — `sensitive_data_policy_choice` (`default` suppressed | `custom` → standalone `xcsh_sensitive_data_policy` with `compliances` + `disabled_predefined_data_types`); `data_guard_rules[]` (domain any/exact/suffix + path + apply).
3. **API protection rules** — `api_protection_rules.api_endpoint_rules[]` (path, domain any/specific, methods, action allow/deny) scoped by the shared client-matcher.
4. **OpenAPI validation rules** (SP2 deferral) — `api_specification_validation += custom_list` → `validation_custom_list` (per-endpoint skip/block/report + fall-through allow).

Plus a **shared client-matcher** (`var.client_matcher` + `local.rendered_client_matcher`: any / ip_prefix / ip_threat), reused DRY by api_protection_rules.

## Testing

- **18 plan-tests** (`terraform/tests/api_protection.tftest.hcl`) — all pass.
- **6 generator unit tests** (`tests/test_api_protection_pairs.py`) — AETG all-pairs coverage, determinism, dedup.
- **Live all-pairs matrix** (`scripts/api-protection-matrix.sh`, 12 variants + canonical restore): **13/13 idempotent + round-trip-import clean** against staging.

## Lock-step provider fix (xcsh v3.71.3)

The live matrix surfaced a provider read-back gap: `api_protection_rules` / `validation_custom_list` with a concrete `client_matcher` arm failed apply (`inconsistent result`: server-echoed `any_client`/`invert_matcher`) and drifted on import (`any_client` / `any_ip` / `skip_response_validation` server-default oneof base markers). Fixed in `terraform-provider-xcsh` (#1095 / PR #1096, released **v3.71.3**): thread prior-state into reconstructed spine blocks + nested-list elements, and suppress those markers on import. `versions.tf` requires `>= 3.71.3`.

## Note

Deferred (YAGNI, documented in the plan): standalone `xcsh_rate_limiter_policy`/`xcsh_rate_limiter`, `api_rate_limit`, deep client-matcher arms (asn/tls/label-selector), `sensitive_data_disclosure_rules`, `custom_data_types`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)