### PR TITLE
SP4: API Testing (xcsh_api_testing standalone + LB api_testing_choice, credentials + schedule)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # webapp-api-protection developer targets.
 
-.PHONY: mud-matrix mud-verify waf-matrix api-discovery-matrix api-definition-matrix api-protection-matrix api-crawl-verify test
+.PHONY: mud-matrix mud-verify waf-matrix api-discovery-matrix api-definition-matrix api-protection-matrix api-testing-matrix api-crawl-verify test
 
 # Run the plan-level test suite (no tenant contact).
 test:
@@ -47,6 +47,16 @@ api-definition-matrix:
 # See scripts/api_protection_pairs.py (generator) and scripts/api-protection-matrix.sh.
 api-protection-matrix:
 	bash scripts/api-protection-matrix.sh
+
+# Cycle the live LB through the API Testing (SP4) all-pairs variant set (standalone
+# xcsh_api_testing + schedule + LB api_testing_choice, 5-arm credential auth) and
+# verify apply / idempotency / round-trip import (re-applying the write-only
+# credential secret on import; blindfold secret = SKIP on the platform 500).
+# Runs in batches: `make api-testing-matrix` (all) or
+# `bash scripts/api-testing-matrix.sh START END`. See scripts/api_testing_pairs.py
+# (generator) and scripts/api-testing-matrix.sh (harness).
+api-testing-matrix:
+	bash scripts/api-testing-matrix.sh
 
 # Staged blindfold verification: seal round-trip (a pre-sealed crawler credential
 # applies + is idempotent + import-clean) plus an authenticated-crawl attempt

--- a/scripts/api-testing-matrix.sh
+++ b/scripts/api-testing-matrix.sh
@@ -32,8 +32,9 @@ trap 'rm -rf /tmp/apitest-variants 2>/dev/null; rm -f /tmp/apitest-*.log /tmp/ap
 cd "$(dirname "$0")/../terraform" || exit 1
 ARM_ACCESS_KEY=$(az storage account keys list -n f5salesdemotfstate -g f5-sales-demo-tfstate --query "[0].value" -o tsv)
 export ARM_ACCESS_KEY
-# Throwaway secret for API-testing credentials (dev env). Not a real credential.
-export API_TEST_SECRET="${API_TEST_SECRET:-sp4-matrix-probe-$RANDOM}"
+# Throwaway secret for API-testing credentials (dev env). Not a real credential, but
+# generated from a CSPRNG (not $RANDOM) so it is high-entropy either way.
+export API_TEST_SECRET="${API_TEST_SECRET:-$(python3 -c 'import secrets; print("sp4-" + secrets.token_urlsafe(24))')}"
 
 NS="webapp-api-protection"
 LB_ADDR="module.http_lb.xcsh_http_loadbalancer.this"

--- a/scripts/api-testing-matrix.sh
+++ b/scripts/api-testing-matrix.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# API Testing (SP4) live coverage-matrix harness.
+#
+# Cycles the LIVE webapp-api-protection LB through the api_testing_pairs variant set
+# and verifies each variant (a) applies, (b) is idempotent (immediate plan = No
+# changes), and (c) is round-trip-import clean for the LB and, when present, the
+# standalone xcsh_api_testing resource. Ends on canonical-restore so the live LB is
+# left healthy (API testing off). Results append to reports/api-testing-matrix.txt.
+#
+# Secret injection (never committed): the manifest carries only placeholders.
+#  - clear credential secret (__TEST_SECRET__) <- $API_TEST_SECRET (env, throwaway).
+#  - blindfold credential secret (__BF_LOCATION__) <- sealed ONCE via blindfold-seal.sh.
+# Secrets are written via jq using env.* (never argv — a positional --arg is visible
+# in /proc/<pid>/cmdline to any local user).
+#
+# Manifest flags:
+#  LIVE   - admin/standard credential (no write-only secret): must import 0-change.
+#  SECRET - clear api_key/basic_auth/bearer_token: F5 XC never returns the secret on
+#           read, so import cannot recover it — re-apply after import to re-set it,
+#           then require a clean plan (write-only-secret gate).
+#  SKIP:* - blindfold credential: attempted live; a 500 / not-supported / entitlement
+#           response is recorded SKIP (documented platform limitation, cf. SP1/SP2),
+#           NOT a FAIL. A 400 BAD_REQUEST is a real FAIL.
+# Sequential — no concurrent terraform against the shared azurerm state.
+#
+# Usage: api-testing-matrix.sh [START [END]]  (inclusive 0-based index range).
+set -uo pipefail
+
+umask 077
+trap 'rm -rf /tmp/apitest-variants 2>/dev/null; rm -f /tmp/apitest-*.log /tmp/apitest-*.json /tmp/apitest-bf.loc 2>/dev/null' EXIT
+
+cd "$(dirname "$0")/../terraform" || exit 1
+ARM_ACCESS_KEY=$(az storage account keys list -n f5salesdemotfstate -g f5-sales-demo-tfstate --query "[0].value" -o tsv)
+export ARM_ACCESS_KEY
+# Throwaway secret for API-testing credentials (dev env). Not a real credential.
+export API_TEST_SECRET="${API_TEST_SECRET:-sp4-matrix-probe-$RANDOM}"
+
+NS="webapp-api-protection"
+LB_ADDR="module.http_lb.xcsh_http_loadbalancer.this"
+LB_ID="${NS}/${NS}"
+AT_ADDR="module.http_lb.xcsh_api_testing.this[0]"
+AT_ID="${NS}/${NS}-api-testing"
+COMMON=(-input=false -lock=true
+  -var 'lb_domains=["www.f5-sales-demo.com","api.f5-sales-demo.com"]'
+  -var 'subscription_id=75f86c46-9cbc-4f6c-85ea-195e3d3c8ac0')
+VARDIR=/tmp/apitest-variants
+REPORT=../reports/api-testing-matrix.txt
+mkdir -p ../reports
+
+START="${1:-0}"
+END="${2:-9999}"
+GATED_RE='not supported|not enabled|not entitled|entitlement|status: 500|internal error|InternalError'
+
+[ "$#" -eq 0 ] && : >"$REPORT"
+
+count=$(python3 ../scripts/api_testing_pairs.py --emit "$VARDIR")
+echo "generated $count variants into $VARDIR (running [$START..$END])"
+
+# Seal a throwaway blindfold value ONCE (non-deterministic — re-sealing per variant
+# would drift). Persisted to a sentinel file (prep_varfile runs in a subshell).
+BF_LOC_FILE=/tmp/apitest-bf.loc
+seal_once() {
+  [ -s "$BF_LOC_FILE" ] && return 0
+  printf '%s' "$API_TEST_SECRET" | ../scripts/blindfold-seal.sh 2>/dev/null >"$BF_LOC_FILE"
+  [ -s "$BF_LOC_FILE" ]
+}
+
+# Inject live secret values into a variant's credentials; print the var-file to use.
+prep_varfile() {
+  local vf="$1" out="${1%.json}.live.json"
+  cp "$vf" "$out"
+  if grep -q '"method": "clear"' "$out"; then
+    jq '.api_testing_domains |= map(.credentials |= map(
+          if .secret.method == "clear" then .secret.plaintext = env.API_TEST_SECRET else . end))' \
+      "$out" >"${out}.tmp" && mv "${out}.tmp" "$out"
+  fi
+  if grep -q '"method": "blindfold"' "$out"; then
+    seal_once || return 1
+    jq --arg loc "$(cat "$BF_LOC_FILE")" '.api_testing_domains |= map(.credentials |= map(
+          if .secret.method == "blindfold" then .secret.location = $loc else . end))' \
+      "$out" >"${out}.tmp" && mv "${out}.tmp" "$out"
+  fi
+  echo "$out"
+}
+
+import_one() {
+  local addr="$1" id="$2" vf="$3" label="$4"
+  terraform state list 2>/dev/null | grep -qxF "$addr" || return 0
+  terraform state rm "$addr" >/dev/null 2>&1 || return 0
+  terraform import "${COMMON[@]}" -var-file="$vf" "$addr" "$id" >>/tmp/apitest-import.log 2>&1 || {
+    echo "FAIL $label import($addr)" >>"$REPORT"
+    return 1
+  }
+}
+
+round_trip() {
+  local label="$1" vf="$2" flag="$3"
+  terraform state rm "$LB_ADDR" >/dev/null 2>&1 || {
+    echo "FAIL $label lb-state-rm" >>"$REPORT"
+    return
+  }
+  terraform import "${COMMON[@]}" -var-file="$vf" "$LB_ADDR" "$LB_ID" >/tmp/apitest-import.log 2>&1 || {
+    echo "FAIL $label lb-import" >>"$REPORT"
+    return
+  }
+  import_one "$AT_ADDR" "$AT_ID" "$vf" "$label" || return
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$vf" >/tmp/apitest-rt-plan.log 2>&1
+  case $? in
+  0) echo "PASS $label" >>"$REPORT" ;;
+  2)
+    # SECRET variants carry a write-only credential secret import cannot recover —
+    # re-apply to re-set it, then require a clean plan. Others must import clean.
+    if [ "$flag" = "SECRET" ]; then
+      terraform apply -auto-approve "${COMMON[@]}" -var-file="$vf" >/tmp/apitest-rt-apply.log 2>&1
+      terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$vf" >/tmp/apitest-rt-plan2.log 2>&1
+      case $? in
+      0) echo "PASS $label (import re-set write-only secret)" >>"$REPORT" ;;
+      2) echo "FAIL $label import-drift" >>"$REPORT" ;;
+      *) echo "FAIL $label rt-plan-error" >>"$REPORT" ;;
+      esac
+    else
+      echo "FAIL $label import-drift (no-secret variant must import clean)" >>"$REPORT"
+    fi
+    ;;
+  *) echo "FAIL $label rt-plan-error" >>"$REPORT" ;;
+  esac
+}
+
+while read -r idx name vf flag; do
+  [ "$idx" -lt "$START" ] && continue
+  [ "$idx" -gt "$END" ] && continue
+  label="$idx-$name"
+  echo "--- $label ($flag) ---"
+  varfile=$(prep_varfile "${VARDIR}/${vf}") || {
+    echo "FAIL $label prep (seal/inject)" >>"$REPORT"
+    continue
+  }
+  if ! terraform apply -auto-approve "${COMMON[@]}" -var-file="$varfile" >/tmp/apitest-apply.log 2>&1; then
+    # blindfold variants are expected to fail on the platform limitation -> SKIP.
+    if [[ "$flag" == SKIP:* ]] && grep -qiE "$GATED_RE" /tmp/apitest-apply.log; then
+      echo "SKIP $label ${flag#SKIP:} ($(grep -oiE "$GATED_RE" /tmp/apitest-apply.log | head -1))" >>"$REPORT"
+    else
+      echo "FAIL $label apply ($(grep -iE 'error' /tmp/apitest-apply.log | head -1 | cut -c1-80))" >>"$REPORT"
+    fi
+    continue
+  fi
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$varfile" >/tmp/apitest-plan.log 2>&1
+  case $? in
+  0) round_trip "$label" "$varfile" "$flag" ;;
+  2) echo "FAIL $label not-idempotent" >>"$REPORT" ;;
+  *) echo "FAIL $label plan-error" >>"$REPORT" ;;
+  esac
+done <"${VARDIR}/manifest.txt"
+
+echo "===== API TESTING MATRIX RESULTS ($START..$END) ====="
+cat "$REPORT"
+echo "PASS=$(grep -c '^PASS ' "$REPORT") FAIL=$(grep -c '^FAIL ' "$REPORT") SKIP=$(grep -c '^SKIP ' "$REPORT")"

--- a/scripts/api_testing_pairs.py
+++ b/scripts/api_testing_pairs.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Generate the API Testing (SP4) coverage matrix.
+
+Coverage model (see docs/superpowers/specs/2026-07-14-sp4-api-testing-design.md):
+  * all-pairs (pairwise, AETG greedy) over the SP4 dimensions, so every pair of
+    option-values co-occurs in at least one variant;
+  * PLUS the canonical restore end state (API testing off).
+
+Pairwise dimensions:
+  surface   lb | standalone | both   -> api_testing_choice + api_testing_standalone_enabled
+  auth      admin | standard | api_key | basic_auth | bearer_token  (per credential)
+  secret    clear | blindfold        (only for api_key/basic_auth/bearer_token)
+  schedule  every_week | every_day | every_month  (standalone surfaces only)
+
+Secret values are NEVER in the manifest — the harness injects them (placeholders
+below), exactly as the SP1/SP2 matrices inject sealed/clear secrets. Manifest flag:
+  LIVE   - no write-only secret (admin/standard): must import 0-change.
+  SECRET - clear api_key/basic_auth/bearer_token: F5 XC never returns the secret on
+           read, so the harness re-applies after import to re-set it, then requires a
+           clean plan (write-only-secret gate).
+  SKIP:<reason> - blindfold secret: F5 XC 500s on offline-sealed API-testing secrets
+           (same platform limitation as SP1 crawler / SP2 access_token); plan-tested only.
+
+payloads() reconciles module constraints so every emitted variant is a valid root
+config, and dedups byte-identical payloads. Deterministic (no RNG).
+
+Output: JSON array of {"name","vars","flag"} to stdout, or files via --emit.
+"""
+
+import itertools
+import json
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+DIMENSIONS = {
+    "surface": ["lb", "standalone", "both"],
+    "auth": ["admin", "standard", "api_key", "basic_auth", "bearer_token"],
+    "secret": ["clear", "blindfold"],
+    "schedule": ["every_week", "every_day", "every_month"],
+}
+
+CLEAR_VALUE_MARKER = "__TEST_SECRET__"  # clear plaintext, injected from env
+BF_PLACEHOLDER = "__BF_LOCATION__"  # blindfold sealed location, injected
+SECRET_ARMS = ("api_key", "basic_auth", "bearer_token")
+
+
+def _best_value(
+    values: list[str],
+    idx: int,
+    row: dict[int, str],
+    uncovered: set[tuple[int, str, int, str]],
+) -> str:
+    """Pick the value for dimension idx covering the most still-uncovered pairs."""
+    best_val, best_gain = values[0], -1
+    for val in values:
+        gain = 0
+        for pidx, pval in row.items():
+            a, b = sorted([(pidx, pval), (idx, val)])
+            if (a[0], a[1], b[0], b[1]) in uncovered:
+                gain += 1
+        if gain > best_gain:
+            best_gain, best_val = gain, val
+    return best_val
+
+
+def all_pairs(dims: dict[str, list[str]]) -> list[dict[str, str]]:
+    """Return AETG-style greedy all-pairs rows ({dim: value})."""
+    names = list(dims)
+    uncovered: set[tuple[int, str, int, str]] = set()
+    for i, j in itertools.combinations(range(len(names)), 2):
+        for vi in dims[names[i]]:
+            for vj in dims[names[j]]:
+                uncovered.add((i, vi, j, vj))
+
+    rows = []
+    while uncovered:
+        si, sv, sj, sv2 = min(uncovered)
+        row = {si: sv, sj: sv2}
+        for idx, name in enumerate(names):
+            if idx not in row:
+                row[idx] = _best_value(dims[name], idx, row, uncovered)
+        for i, j in itertools.combinations(sorted(row), 2):
+            uncovered.discard((i, row[i], j, row[j]))
+        rows.append({names[k]: v for k, v in row.items()})
+    return rows
+
+
+def payloads(v: Mapping[str, object]) -> tuple[dict[str, object], str]:
+    """Expand a pairwise row into real tfvars + the manifest flag."""
+    out: dict[str, object] = {}
+    surface = v.get("surface")
+    auth = v.get("auth")
+    method_sel = v.get("secret")
+
+    out["api_testing_choice"] = "enabled" if surface in ("lb", "both") else "disable"
+    out["api_testing_standalone_enabled"] = surface in ("standalone", "both")
+
+    # schedule only observable on a standalone surface; canonicalize otherwise so
+    # (schedule x lb-only) rows dedup instead of emitting redundant variants.
+    if surface in ("standalone", "both"):
+        out["api_testing_schedule"] = v.get("schedule")
+
+    cred: dict[str, object] = {"credential_name": f"c-{auth}", "auth_type": auth}
+    flag = "LIVE"
+    if auth == "api_key":
+        cred["api_key_name"] = "X-API-Key"
+    if auth == "basic_auth":
+        cred["user"] = "tester"
+    if auth in SECRET_ARMS:
+        if method_sel == "blindfold":
+            cred["secret"] = {"method": "blindfold", "location": BF_PLACEHOLDER}
+            flag = "SKIP:blindfold API-testing secret 500s on F5 XC (platform limitation); clear is the live path"
+        else:
+            cred["secret"] = {"method": "clear", "plaintext": CLEAR_VALUE_MARKER}
+            flag = "SECRET"
+
+    out["api_testing_domains"] = [
+        {"domain": "api.f5-sales-demo.com", "credentials": [cred]}
+    ]
+    return out, flag
+
+
+def canonical() -> dict[str, object]:
+    """Return the live-canonical end state (API testing off)."""
+    return {"api_testing_choice": "disable", "api_testing_standalone_enabled": False}
+
+
+def build() -> list[dict[str, object]]:
+    """Build the ordered variant manifest (all-pairs + canonical restore), deduped."""
+    variants: list[dict[str, object]] = []
+    seen: set[str] = set()
+    idx = 0
+    for row in all_pairs(DIMENSIONS):
+        vars_, flag = payloads(row)
+        key = json.dumps(vars_, sort_keys=True)
+        if key in seen:
+            continue
+        seen.add(key)
+        variants.append({"name": f"pair-{idx:03d}", "vars": vars_, "flag": flag})
+        idx += 1
+    variants.append({"name": "canonical-restore", "vars": canonical(), "flag": "LIVE"})
+    return variants
+
+
+def emit(directory: str) -> int:
+    """Write one <NNN>-<name>.tfvars.json per variant plus manifest.txt."""
+    out_dir = Path(directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for existing in out_dir.iterdir():
+        if existing.name.endswith(".tfvars.json") or existing.name == "manifest.txt":
+            existing.unlink()
+    variants = build()
+    named = [(f"{i:03d}-{v['name']}.tfvars.json", v) for i, v in enumerate(variants)]
+    for fname, v in named:
+        (out_dir / fname).write_text(json.dumps(v["vars"], indent=2) + "\n")
+    lines = [
+        f"{i:03d} {v['name']} {fname} {v['flag']}" for i, (fname, v) in enumerate(named)
+    ]
+    (out_dir / "manifest.txt").write_text("\n".join(lines) + "\n")
+    return len(variants)
+
+
+def main(argv: list[str]) -> None:
+    """CLI: --count, --emit <dir>, else JSON to stdout."""
+    match argv[1:]:
+        case ["--count"]:
+            sys.stdout.write(f"{len(build())}\n")
+        case ["--emit", directory]:
+            sys.stdout.write(f"{emit(directory)}\n")
+        case _:
+            json.dump(build(), sys.stdout, indent=2)
+            sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/scripts/api_testing_pairs.py
+++ b/scripts/api_testing_pairs.py
@@ -8,18 +8,20 @@ Coverage model (see docs/superpowers/specs/2026-07-14-sp4-api-testing-design.md)
 
 Pairwise dimensions:
   surface   lb | standalone | both   -> api_testing_choice + api_testing_standalone_enabled
-  auth      admin | standard | api_key | basic_auth | bearer_token  (per credential)
-  secret    clear | blindfold        (only for api_key/basic_auth/bearer_token)
+  auth      api_key | basic_auth | bearer_token  (the only valid F5 XC credentials_choice
+            members — verified live; admin/standard 400 and are excluded)
+  secret    clear | blindfold        (every credential carries a SecretType)
   schedule  every_week | every_day | every_month  (standalone surfaces only)
 
-Secret values are NEVER in the manifest — the harness injects them (placeholders
-below), exactly as the SP1/SP2 matrices inject sealed/clear secrets. Manifest flag:
-  LIVE   - no write-only secret (admin/standard): must import 0-change.
-  SECRET - clear api_key/basic_auth/bearer_token: F5 XC never returns the secret on
-           read, so the harness re-applies after import to re-set it, then requires a
-           clean plan (write-only-secret gate).
+Every domain requires >=1 credential (a credential-less domain 500s), and every
+credential carries a write-only secret. Secret values are NEVER in the manifest — the
+harness injects them (placeholders below). Manifest flag:
+  SECRET - clear secret: F5 XC never returns the secret on read, so the harness
+           re-applies after import to re-set it, then requires a clean plan.
   SKIP:<reason> - blindfold secret: F5 XC 500s on offline-sealed API-testing secrets
-           (same platform limitation as SP1 crawler / SP2 access_token); plan-tested only.
+           (same platform limitation as SP1 crawler / SP2 access_token); attempted
+           live, recorded SKIP on the 500.
+  LIVE   - canonical-restore only (API testing off; secret-free).
 
 payloads() reconciles module constraints so every emitted variant is a valid root
 config, and dedups byte-identical payloads. Deterministic (no RNG).
@@ -35,14 +37,13 @@ from pathlib import Path
 
 DIMENSIONS = {
     "surface": ["lb", "standalone", "both"],
-    "auth": ["admin", "standard", "api_key", "basic_auth", "bearer_token"],
+    "auth": ["api_key", "basic_auth", "bearer_token"],
     "secret": ["clear", "blindfold"],
     "schedule": ["every_week", "every_day", "every_month"],
 }
 
 CLEAR_VALUE_MARKER = "__TEST_SECRET__"  # clear plaintext, injected from env
 BF_PLACEHOLDER = "__BF_LOCATION__"  # blindfold sealed location, injected
-SECRET_ARMS = ("api_key", "basic_auth", "bearer_token")
 
 
 def _best_value(
@@ -102,18 +103,16 @@ def payloads(v: Mapping[str, object]) -> tuple[dict[str, object], str]:
         out["api_testing_schedule"] = v.get("schedule")
 
     cred: dict[str, object] = {"credential_name": f"c-{auth}", "auth_type": auth}
-    flag = "LIVE"
     if auth == "api_key":
         cred["api_key_name"] = "X-API-Key"
     if auth == "basic_auth":
         cred["user"] = "tester"
-    if auth in SECRET_ARMS:
-        if method_sel == "blindfold":
-            cred["secret"] = {"method": "blindfold", "location": BF_PLACEHOLDER}
-            flag = "SKIP:blindfold API-testing secret 500s on F5 XC (platform limitation); clear is the live path"
-        else:
-            cred["secret"] = {"method": "clear", "plaintext": CLEAR_VALUE_MARKER}
-            flag = "SECRET"
+    if method_sel == "blindfold":
+        cred["secret"] = {"method": "blindfold", "location": BF_PLACEHOLDER}
+        flag = "SKIP:blindfold API-testing secret 500s on F5 XC (platform limitation); clear is the live path"
+    else:
+        cred["secret"] = {"method": "clear", "plaintext": CLEAR_VALUE_MARKER}
+        flag = "SECRET"
 
     out["api_testing_domains"] = [
         {"domain": "api.f5-sales-demo.com", "credentials": [cred]}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -133,6 +133,14 @@ module "http_lb" {
   api_protection_rules               = var.api_protection_rules
   validation_custom_rules            = var.validation_custom_rules
 
+  # API Testing (SP4) passthrough. Defaults keep it off (disable_api_testing
+  # suppressed => 0-change) and create no standalone resource.
+  api_testing_choice              = var.api_testing_choice
+  api_testing_standalone_enabled  = var.api_testing_standalone_enabled
+  api_testing_schedule            = var.api_testing_schedule
+  api_testing_custom_header_value = var.api_testing_custom_header_value
+  api_testing_domains             = var.api_testing_domains
+
   # Enabling client_side_defense on the LB requires a protected domain to already
   # exist in this namespace (F5 XC generates the CSD JS config from it), so the
   # LB must be created/updated AFTER the protected domain. The MUD entitlement

--- a/terraform/modules/http-lb/api_testing.tf
+++ b/terraform/modules/http-lb/api_testing.tf
@@ -1,0 +1,100 @@
+# xcsh_api_testing (SP4) — standalone scheduled API-testing config. Created iff
+# api_testing_standalone_enabled (single knob). Consumes local.rendered_api_testing
+# (shared with the LB inline api_testing block, DRY). Schedule is a flat top-level
+# oneof; every_week is the suppressed server default (emit neither marker for it).
+# Credentials carry the clear/blindfold SecretType (seal-once-pin — see locals_api.tf).
+resource "xcsh_api_testing" "this" {
+  count     = var.api_testing_standalone_enabled ? 1 : 0
+  name      = "${var.namespace}-api-testing"
+  namespace = var.namespace
+
+  custom_header_value = var.api_testing_custom_header_value
+
+  dynamic "domains" {
+    for_each = local.rendered_api_testing
+    content {
+      domain                    = domains.value.domain
+      allow_destructive_methods = domains.value.allow_destructive_methods
+
+      dynamic "credentials" {
+        for_each = domains.value.credentials
+        content {
+          credential_name = credentials.value.credential_name
+
+          dynamic "admin" {
+            for_each = credentials.value.use_admin ? [1] : []
+            content {}
+          }
+          dynamic "standard" {
+            for_each = credentials.value.use_standard ? [1] : []
+            content {}
+          }
+          dynamic "api_key" {
+            for_each = credentials.value.use_api_key ? [1] : []
+            content {
+              key = credentials.value.api_key_name
+              value {
+                dynamic "blindfold_secret_info" {
+                  for_each = credentials.value.secret_use_blindfold ? [1] : []
+                  content { location = credentials.value.secret_location }
+                }
+                dynamic "clear_secret_info" {
+                  for_each = credentials.value.secret_use_blindfold ? [] : [1]
+                  content { url = credentials.value.secret_url }
+                }
+              }
+            }
+          }
+          dynamic "basic_auth" {
+            for_each = credentials.value.use_basic_auth ? [1] : []
+            content {
+              user = credentials.value.user
+              password {
+                dynamic "blindfold_secret_info" {
+                  for_each = credentials.value.secret_use_blindfold ? [1] : []
+                  content { location = credentials.value.secret_location }
+                }
+                dynamic "clear_secret_info" {
+                  for_each = credentials.value.secret_use_blindfold ? [] : [1]
+                  content { url = credentials.value.secret_url }
+                }
+              }
+            }
+          }
+          dynamic "bearer_token" {
+            for_each = credentials.value.use_bearer ? [1] : []
+            content {
+              token {
+                dynamic "blindfold_secret_info" {
+                  for_each = credentials.value.secret_use_blindfold ? [1] : []
+                  content { location = credentials.value.secret_location }
+                }
+                dynamic "clear_secret_info" {
+                  for_each = credentials.value.secret_use_blindfold ? [] : [1]
+                  content { url = credentials.value.secret_url }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  # Schedule oneof (every_week = suppressed default => emit neither marker).
+  dynamic "every_day" {
+    for_each = local.api_testing_use_every_day ? [1] : []
+    content {}
+  }
+  dynamic "every_month" {
+    for_each = local.api_testing_use_every_month ? [1] : []
+    content {}
+  }
+
+  lifecycle {
+    precondition {
+      condition     = length(var.api_testing_domains) > 0
+      error_message = "api_testing_standalone_enabled requires at least one api_testing_domains entry."
+    }
+  }
+}

--- a/terraform/modules/http-lb/api_testing.tf
+++ b/terraform/modules/http-lb/api_testing.tf
@@ -21,14 +21,6 @@ resource "xcsh_api_testing" "this" {
         content {
           credential_name = credentials.value.credential_name
 
-          dynamic "admin" {
-            for_each = credentials.value.use_admin ? [1] : []
-            content {}
-          }
-          dynamic "standard" {
-            for_each = credentials.value.use_standard ? [1] : []
-            content {}
-          }
           dynamic "api_key" {
             for_each = credentials.value.use_api_key ? [1] : []
             content {

--- a/terraform/modules/http-lb/locals_api_testing.tf
+++ b/terraform/modules/http-lb/locals_api_testing.tf
@@ -1,0 +1,38 @@
+# Rendered API Testing domains/credentials (SP4, DRY). Both surfaces (standalone
+# xcsh_api_testing + LB inline api_testing block) consume local.rendered_api_testing —
+# one transform that pre-computes each credential's auth-arm selectors and the
+# clear/blindfold SecretType shape (same seal-once-pin rule as locals_api.tf: the
+# blindfold `location` is a PRE-SEALED string:///... pinned offline, never computed
+# inline, so apply stays idempotent + import-clean).
+locals {
+  rendered_api_testing = [
+    for d in var.api_testing_domains : {
+      domain                    = d.domain
+      allow_destructive_methods = d.allow_destructive_methods
+      credentials = [
+        for c in d.credentials : {
+          credential_name = c.credential_name
+          use_admin       = c.auth_type == "admin"
+          use_standard    = c.auth_type == "standard"
+          use_api_key     = c.auth_type == "api_key"
+          use_basic_auth  = c.auth_type == "basic_auth"
+          use_bearer      = c.auth_type == "bearer_token"
+          api_key_name    = c.api_key_name
+          user            = c.user
+          # SecretType (api_key value / basic_auth password / bearer_token token):
+          # exactly one of url (clear) / location (blindfold) is non-null when present.
+          secret_use_blindfold = c.secret != null && try(c.secret.method, "clear") == "blindfold"
+          secret_url = (c.secret != null && try(c.secret.method, "clear") == "clear" && try(c.secret.plaintext, null) != null
+            ? "string:///${base64encode(c.secret.plaintext)}"
+          : null)
+          secret_location = c.secret != null && try(c.secret.method, "clear") == "blindfold" ? c.secret.location : null
+        }
+      ]
+    }
+  ]
+
+  # Schedule arm selectors (standalone only). every_week is the suppressed server
+  # default => emit NEITHER marker so a bare resource is import-clean.
+  api_testing_use_every_day   = var.api_testing_schedule == "every_day"
+  api_testing_use_every_month = var.api_testing_schedule == "every_month"
+}

--- a/terraform/modules/http-lb/locals_api_testing.tf
+++ b/terraform/modules/http-lb/locals_api_testing.tf
@@ -12,20 +12,16 @@ locals {
       credentials = [
         for c in d.credentials : {
           credential_name = c.credential_name
-          use_admin       = c.auth_type == "admin"
-          use_standard    = c.auth_type == "standard"
           use_api_key     = c.auth_type == "api_key"
           use_basic_auth  = c.auth_type == "basic_auth"
           use_bearer      = c.auth_type == "bearer_token"
           api_key_name    = c.api_key_name
           user            = c.user
           # SecretType (api_key value / basic_auth password / bearer_token token):
-          # exactly one of url (clear) / location (blindfold) is non-null when present.
-          secret_use_blindfold = c.secret != null && try(c.secret.method, "clear") == "blindfold"
-          secret_url = (c.secret != null && try(c.secret.method, "clear") == "clear" && try(c.secret.plaintext, null) != null
-            ? "string:///${base64encode(c.secret.plaintext)}"
-          : null)
-          secret_location = c.secret != null && try(c.secret.method, "clear") == "blindfold" ? c.secret.location : null
+          # exactly one of url (clear) / location (blindfold) is non-null.
+          secret_use_blindfold = c.secret.method == "blindfold"
+          secret_url           = c.secret.method == "clear" ? "string:///${base64encode(c.secret.plaintext)}" : null
+          secret_location      = c.secret.method == "blindfold" ? c.secret.location : null
         }
       ]
     }

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -936,5 +936,15 @@ resource "xcsh_http_loadbalancer" "this" {
       condition     = var.api_discovery_code_scan != "selected" || length(var.api_discovery_code_scan_repos) > 0
       error_message = "api_discovery_code_scan=\"selected\" requires api_discovery_code_scan_repos to be non-empty."
     }
+
+    # API testing (both surfaces) needs real domains — F5 XC rejects a domain with no
+    # credentials (500) and an api_testing block with no domains is meaningless. The
+    # standalone resource guards this in its own precondition; mirror it for the LB
+    # inline block so api_testing_choice="enabled" fails fast at plan (cross-variable,
+    # symmetric with the standalone path).
+    precondition {
+      condition     = var.api_testing_choice != "enabled" || length(var.api_testing_domains) > 0
+      error_message = "api_testing_choice=\"enabled\" requires at least one api_testing_domains entry."
+    }
   }
 }

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -797,14 +797,6 @@ resource "xcsh_http_loadbalancer" "this" {
             content {
               credential_name = credentials.value.credential_name
 
-              dynamic "admin" {
-                for_each = credentials.value.use_admin ? [1] : []
-                content {}
-              }
-              dynamic "standard" {
-                for_each = credentials.value.use_standard ? [1] : []
-                content {}
-              }
               dynamic "api_key" {
                 for_each = credentials.value.use_api_key ? [1] : []
                 content {

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -776,6 +776,89 @@ resource "xcsh_http_loadbalancer" "this" {
     }
   }
 
+  # API Testing (SP4) — LB api_testing_choice oneof: the inline api_testing block
+  # (scheduled/triggered API tests against domains with credentials) vs the server
+  # default disable_api_testing (import-suppressed => omit => 0-change). Shares the
+  # rendered domains/credentials with the standalone xcsh_api_testing resource (DRY);
+  # the LB surface carries no schedule. Emit only when api_testing_choice = "enabled".
+  dynamic "api_testing" {
+    for_each = var.api_testing_choice == "enabled" ? [1] : []
+    content {
+      custom_header_value = var.api_testing_custom_header_value
+
+      dynamic "domains" {
+        for_each = local.rendered_api_testing
+        content {
+          domain                    = domains.value.domain
+          allow_destructive_methods = domains.value.allow_destructive_methods
+
+          dynamic "credentials" {
+            for_each = domains.value.credentials
+            content {
+              credential_name = credentials.value.credential_name
+
+              dynamic "admin" {
+                for_each = credentials.value.use_admin ? [1] : []
+                content {}
+              }
+              dynamic "standard" {
+                for_each = credentials.value.use_standard ? [1] : []
+                content {}
+              }
+              dynamic "api_key" {
+                for_each = credentials.value.use_api_key ? [1] : []
+                content {
+                  key = credentials.value.api_key_name
+                  value {
+                    dynamic "blindfold_secret_info" {
+                      for_each = credentials.value.secret_use_blindfold ? [1] : []
+                      content { location = credentials.value.secret_location }
+                    }
+                    dynamic "clear_secret_info" {
+                      for_each = credentials.value.secret_use_blindfold ? [] : [1]
+                      content { url = credentials.value.secret_url }
+                    }
+                  }
+                }
+              }
+              dynamic "basic_auth" {
+                for_each = credentials.value.use_basic_auth ? [1] : []
+                content {
+                  user = credentials.value.user
+                  password {
+                    dynamic "blindfold_secret_info" {
+                      for_each = credentials.value.secret_use_blindfold ? [1] : []
+                      content { location = credentials.value.secret_location }
+                    }
+                    dynamic "clear_secret_info" {
+                      for_each = credentials.value.secret_use_blindfold ? [] : [1]
+                      content { url = credentials.value.secret_url }
+                    }
+                  }
+                }
+              }
+              dynamic "bearer_token" {
+                for_each = credentials.value.use_bearer ? [1] : []
+                content {
+                  token {
+                    dynamic "blindfold_secret_info" {
+                      for_each = credentials.value.secret_use_blindfold ? [1] : []
+                      content { location = credentials.value.secret_location }
+                    }
+                    dynamic "clear_secret_info" {
+                      for_each = credentials.value.secret_use_blindfold ? [] : [1]
+                      content { url = credentials.value.secret_url }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
   # Client-Side Defense — inject the F5 XC telemetry JavaScript into served pages
   # to detect Magecart/formjacking/skimming (client_side_defense oneof vs the
   # server default disable_client_side_defense). Requires the CSD tenant addon

--- a/terraform/modules/http-lb/outputs_api_testing.tf
+++ b/terraform/modules/http-lb/outputs_api_testing.tf
@@ -1,0 +1,25 @@
+# API Testing (SP4) outputs.
+output "api_testing_choice" {
+  description = "Effective LB api_testing_choice (disable | enabled)."
+  value       = var.api_testing_choice
+}
+
+output "api_testing_standalone_created" {
+  description = "Whether a standalone xcsh_api_testing resource is created."
+  value       = var.api_testing_standalone_enabled
+}
+
+output "api_testing_schedule" {
+  description = "Standalone api_testing schedule arm (every_week suppressed default | every_day | every_month)."
+  value       = var.api_testing_schedule
+}
+
+output "api_testing_domain_count" {
+  description = "Number of configured API-testing domains."
+  value       = nonsensitive(length(var.api_testing_domains))
+}
+
+output "api_testing_credential_count" {
+  description = "Total configured API-testing credentials across all domains."
+  value       = nonsensitive(length(var.api_testing_domains) == 0 ? 0 : sum([for d in var.api_testing_domains : length(d.credentials)]))
+}

--- a/terraform/modules/http-lb/variables_api_testing.tf
+++ b/terraform/modules/http-lb/variables_api_testing.tf
@@ -53,55 +53,51 @@ variable "api_testing_custom_header_value" {
 }
 
 # Shared testing domains + credentials, consumed by BOTH surfaces (DRY). Each
-# credential selects exactly one auth arm; the secret arms (api_key value /
-# basic_auth password / bearer_token token) carry a clear/blindfold SecretType.
-# allow_destructive_methods defaults false (destructive tests can DELETE data).
+# credential selects exactly one auth arm; every arm carries a clear/blindfold
+# SecretType. Verified live against the F5 XC api_testings API: credentials_choice =
+# {api_key, basic_auth, bearer_token} ONLY — the schema's `admin`/`standard` blocks
+# are NOT valid credentials_choice members (POST 400 "credentials_choice ... got
+# nil"), so they are excluded; and a domain with zero credentials 500s, so >=1
+# credential is required. allow_destructive_methods defaults false (can DELETE data).
 variable "api_testing_domains" {
-  description = "Testing domains: {domain, allow_destructive_methods, credentials[]}. credentials: {credential_name, auth_type admin|standard|api_key|basic_auth|bearer_token, api_key_name, user, secret {method,plaintext,location}}."
+  description = "Testing domains: {domain, allow_destructive_methods, credentials[]}. credentials: {credential_name, auth_type api_key|basic_auth|bearer_token, api_key_name, user, secret {method,plaintext,location}}. >=1 credential per domain."
   type = list(object({
     domain                    = string
     allow_destructive_methods = optional(bool, false)
-    credentials = optional(list(object({
+    credentials = list(object({
       credential_name = string
-      auth_type       = string           # admin | standard | api_key | basic_auth | bearer_token
+      auth_type       = string           # api_key | basic_auth | bearer_token
       api_key_name    = optional(string) # api_key: header/query key name
       user            = optional(string) # basic_auth: username
-      secret = optional(object({         # api_key value / basic_auth password / bearer_token token
+      secret = object({                  # api_key value / basic_auth password / bearer_token token
         method    = optional(string, "clear")
         plaintext = optional(string)
         location  = optional(string)
-      }))
-    })), [])
+      })
+    }))
   }))
   default   = []
   sensitive = true # credentials carry secret plaintext
 
   validation {
-    condition = alltrue(flatten([
-      for d in var.api_testing_domains : [
-        for c in d.credentials :
-        contains(["admin", "standard", "api_key", "basic_auth", "bearer_token"], c.auth_type)
-      ]
-    ]))
-    error_message = "each credential auth_type must be admin, standard, api_key, basic_auth, or bearer_token."
+    condition     = alltrue([for d in var.api_testing_domains : length(d.credentials) > 0])
+    error_message = "each api_testing_domains entry requires at least one credential (F5 XC rejects a domain with zero credentials)."
   }
 
   validation {
     condition = alltrue(flatten([
       for d in var.api_testing_domains : [
         for c in d.credentials :
-        # secret-bearing arms require a secret; marker arms (admin/standard) must not carry one
-        (contains(["api_key", "basic_auth", "bearer_token"], c.auth_type)) == (c.secret != null)
+        contains(["api_key", "basic_auth", "bearer_token"], c.auth_type)
       ]
     ]))
-    error_message = "api_key/basic_auth/bearer_token require a secret{}; admin/standard must omit it."
+    error_message = "each credential auth_type must be api_key, basic_auth, or bearer_token (admin/standard are not valid F5 XC credentials_choice members)."
   }
 
   validation {
     condition = alltrue(flatten([
       for d in var.api_testing_domains : [
-        for c in d.credentials :
-        c.secret == null || contains(["clear", "blindfold"], c.secret.method)
+        for c in d.credentials : contains(["clear", "blindfold"], c.secret.method)
       ]
     ]))
     error_message = "credential secret.method must be \"clear\" or \"blindfold\"."
@@ -111,10 +107,20 @@ variable "api_testing_domains" {
     condition = alltrue(flatten([
       for d in var.api_testing_domains : [
         for c in d.credentials :
-        c.secret == null || c.secret.method != "blindfold" || c.secret.location != null
+        c.secret.method != "blindfold" || c.secret.location != null
       ]
     ]))
     error_message = "blindfold credential secret requires a pre-sealed location (scripts/blindfold-seal.sh)."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for d in var.api_testing_domains : [
+        for c in d.credentials :
+        c.secret.method != "clear" || c.secret.plaintext != null
+      ]
+    ]))
+    error_message = "clear credential secret requires plaintext."
   }
 
   validation {

--- a/terraform/modules/http-lb/variables_api_testing.tf
+++ b/terraform/modules/http-lb/variables_api_testing.tf
@@ -1,0 +1,137 @@
+# ---------------------------------------------------------------------------
+# API Testing (SP4) — inputs. Two surfaces share one domains/credentials shape:
+#   * standalone xcsh_api_testing (api_testing_standalone_enabled) + schedule oneof
+#   * LB api_testing_choice inline api_testing block (vs suppressed disable_api_testing)
+# Defaults reproduce the current bare LB (disable_api_testing suppressed => 0-change)
+# and create no standalone resource. Credentials reuse the clear/blindfold SecretType
+# convention (variables_api.tf / locals_api.tf). See docs/superpowers (local).
+# ---------------------------------------------------------------------------
+
+# LB api_testing_choice oneof: "disable" (server default disable_api_testing,
+# import-suppressed => omit => 0-change) or "enabled" (inline api_testing block).
+variable "api_testing_choice" {
+  description = "LB api_testing_choice: disable (suppressed server default) or enabled (inline api_testing block)."
+  type        = string
+  default     = "disable"
+
+  validation {
+    condition     = contains(["disable", "enabled"], var.api_testing_choice)
+    error_message = "api_testing_choice must be \"disable\" or \"enabled\"."
+  }
+}
+
+# Gate the standalone xcsh_api_testing resource (single knob: count derives from this,
+# no separate reference selector to desync — cf. SP3 sensitive-data review lesson).
+variable "api_testing_standalone_enabled" {
+  description = "Create a standalone xcsh_api_testing resource (scheduled API tests) in addition to / instead of the LB inline block."
+  type        = bool
+  default     = false
+}
+
+# Standalone schedule oneof. "every_week" is the server default (import-suppressed =>
+# omit); "every_day"/"every_month" are explicit non-default choices.
+variable "api_testing_schedule" {
+  description = "Standalone xcsh_api_testing run schedule: every_week (suppressed default) | every_day | every_month."
+  type        = string
+  default     = "every_week"
+
+  validation {
+    condition     = contains(["every_week", "every_day", "every_month"], var.api_testing_schedule)
+    error_message = "api_testing_schedule must be every_week, every_day, or every_month."
+  }
+}
+
+variable "api_testing_custom_header_value" {
+  description = "x-F5-API-testing-identifier header value added to test traffic (custom_header_value). Required by xcsh_api_testing; defaulted so test traffic is always identifiable."
+  type        = string
+  default     = "f5xc-api-testing"
+
+  validation {
+    condition     = length(var.api_testing_custom_header_value) > 0
+    error_message = "api_testing_custom_header_value must be non-empty (it is a required attribute)."
+  }
+}
+
+# Shared testing domains + credentials, consumed by BOTH surfaces (DRY). Each
+# credential selects exactly one auth arm; the secret arms (api_key value /
+# basic_auth password / bearer_token token) carry a clear/blindfold SecretType.
+# allow_destructive_methods defaults false (destructive tests can DELETE data).
+variable "api_testing_domains" {
+  description = "Testing domains: {domain, allow_destructive_methods, credentials[]}. credentials: {credential_name, auth_type admin|standard|api_key|basic_auth|bearer_token, api_key_name, user, secret {method,plaintext,location}}."
+  type = list(object({
+    domain                    = string
+    allow_destructive_methods = optional(bool, false)
+    credentials = optional(list(object({
+      credential_name = string
+      auth_type       = string           # admin | standard | api_key | basic_auth | bearer_token
+      api_key_name    = optional(string) # api_key: header/query key name
+      user            = optional(string) # basic_auth: username
+      secret = optional(object({         # api_key value / basic_auth password / bearer_token token
+        method    = optional(string, "clear")
+        plaintext = optional(string)
+        location  = optional(string)
+      }))
+    })), [])
+  }))
+  default   = []
+  sensitive = true # credentials carry secret plaintext
+
+  validation {
+    condition = alltrue(flatten([
+      for d in var.api_testing_domains : [
+        for c in d.credentials :
+        contains(["admin", "standard", "api_key", "basic_auth", "bearer_token"], c.auth_type)
+      ]
+    ]))
+    error_message = "each credential auth_type must be admin, standard, api_key, basic_auth, or bearer_token."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for d in var.api_testing_domains : [
+        for c in d.credentials :
+        # secret-bearing arms require a secret; marker arms (admin/standard) must not carry one
+        (contains(["api_key", "basic_auth", "bearer_token"], c.auth_type)) == (c.secret != null)
+      ]
+    ]))
+    error_message = "api_key/basic_auth/bearer_token require a secret{}; admin/standard must omit it."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for d in var.api_testing_domains : [
+        for c in d.credentials :
+        c.secret == null || contains(["clear", "blindfold"], c.secret.method)
+      ]
+    ]))
+    error_message = "credential secret.method must be \"clear\" or \"blindfold\"."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for d in var.api_testing_domains : [
+        for c in d.credentials :
+        c.secret == null || c.secret.method != "blindfold" || c.secret.location != null
+      ]
+    ]))
+    error_message = "blindfold credential secret requires a pre-sealed location (scripts/blindfold-seal.sh)."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for d in var.api_testing_domains : [
+        for c in d.credentials : c.auth_type != "basic_auth" || c.user != null
+      ]
+    ]))
+    error_message = "basic_auth credential requires user."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for d in var.api_testing_domains : [
+        for c in d.credentials : c.auth_type != "api_key" || c.api_key_name != null
+      ]
+    ]))
+    error_message = "api_key credential requires api_key_name."
+  }
+}

--- a/terraform/tests/api_testing.tftest.hcl
+++ b/terraform/tests/api_testing.tftest.hcl
@@ -1,7 +1,9 @@
 # Plan-level tests for API Testing (SP4): LB api_testing_choice inline block, the
-# standalone xcsh_api_testing resource + schedule oneof, and the 5-arm credential
-# auth oneof (admin/standard/api_key/basic_auth/bearer_token) with clear/blindfold
-# SecretType. Targets ./modules/http-lb with a dummy origin.
+# standalone xcsh_api_testing resource + schedule oneof, and the credential auth oneof
+# (api_key/basic_auth/bearer_token — the only valid F5 XC credentials_choice members;
+# admin/standard 400 and are excluded) with clear/blindfold SecretType. Every domain
+# requires >=1 credential and every credential a secret (verified live). Targets
+# ./modules/http-lb with a dummy origin.
 variables {
   namespace         = "webapp-api-protection"
   lb_domains        = ["www.f5-sales-demo.com"]
@@ -28,74 +30,12 @@ run "api_testing_default_disabled" {
 }
 
 # --- LB inline api_testing block ---
-run "api_testing_lb_enabled_admin" {
-  command = plan
-  module { source = "./modules/http-lb" }
-  variables {
-    api_testing_choice = "enabled"
-    api_testing_domains = [{
-      domain      = "api.f5-sales-demo.com"
-      credentials = [{ credential_name = "c-admin", auth_type = "admin" }]
-    }]
-  }
-  assert {
-    condition     = output.api_testing_choice == "enabled" && output.api_testing_credential_count == 1
-    error_message = "LB api_testing block must render with one admin credential"
-  }
-}
-
-run "api_testing_lb_custom_header" {
+run "api_testing_lb_enabled_api_key" {
   command = plan
   module { source = "./modules/http-lb" }
   variables {
     api_testing_choice              = "enabled"
     api_testing_custom_header_value = "sp4-tests"
-    api_testing_domains             = [{ domain = "api.f5-sales-demo.com" }]
-  }
-  assert {
-    condition     = output.api_testing_domain_count == 1
-    error_message = "custom_header_value + a domain must render"
-  }
-}
-
-# --- Standalone resource + schedule arms ---
-run "api_testing_standalone_every_day" {
-  command = plan
-  module { source = "./modules/http-lb" }
-  variables {
-    api_testing_standalone_enabled = true
-    api_testing_schedule           = "every_day"
-    api_testing_domains = [{
-      domain      = "api.f5-sales-demo.com"
-      credentials = [{ credential_name = "c-std", auth_type = "standard" }]
-    }]
-  }
-  assert {
-    condition     = output.api_testing_standalone_created == true && output.api_testing_schedule == "every_day"
-    error_message = "standalone xcsh_api_testing with every_day schedule must render"
-  }
-}
-
-run "api_testing_standalone_every_month" {
-  command = plan
-  module { source = "./modules/http-lb" }
-  variables {
-    api_testing_standalone_enabled = true
-    api_testing_schedule           = "every_month"
-    api_testing_domains            = [{ domain = "api.f5-sales-demo.com" }]
-  }
-  assert {
-    condition     = output.api_testing_schedule == "every_month"
-    error_message = "every_month schedule must render"
-  }
-}
-
-# --- Credential auth arms with SecretType ---
-run "api_testing_api_key_clear" {
-  command = plan
-  module { source = "./modules/http-lb" }
-  variables {
-    api_testing_choice = "enabled"
     api_testing_domains = [{
       domain = "api.f5-sales-demo.com"
       credentials = [{
@@ -107,16 +47,18 @@ run "api_testing_api_key_clear" {
     }]
   }
   assert {
-    condition     = output.api_testing_credential_count == 1
-    error_message = "api_key credential (clear secret) must render"
+    condition     = output.api_testing_choice == "enabled" && output.api_testing_credential_count == 1
+    error_message = "LB api_testing block must render with one api_key credential"
   }
 }
 
-run "api_testing_basic_auth_clear" {
+# --- Standalone resource + schedule arms ---
+run "api_testing_standalone_every_day_basic_auth" {
   command = plan
   module { source = "./modules/http-lb" }
   variables {
-    api_testing_choice = "enabled"
+    api_testing_standalone_enabled = true
+    api_testing_schedule           = "every_day"
     api_testing_domains = [{
       domain = "api.f5-sales-demo.com"
       credentials = [{
@@ -128,16 +70,17 @@ run "api_testing_basic_auth_clear" {
     }]
   }
   assert {
-    condition     = output.api_testing_credential_count == 1
-    error_message = "basic_auth credential must render"
+    condition     = output.api_testing_standalone_created == true && output.api_testing_schedule == "every_day"
+    error_message = "standalone xcsh_api_testing with every_day schedule must render"
   }
 }
 
-run "api_testing_bearer_blindfold" {
+run "api_testing_standalone_every_month_bearer_blindfold" {
   command = plan
   module { source = "./modules/http-lb" }
   variables {
     api_testing_standalone_enabled = true
+    api_testing_schedule           = "every_month"
     api_testing_domains = [{
       domain = "api.f5-sales-demo.com"
       credentials = [{
@@ -148,8 +91,31 @@ run "api_testing_bearer_blindfold" {
     }]
   }
   assert {
-    condition     = output.api_testing_credential_count == 1
-    error_message = "bearer_token credential (blindfold secret) must render"
+    condition     = output.api_testing_schedule == "every_month" && output.api_testing_credential_count == 1
+    error_message = "every_month + bearer_token blindfold credential must render"
+  }
+}
+
+# --- both surfaces at once ---
+run "api_testing_both_surfaces" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_testing_choice             = "enabled"
+    api_testing_standalone_enabled = true
+    api_testing_domains = [{
+      domain = "api.f5-sales-demo.com"
+      credentials = [{
+        credential_name = "c-key"
+        auth_type       = "api_key"
+        api_key_name    = "X-API-Key"
+        secret          = { method = "clear", plaintext = "s3cr3t" }
+      }]
+    }]
+  }
+  assert {
+    condition     = output.api_testing_choice == "enabled" && output.api_testing_standalone_created == true
+    error_message = "both surfaces must render from one shared domains/credentials input"
   }
 }
 
@@ -174,32 +140,17 @@ run "api_testing_rejects_bad_auth_type" {
   variables {
     api_testing_domains = [{
       domain      = "api.f5-sales-demo.com"
-      credentials = [{ credential_name = "c", auth_type = "oauth" }]
-    }]
-  }
-  expect_failures = [var.api_testing_domains]
-}
-
-run "api_testing_rejects_api_key_without_secret" {
-  command = plan
-  module { source = "./modules/http-lb" }
-  variables {
-    api_testing_domains = [{
-      domain      = "api.f5-sales-demo.com"
-      credentials = [{ credential_name = "c", auth_type = "api_key", api_key_name = "X" }]
-    }]
-  }
-  expect_failures = [var.api_testing_domains]
-}
-
-run "api_testing_rejects_admin_with_secret" {
-  command = plan
-  module { source = "./modules/http-lb" }
-  variables {
-    api_testing_domains = [{
-      domain      = "api.f5-sales-demo.com"
       credentials = [{ credential_name = "c", auth_type = "admin", secret = { method = "clear", plaintext = "x" } }]
     }]
+  }
+  expect_failures = [var.api_testing_domains]
+}
+
+run "api_testing_rejects_domain_without_credentials" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_testing_domains = [{ domain = "api.f5-sales-demo.com", credentials = [] }]
   }
   expect_failures = [var.api_testing_domains]
 }
@@ -223,6 +174,18 @@ run "api_testing_rejects_api_key_without_name" {
     api_testing_domains = [{
       domain      = "api.f5-sales-demo.com"
       credentials = [{ credential_name = "c", auth_type = "api_key", secret = { method = "clear", plaintext = "x" } }]
+    }]
+  }
+  expect_failures = [var.api_testing_domains]
+}
+
+run "api_testing_rejects_clear_without_plaintext" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_testing_domains = [{
+      domain      = "api.f5-sales-demo.com"
+      credentials = [{ credential_name = "c", auth_type = "bearer_token", secret = { method = "clear" } }]
     }]
   }
   expect_failures = [var.api_testing_domains]

--- a/terraform/tests/api_testing.tftest.hcl
+++ b/terraform/tests/api_testing.tftest.hcl
@@ -146,6 +146,13 @@ run "api_testing_rejects_bad_auth_type" {
   expect_failures = [var.api_testing_domains]
 }
 
+run "api_testing_rejects_lb_enabled_without_domains" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { api_testing_choice = "enabled" } # api_testing_domains defaults to []
+  expect_failures = [xcsh_http_loadbalancer.this]
+}
+
 run "api_testing_rejects_domain_without_credentials" {
   command = plan
   module { source = "./modules/http-lb" }

--- a/terraform/tests/api_testing.tftest.hcl
+++ b/terraform/tests/api_testing.tftest.hcl
@@ -1,0 +1,241 @@
+# Plan-level tests for API Testing (SP4): LB api_testing_choice inline block, the
+# standalone xcsh_api_testing resource + schedule oneof, and the 5-arm credential
+# auth oneof (admin/standard/api_key/basic_auth/bearer_token) with clear/blindfold
+# SecretType. Targets ./modules/http-lb with a dummy origin.
+variables {
+  namespace         = "webapp-api-protection"
+  lb_domains        = ["www.f5-sales-demo.com"]
+  origin_ip         = "203.0.113.10"
+  origin_port       = 80
+  health_check_path = "/health"
+  labels            = {}
+  csd_enabled       = false
+  mud_enabled       = false
+}
+
+# --- Defaults: off + 0-change shape ---
+run "api_testing_default_disabled" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  assert {
+    condition     = output.api_testing_choice == "disable" && output.api_testing_standalone_created == false
+    error_message = "API testing must default to disabled with no standalone resource"
+  }
+  assert {
+    condition     = output.api_testing_schedule == "every_week" && output.api_testing_domain_count == 0
+    error_message = "schedule must default to the suppressed every_week and no domains"
+  }
+}
+
+# --- LB inline api_testing block ---
+run "api_testing_lb_enabled_admin" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_testing_choice = "enabled"
+    api_testing_domains = [{
+      domain      = "api.f5-sales-demo.com"
+      credentials = [{ credential_name = "c-admin", auth_type = "admin" }]
+    }]
+  }
+  assert {
+    condition     = output.api_testing_choice == "enabled" && output.api_testing_credential_count == 1
+    error_message = "LB api_testing block must render with one admin credential"
+  }
+}
+
+run "api_testing_lb_custom_header" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_testing_choice              = "enabled"
+    api_testing_custom_header_value = "sp4-tests"
+    api_testing_domains             = [{ domain = "api.f5-sales-demo.com" }]
+  }
+  assert {
+    condition     = output.api_testing_domain_count == 1
+    error_message = "custom_header_value + a domain must render"
+  }
+}
+
+# --- Standalone resource + schedule arms ---
+run "api_testing_standalone_every_day" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_testing_standalone_enabled = true
+    api_testing_schedule           = "every_day"
+    api_testing_domains = [{
+      domain      = "api.f5-sales-demo.com"
+      credentials = [{ credential_name = "c-std", auth_type = "standard" }]
+    }]
+  }
+  assert {
+    condition     = output.api_testing_standalone_created == true && output.api_testing_schedule == "every_day"
+    error_message = "standalone xcsh_api_testing with every_day schedule must render"
+  }
+}
+
+run "api_testing_standalone_every_month" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_testing_standalone_enabled = true
+    api_testing_schedule           = "every_month"
+    api_testing_domains            = [{ domain = "api.f5-sales-demo.com" }]
+  }
+  assert {
+    condition     = output.api_testing_schedule == "every_month"
+    error_message = "every_month schedule must render"
+  }
+}
+
+# --- Credential auth arms with SecretType ---
+run "api_testing_api_key_clear" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_testing_choice = "enabled"
+    api_testing_domains = [{
+      domain = "api.f5-sales-demo.com"
+      credentials = [{
+        credential_name = "c-key"
+        auth_type       = "api_key"
+        api_key_name    = "X-API-Key"
+        secret          = { method = "clear", plaintext = "s3cr3t" }
+      }]
+    }]
+  }
+  assert {
+    condition     = output.api_testing_credential_count == 1
+    error_message = "api_key credential (clear secret) must render"
+  }
+}
+
+run "api_testing_basic_auth_clear" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_testing_choice = "enabled"
+    api_testing_domains = [{
+      domain = "api.f5-sales-demo.com"
+      credentials = [{
+        credential_name = "c-basic"
+        auth_type       = "basic_auth"
+        user            = "tester"
+        secret          = { method = "clear", plaintext = "pw" }
+      }]
+    }]
+  }
+  assert {
+    condition     = output.api_testing_credential_count == 1
+    error_message = "basic_auth credential must render"
+  }
+}
+
+run "api_testing_bearer_blindfold" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_testing_standalone_enabled = true
+    api_testing_domains = [{
+      domain = "api.f5-sales-demo.com"
+      credentials = [{
+        credential_name = "c-bearer"
+        auth_type       = "bearer_token"
+        secret          = { method = "blindfold", location = "string:///UFJFU0VBTEVE" }
+      }]
+    }]
+  }
+  assert {
+    condition     = output.api_testing_credential_count == 1
+    error_message = "bearer_token credential (blindfold secret) must render"
+  }
+}
+
+# --- Validation failures ---
+run "api_testing_rejects_bad_choice" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { api_testing_choice = "on" }
+  expect_failures = [var.api_testing_choice]
+}
+
+run "api_testing_rejects_bad_schedule" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { api_testing_schedule = "hourly" }
+  expect_failures = [var.api_testing_schedule]
+}
+
+run "api_testing_rejects_bad_auth_type" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_testing_domains = [{
+      domain      = "api.f5-sales-demo.com"
+      credentials = [{ credential_name = "c", auth_type = "oauth" }]
+    }]
+  }
+  expect_failures = [var.api_testing_domains]
+}
+
+run "api_testing_rejects_api_key_without_secret" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_testing_domains = [{
+      domain      = "api.f5-sales-demo.com"
+      credentials = [{ credential_name = "c", auth_type = "api_key", api_key_name = "X" }]
+    }]
+  }
+  expect_failures = [var.api_testing_domains]
+}
+
+run "api_testing_rejects_admin_with_secret" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_testing_domains = [{
+      domain      = "api.f5-sales-demo.com"
+      credentials = [{ credential_name = "c", auth_type = "admin", secret = { method = "clear", plaintext = "x" } }]
+    }]
+  }
+  expect_failures = [var.api_testing_domains]
+}
+
+run "api_testing_rejects_basic_auth_without_user" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_testing_domains = [{
+      domain      = "api.f5-sales-demo.com"
+      credentials = [{ credential_name = "c", auth_type = "basic_auth", secret = { method = "clear", plaintext = "pw" } }]
+    }]
+  }
+  expect_failures = [var.api_testing_domains]
+}
+
+run "api_testing_rejects_api_key_without_name" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_testing_domains = [{
+      domain      = "api.f5-sales-demo.com"
+      credentials = [{ credential_name = "c", auth_type = "api_key", secret = { method = "clear", plaintext = "x" } }]
+    }]
+  }
+  expect_failures = [var.api_testing_domains]
+}
+
+run "api_testing_rejects_blindfold_without_location" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_testing_domains = [{
+      domain      = "api.f5-sales-demo.com"
+      credentials = [{ credential_name = "c", auth_type = "bearer_token", secret = { method = "blindfold" } }]
+    }]
+  }
+  expect_failures = [var.api_testing_domains]
+}

--- a/terraform/variables_api_testing.tf
+++ b/terraform/variables_api_testing.tf
@@ -31,17 +31,17 @@ variable "api_testing_domains" {
   type = list(object({
     domain                    = string
     allow_destructive_methods = optional(bool, false)
-    credentials = optional(list(object({
+    credentials = list(object({
       credential_name = string
       auth_type       = string
       api_key_name    = optional(string)
       user            = optional(string)
-      secret = optional(object({
+      secret = object({
         method    = optional(string, "clear")
         plaintext = optional(string)
         location  = optional(string)
-      }))
-    })), [])
+      })
+    }))
   }))
   default   = []
   sensitive = true

--- a/terraform/variables_api_testing.tf
+++ b/terraform/variables_api_testing.tf
@@ -1,0 +1,48 @@
+# API Testing (SP4) root passthrough. Validations live in the module
+# (modules/http-lb/variables_api_testing.tf); the root just forwards. Defaults keep
+# API testing off (0-change) and create no standalone resource.
+
+variable "api_testing_choice" {
+  description = "LB api_testing_choice: disable (suppressed server default) or enabled (inline api_testing block)."
+  type        = string
+  default     = "disable"
+}
+
+variable "api_testing_standalone_enabled" {
+  description = "Create a standalone xcsh_api_testing resource (scheduled API tests)."
+  type        = bool
+  default     = false
+}
+
+variable "api_testing_schedule" {
+  description = "Standalone xcsh_api_testing schedule: every_week (suppressed default) | every_day | every_month."
+  type        = string
+  default     = "every_week"
+}
+
+variable "api_testing_custom_header_value" {
+  description = "x-F5-API-testing-identifier header value on test traffic (required by xcsh_api_testing; defaulted)."
+  type        = string
+  default     = "f5xc-api-testing"
+}
+
+variable "api_testing_domains" {
+  description = "Testing domains + credentials (see modules/http-lb/variables_api_testing.tf for the shape and validations)."
+  type = list(object({
+    domain                    = string
+    allow_destructive_methods = optional(bool, false)
+    credentials = optional(list(object({
+      credential_name = string
+      auth_type       = string
+      api_key_name    = optional(string)
+      user            = optional(string)
+      secret = optional(object({
+        method    = optional(string, "clear")
+        plaintext = optional(string)
+        location  = optional(string)
+      }))
+    })), [])
+  }))
+  default   = []
+  sensitive = true
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -15,7 +15,15 @@ terraform {
       # spine blocks + nested-list elements and suppresses those markers on import, so
       # the SP3 matrix is 13/13 idempotent + round-trip-import clean. Builds on 3.71.2's
       # object-ref tenant reconstruction (#1091). Locally consumed via dev_overrides.
-      version = ">= 3.71.3"
+      #
+      # >= 3.71.4: SP4 API-Testing read-back fix (provider #1099, PR #1100). Applying an
+      # xcsh_api_testing / LB api_testing credential previously failed apply ("inconsistent
+      # result": server-echoed credentials_choice base marker `standard`; dropped write-only
+      # api_key.value secret) and drifted on import. 3.71.4 threads prior-state into lists
+      # nested in LIST elements (domains[].credentials[]) and preserves list-element empty
+      # markers' absence, + suppresses `standard` on import. SP4 matrix idempotent +
+      # round-trip-import clean.
+      version = ">= 3.71.4"
     }
     # Azure providers: this plan also deploys its OWN Azure origin server and
     # traffic generator (modules/origin-server, modules/traffic-generator), which

--- a/tests/test_api_testing_pairs.py
+++ b/tests/test_api_testing_pairs.py
@@ -2,6 +2,7 @@
 
 import itertools
 import json
+from typing import Any, cast
 
 import api_testing_pairs as m
 
@@ -42,8 +43,9 @@ def test_canonical_restore_is_last_and_off() -> None:
     """The final variant restores canonical (API testing off)."""
     last = m.build()[-1]
     assert last["name"] == "canonical-restore"
-    assert last["vars"]["api_testing_choice"] == "disable"
-    assert last["vars"]["api_testing_standalone_enabled"] is False
+    variant_vars = cast("dict[str, Any]", last["vars"])
+    assert variant_vars["api_testing_choice"] == "disable"
+    assert variant_vars["api_testing_standalone_enabled"] is False
 
 
 def test_flags_match_secret_arms() -> None:
@@ -52,23 +54,26 @@ def test_flags_match_secret_arms() -> None:
         if v["name"] == "canonical-restore":
             assert v["flag"] == "LIVE"
             continue
-        creds = v["vars"]["api_testing_domains"][0]["credentials"][0]
+        variant_vars = cast("dict[str, Any]", v["vars"])
+        creds = variant_vars["api_testing_domains"][0]["credentials"][0]
         assert creds["auth_type"] in ("api_key", "basic_auth", "bearer_token")
         secret = creds["secret"]
+        flag = cast(str, v["flag"])
         if secret["method"] == "blindfold":
-            assert v["flag"].startswith("SKIP:")
+            assert flag.startswith("SKIP:")
             assert secret["location"] == m.BF_PLACEHOLDER
         else:
-            assert v["flag"] == "SECRET"
+            assert flag == "SECRET"
             assert secret["plaintext"] == m.CLEAR_VALUE_MARKER
 
 
 def test_secret_never_holds_real_value() -> None:
     """The manifest must carry only placeholders, never a real secret."""
     for v in m.build():
-        blob = json_dump(v["vars"])
-        for cred in (
-            v["vars"].get("api_testing_domains", [{}])[0].get("credentials", [])
+        variant_vars = cast("dict[str, Any]", v["vars"])
+        blob = json_dump(variant_vars)
+        for cred in variant_vars.get("api_testing_domains", [{}])[0].get(
+            "credentials", []
         ):
             sec = cred.get("secret")
             if sec and sec["method"] == "clear":
@@ -78,7 +83,7 @@ def test_secret_never_holds_real_value() -> None:
 def test_schedule_only_on_standalone_surfaces() -> None:
     """schedule is emitted only when a standalone resource exists."""
     for v in m.build():
-        vs = v["vars"]
+        vs = cast("dict[str, Any]", v["vars"])
         if vs.get("api_testing_standalone_enabled"):
             assert "api_testing_schedule" in vs
         elif v["name"] != "canonical-restore":

--- a/tests/test_api_testing_pairs.py
+++ b/tests/test_api_testing_pairs.py
@@ -1,0 +1,89 @@
+"""Unit tests for the API Testing (SP4) all-pairs generator."""
+
+import itertools
+import json
+
+import api_testing_pairs as m
+
+
+def test_covers_all_pairs() -> None:
+    """Every value-pair from distinct dimensions co-occurs in at least one row."""
+    rows = m.all_pairs(m.DIMENSIONS)
+    names = list(m.DIMENSIONS)
+    for i, j in itertools.combinations(range(len(names)), 2):
+        for vi in m.DIMENSIONS[names[i]]:
+            for vj in m.DIMENSIONS[names[j]]:
+                assert any(r[names[i]] == vi and r[names[j]] == vj for r in rows), (
+                    f"pair ({names[i]}={vi}, {names[j]}={vj}) uncovered"
+                )
+
+
+def json_dump(obj: object) -> str:
+    return json.dumps(obj, sort_keys=True)
+
+
+def test_deterministic() -> None:
+    """build() is stable across calls (no RNG / set-iteration order leakage)."""
+    first = json_dump(m.build())
+    assert json_dump(m.build()) == first
+    assert json_dump(m.build()) == first
+
+
+def test_dedup_no_identical_payloads() -> None:
+    """No two emitted variants share a byte-identical tfvars payload."""
+    seen = set()
+    for v in m.build():
+        key = json_dump(v["vars"])
+        assert key not in seen, f"duplicate payload: {v['name']}"
+        seen.add(key)
+
+
+def test_canonical_restore_is_last_and_off() -> None:
+    """The final variant restores canonical (API testing off)."""
+    last = m.build()[-1]
+    assert last["name"] == "canonical-restore"
+    assert last["vars"]["api_testing_choice"] == "disable"
+    assert last["vars"]["api_testing_standalone_enabled"] is False
+
+
+def test_flags_match_secret_arms() -> None:
+    """admin/standard => LIVE; clear secret arm => SECRET; blindfold => SKIP."""
+    for v in m.build():
+        if v["name"] == "canonical-restore":
+            continue
+        creds = v["vars"]["api_testing_domains"][0]["credentials"][0]
+        auth = creds["auth_type"]
+        flag = v["flag"]
+        if auth in ("admin", "standard"):
+            assert flag == "LIVE"
+            assert "secret" not in creds
+        else:
+            secret = creds["secret"]
+            if secret["method"] == "blindfold":
+                assert flag.startswith("SKIP:")
+                assert secret["location"] == m.BF_PLACEHOLDER
+            else:
+                assert flag == "SECRET"
+                assert secret["plaintext"] == m.CLEAR_VALUE_MARKER
+
+
+def test_secret_never_holds_real_value() -> None:
+    """The manifest must carry only placeholders, never a real secret."""
+    for v in m.build():
+        blob = json_dump(v["vars"])
+        for cred in (
+            v["vars"].get("api_testing_domains", [{}])[0].get("credentials", [])
+        ):
+            sec = cred.get("secret")
+            if sec and sec["method"] == "clear":
+                assert sec["plaintext"] == m.CLEAR_VALUE_MARKER, blob
+
+
+def test_schedule_only_on_standalone_surfaces() -> None:
+    """schedule is emitted only when a standalone resource exists."""
+    for v in m.build():
+        vs = v["vars"]
+        if vs.get("api_testing_standalone_enabled"):
+            assert "api_testing_schedule" in vs
+        elif v["name"] != "canonical-restore":
+            assert "api_testing_schedule" not in vs

--- a/tests/test_api_testing_pairs.py
+++ b/tests/test_api_testing_pairs.py
@@ -47,24 +47,20 @@ def test_canonical_restore_is_last_and_off() -> None:
 
 
 def test_flags_match_secret_arms() -> None:
-    """admin/standard => LIVE; clear secret arm => SECRET; blindfold => SKIP."""
+    """Every credential carries a secret; clear => SECRET, blindfold => SKIP."""
     for v in m.build():
         if v["name"] == "canonical-restore":
+            assert v["flag"] == "LIVE"
             continue
         creds = v["vars"]["api_testing_domains"][0]["credentials"][0]
-        auth = creds["auth_type"]
-        flag = v["flag"]
-        if auth in ("admin", "standard"):
-            assert flag == "LIVE"
-            assert "secret" not in creds
+        assert creds["auth_type"] in ("api_key", "basic_auth", "bearer_token")
+        secret = creds["secret"]
+        if secret["method"] == "blindfold":
+            assert v["flag"].startswith("SKIP:")
+            assert secret["location"] == m.BF_PLACEHOLDER
         else:
-            secret = creds["secret"]
-            if secret["method"] == "blindfold":
-                assert flag.startswith("SKIP:")
-                assert secret["location"] == m.BF_PLACEHOLDER
-            else:
-                assert flag == "SECRET"
-                assert secret["plaintext"] == m.CLEAR_VALUE_MARKER
+            assert v["flag"] == "SECRET"
+            assert secret["plaintext"] == m.CLEAR_VALUE_MARKER
 
 
 def test_secret_never_holds_real_value() -> None:


### PR DESCRIPTION
## Summary

SP4 — **API Testing** for the `webapp-api-protection` HTTP LoadBalancer module, both surfaces, exhaustively parameterized, plan-tested, and live all-pairs verified against the f5-sales-demo staging tenant.

Closes #45.

## What's delivered
1. **Standalone `xcsh_api_testing`** (`api_testing_standalone_enabled`) — `domains[]` (domain, `allow_destructive_methods`, `credentials[]`) + a flat schedule oneof (`every_week` suppressed default | `every_day` | `every_month`) + `custom_header_value`.
2. **LB `api_testing_choice`** oneof — inline `api_testing` block (same `custom_header_value` + `domains[]` + `credentials[]`, no schedule) vs the suppressed server default `disable_api_testing` (omit ⇒ 0-change).

Both surfaces share one `local.rendered_api_testing` (DRY). Credentials use the clear/blindfold SecretType convention (seal-once-pin).

## Real F5 XC contract (confirmed live — key finding)
Live API probing corrected the surface vs. the generated schema:
- `credentials_choice` = **`api_key` / `basic_auth` / `bearer_token`** only (each a SecretType). `admin` / `standard` return `400` and are **excluded** (schema artifacts).
- A domain with **zero credentials** returns `500` → **≥1 credential per domain** (module validation), and every credential requires a secret.
- `custom_header_value` is required → defaulted.

## Testing
- **14 plan-tests** (`terraform/tests/api_testing.tftest.hcl`) — pass.
- **7 generator unit tests** (`tests/test_api_testing_pairs.py`).
- **Live all-pairs matrix** (`scripts/api-testing-matrix.sh`): **7 PASS / 0 FAIL / 4 SKIP** — every clear-secret credential arm (both surfaces) idempotent + round-trip-import clean via the write-only-secret re-apply gate; blindfold credential secrets SKIP on the documented F5 XC `500`.

## Lock-step provider fix (xcsh v3.71.4)
The matrix surfaced `inconsistent result after apply: credentials[0].standard was absent, now present` (+ dropped write-only `api_key.value`). `credentials[]` is a list nested in the `domains[]` list element, and read-back state-threading only engaged for lists inside single blocks. Fixed in `terraform-provider-xcsh` (#1099 / PR #1100, **v3.71.4**): thread prior-state into lists nested in list elements + preserve list-element empty-marker absence + suppress `standard` on import. `versions.tf` requires `>= 3.71.4`.

## Notes
Deferred/excluded (documented): `admin`/`standard` arms (API-rejected), blindfold credential secret (live SKIP on 500), `allow_destructive_methods=true` (supported but kept false on shared staging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)