### PR TITLE
Coverage Batch A: OpenAPI validation enforcement (all_spec_endpoints enforces)

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -119,6 +119,15 @@ module "http_lb" {
   api_definition_schema_origin       = var.api_definition_schema_origin
   api_specification_validation       = var.api_specification_validation
 
+  # OpenAPI validation enforcement (Batch A) passthrough.
+  api_validation_request_mode        = var.api_validation_request_mode
+  api_validation_request_properties  = var.api_validation_request_properties
+  api_validation_response_mode       = var.api_validation_response_mode
+  api_validation_response_properties = var.api_validation_response_properties
+  api_validation_fall_through        = var.api_validation_fall_through
+  api_validation_oversized_body      = var.api_validation_oversized_body
+  api_validation_additional_params   = var.api_validation_additional_params
+
   # API Protection (SP3) passthrough. Defaults keep every control off/suppressed (0-change).
   client_matcher                     = var.client_matcher
   rate_limit_choice                  = var.rate_limit_choice

--- a/terraform/modules/http-lb/locals_api_validation.tf
+++ b/terraform/modules/http-lb/locals_api_validation.tf
@@ -1,0 +1,32 @@
+# Rendered OpenAPI-validation arm selectors (Batch A, DRY). Both api_specification
+# validation arms consume local.rendered_api_validation for validation_mode / settings
+# / fall_through so the two stay consistent and neither hardcodes skip.
+locals {
+  rendered_api_validation = {
+    # request-side oneof
+    req_skip   = var.api_validation_request_mode == "skip"
+    req_active = contains(["block", "report"], var.api_validation_request_mode)
+    req_block  = var.api_validation_request_mode == "block"
+    req_report = var.api_validation_request_mode == "report"
+    req_props  = var.api_validation_request_properties
+
+    # response-side oneof (omit => emit neither arm)
+    resp_emit   = var.api_validation_response_mode != "omit"
+    resp_skip   = var.api_validation_response_mode == "skip"
+    resp_active = contains(["block", "report"], var.api_validation_response_mode)
+    resp_block  = var.api_validation_response_mode == "block"
+    resp_report = var.api_validation_response_mode == "report"
+    resp_props  = var.api_validation_response_properties
+
+    # fall-through
+    ft_custom = var.api_validation_fall_through == "custom"
+
+    # settings (emit the settings block only if any knob is set)
+    settings_emit   = var.api_validation_oversized_body != "omit" || var.api_validation_additional_params != "omit"
+    oversized_fail  = var.api_validation_oversized_body == "fail"
+    oversized_skip  = var.api_validation_oversized_body == "skip"
+    params_custom   = var.api_validation_additional_params != "omit"
+    params_allow    = var.api_validation_additional_params == "allow"
+    params_disallow = var.api_validation_additional_params == "disallow"
+  }
+}

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -581,11 +581,116 @@ resource "xcsh_http_loadbalancer" "this" {
       dynamic "validation_all_spec_endpoints" {
         for_each = var.api_specification_validation == "all_spec_endpoints" ? [1] : []
         content {
-          fall_through_mode {
-            fall_through_mode_allow {}
-          }
+          # ONE validation_mode applied to every spec endpoint (Batch A: this used to
+          # hardcode skip_validation and enforce nothing). Request + response are
+          # independent oneofs; response omitted entirely unless response_mode set.
           validation_mode {
-            skip_validation {}
+            dynamic "skip_validation" {
+              for_each = local.rendered_api_validation.req_skip ? [1] : []
+              content {}
+            }
+            dynamic "validation_mode_active" {
+              for_each = local.rendered_api_validation.req_active ? [1] : []
+              content {
+                request_validation_properties = local.rendered_api_validation.req_props
+                dynamic "enforcement_block" {
+                  for_each = local.rendered_api_validation.req_block ? [1] : []
+                  content {}
+                }
+                dynamic "enforcement_report" {
+                  for_each = local.rendered_api_validation.req_report ? [1] : []
+                  content {}
+                }
+              }
+            }
+            dynamic "skip_response_validation" {
+              for_each = local.rendered_api_validation.resp_emit && local.rendered_api_validation.resp_skip ? [1] : []
+              content {}
+            }
+            dynamic "response_validation_mode_active" {
+              for_each = local.rendered_api_validation.resp_emit && local.rendered_api_validation.resp_active ? [1] : []
+              content {
+                response_validation_properties = local.rendered_api_validation.resp_props
+                dynamic "enforcement_block" {
+                  for_each = local.rendered_api_validation.resp_block ? [1] : []
+                  content {}
+                }
+                dynamic "enforcement_report" {
+                  for_each = local.rendered_api_validation.resp_report ? [1] : []
+                  content {}
+                }
+              }
+            }
+          }
+
+          fall_through_mode {
+            dynamic "fall_through_mode_allow" {
+              for_each = local.rendered_api_validation.ft_custom ? [] : [1]
+              content {}
+            }
+            # fall_through_mode_custom rules use action_block/report/skip (NOT the
+            # per-rule validation_mode used by validation_custom_list). Reuse the
+            # shared validation_custom_rules, mapping action -> action_*.
+            dynamic "fall_through_mode_custom" {
+              for_each = local.rendered_api_validation.ft_custom ? [1] : []
+              content {
+                dynamic "open_api_validation_rules" {
+                  for_each = var.validation_custom_rules
+                  content {
+                    metadata {
+                      name = "fallthrough-rule-${open_api_validation_rules.key}"
+                    }
+                    api_endpoint {
+                      methods = open_api_validation_rules.value.methods
+                      path    = open_api_validation_rules.value.path
+                    }
+                    dynamic "action_block" {
+                      for_each = open_api_validation_rules.value.action == "block" ? [1] : []
+                      content {}
+                    }
+                    dynamic "action_report" {
+                      for_each = open_api_validation_rules.value.action == "report" ? [1] : []
+                      content {}
+                    }
+                    dynamic "action_skip" {
+                      for_each = open_api_validation_rules.value.action == "skip" ? [1] : []
+                      content {}
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          # OpenAPI settings (oversized body + additional query parameters). Emitted
+          # only when a knob is set, so the default stays 0-change / import-clean.
+          dynamic "settings" {
+            for_each = local.rendered_api_validation.settings_emit ? [1] : []
+            content {
+              dynamic "oversized_body_fail_validation" {
+                for_each = local.rendered_api_validation.oversized_fail ? [1] : []
+                content {}
+              }
+              dynamic "oversized_body_skip_validation" {
+                for_each = local.rendered_api_validation.oversized_skip ? [1] : []
+                content {}
+              }
+              dynamic "property_validation_settings_custom" {
+                for_each = local.rendered_api_validation.params_custom ? [1] : []
+                content {
+                  query_parameters {
+                    dynamic "allow_additional_parameters" {
+                      for_each = local.rendered_api_validation.params_allow ? [1] : []
+                      content {}
+                    }
+                    dynamic "disallow_additional_parameters" {
+                      for_each = local.rendered_api_validation.params_disallow ? [1] : []
+                      content {}
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -620,14 +725,10 @@ resource "xcsh_http_loadbalancer" "this" {
                 dynamic "validation_mode_active" {
                   for_each = contains(["block", "report"], open_api_validation_rules.value.action) ? [1] : []
                   content {
-                    # request_validation_properties has SizeAtLeast(1): validate the
-                    # common request properties against the OpenAPI spec.
-                    request_validation_properties = [
-                      "PROPERTY_QUERY_PARAMETERS",
-                      "PROPERTY_PATH_PARAMETERS",
-                      "PROPERTY_HTTP_HEADERS",
-                      "PROPERTY_HTTP_BODY",
-                    ]
+                    # request_validation_properties has SizeAtLeast(1); shared with
+                    # all_spec_endpoints via var.api_validation_request_properties
+                    # (Batch A: was hardcoded).
+                    request_validation_properties = var.api_validation_request_properties
                     dynamic "enforcement_block" {
                       for_each = open_api_validation_rules.value.action == "block" ? [1] : []
                       content {}

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -1047,5 +1047,12 @@ resource "xcsh_http_loadbalancer" "this" {
       condition     = var.api_testing_choice != "enabled" || length(var.api_testing_domains) > 0
       error_message = "api_testing_choice=\"enabled\" requires at least one api_testing_domains entry."
     }
+
+    # Custom OpenAPI fall-through / custom_list needs rules to emit — an empty
+    # fall_through_mode_custom {} (or custom_list with no rules) fails at apply.
+    precondition {
+      condition     = var.api_validation_fall_through != "custom" || length(var.validation_custom_rules) > 0
+      error_message = "api_validation_fall_through=\"custom\" requires at least one validation_custom_rules entry."
+    }
   }
 }

--- a/terraform/modules/http-lb/outputs_api_validation.tf
+++ b/terraform/modules/http-lb/outputs_api_validation.tf
@@ -1,0 +1,22 @@
+# OpenAPI validation enforcement (Batch A) outputs — echo the effective config so
+# plan-tests can assert arm selection (the deeply-nested dynamic blocks are otherwise
+# not observable at plan time; a clean plan with a given mode proves the block renders).
+output "api_validation_request_mode" {
+  description = "Effective all_spec_endpoints request validation mode."
+  value       = var.api_validation_request_mode
+}
+
+output "api_validation_response_mode" {
+  description = "Effective all_spec_endpoints response validation mode."
+  value       = var.api_validation_response_mode
+}
+
+output "api_validation_fall_through" {
+  description = "Effective validation fall-through (allow | custom)."
+  value       = var.api_validation_fall_through
+}
+
+output "api_validation_enforces" {
+  description = "Whether validation actually enforces (request or response active), i.e. not skip/omit only."
+  value       = local.rendered_api_validation.req_active || (local.rendered_api_validation.resp_emit && local.rendered_api_validation.resp_active)
+}

--- a/terraform/modules/http-lb/outputs_api_validation.tf
+++ b/terraform/modules/http-lb/outputs_api_validation.tf
@@ -17,6 +17,6 @@ output "api_validation_fall_through" {
 }
 
 output "api_validation_enforces" {
-  description = "Whether validation actually enforces (request or response active), i.e. not skip/omit only."
-  value       = local.rendered_api_validation.req_active || (local.rendered_api_validation.resp_emit && local.rendered_api_validation.resp_active)
+  description = "Whether all_spec_endpoints validation actually enforces (request or response active), i.e. not skip/omit only. False unless api_specification_validation=all_spec_endpoints is the active arm."
+  value       = var.api_specification_validation == "all_spec_endpoints" && (local.rendered_api_validation.req_active || (local.rendered_api_validation.resp_emit && local.rendered_api_validation.resp_active))
 }

--- a/terraform/modules/http-lb/variables_api_validation.tf
+++ b/terraform/modules/http-lb/variables_api_validation.tf
@@ -1,0 +1,114 @@
+# ---------------------------------------------------------------------------
+# OpenAPI validation enforcement (Coverage Batch A). Shared config for BOTH the
+# api_specification validation arms: validation_all_spec_endpoints (one validation_mode
+# for every spec endpoint) and validation_custom_list (per-rule action + shared
+# settings / fall-through). Fixes the correctness gap where all_spec_endpoints
+# hardcoded skip_validation (built inventory but enforced nothing).
+# ---------------------------------------------------------------------------
+
+# The 8 OpenAPI properties the LB can validate (request or response side).
+locals {
+  _api_validation_properties = [
+    "PROPERTY_QUERY_PARAMETERS", "PROPERTY_PATH_PARAMETERS", "PROPERTY_CONTENT_TYPE",
+    "PROPERTY_COOKIE_PARAMETERS", "PROPERTY_HTTP_HEADERS", "PROPERTY_HTTP_BODY",
+    "PROPERTY_SECURITY_SCHEMA", "PROPERTY_RESPONSE_CODE",
+  ]
+}
+
+# Request-side enforcement for validation_all_spec_endpoints:
+#   skip   -> validation_mode { skip_validation {} }               (no enforcement)
+#   block  -> validation_mode_active + enforcement_block           (reject mismatches)
+#   report -> validation_mode_active + enforcement_report          (log only)
+variable "api_validation_request_mode" {
+  description = "all_spec_endpoints request validation: skip | block | report."
+  type        = string
+  default     = "skip"
+
+  validation {
+    condition     = contains(["skip", "block", "report"], var.api_validation_request_mode)
+    error_message = "api_validation_request_mode must be skip, block, or report."
+  }
+}
+
+variable "api_validation_request_properties" {
+  description = "Request properties to validate (validation_mode_active.request_validation_properties) when request_mode=block|report."
+  type        = list(string)
+  default     = ["PROPERTY_QUERY_PARAMETERS", "PROPERTY_PATH_PARAMETERS", "PROPERTY_HTTP_HEADERS", "PROPERTY_HTTP_BODY"]
+
+  validation {
+    condition = alltrue([
+      for p in var.api_validation_request_properties :
+      contains(["PROPERTY_QUERY_PARAMETERS", "PROPERTY_PATH_PARAMETERS", "PROPERTY_CONTENT_TYPE", "PROPERTY_COOKIE_PARAMETERS", "PROPERTY_HTTP_HEADERS", "PROPERTY_HTTP_BODY", "PROPERTY_SECURITY_SCHEMA", "PROPERTY_RESPONSE_CODE"], p)
+    ])
+    error_message = "each api_validation_request_properties value must be a valid PROPERTY_* enum."
+  }
+
+  validation {
+    condition     = length(var.api_validation_request_properties) > 0
+    error_message = "api_validation_request_properties must be non-empty (SizeAtLeast 1) when request validation is active."
+  }
+}
+
+# Response-side enforcement (independent oneof): omit emits neither response arm.
+variable "api_validation_response_mode" {
+  description = "all_spec_endpoints response validation: omit | skip | block | report."
+  type        = string
+  default     = "omit"
+
+  validation {
+    condition     = contains(["omit", "skip", "block", "report"], var.api_validation_response_mode)
+    error_message = "api_validation_response_mode must be omit, skip, block, or report."
+  }
+}
+
+variable "api_validation_response_properties" {
+  description = "Response properties to validate (response_validation_mode_active.response_validation_properties) when response_mode=block|report."
+  type        = list(string)
+  default     = ["PROPERTY_HTTP_BODY", "PROPERTY_RESPONSE_CODE"]
+
+  validation {
+    condition = alltrue([
+      for p in var.api_validation_response_properties :
+      contains(["PROPERTY_QUERY_PARAMETERS", "PROPERTY_PATH_PARAMETERS", "PROPERTY_CONTENT_TYPE", "PROPERTY_COOKIE_PARAMETERS", "PROPERTY_HTTP_HEADERS", "PROPERTY_HTTP_BODY", "PROPERTY_SECURITY_SCHEMA", "PROPERTY_RESPONSE_CODE"], p)
+    ])
+    error_message = "each api_validation_response_properties value must be a valid PROPERTY_* enum."
+  }
+}
+
+# Fall-through for endpoints NOT in the spec (both arms). allow = pass through;
+# custom = apply the validation_custom_rules as the fall-through rule set.
+variable "api_validation_fall_through" {
+  description = "Fall-through for unlisted endpoints: allow | custom."
+  type        = string
+  default     = "allow"
+
+  validation {
+    condition     = contains(["allow", "custom"], var.api_validation_fall_through)
+    error_message = "api_validation_fall_through must be allow or custom."
+  }
+}
+
+# OpenAPI settings.oversized_body handling: omit (server default) | fail | skip.
+variable "api_validation_oversized_body" {
+  description = "settings.oversized_body: omit | fail (oversized_body_fail_validation) | skip (oversized_body_skip_validation)."
+  type        = string
+  default     = "omit"
+
+  validation {
+    condition     = contains(["omit", "fail", "skip"], var.api_validation_oversized_body)
+    error_message = "api_validation_oversized_body must be omit, fail, or skip."
+  }
+}
+
+# settings.property_validation_settings_custom.query_parameters additional-params:
+# omit (server default) | allow | disallow (extra query params not in the spec).
+variable "api_validation_additional_params" {
+  description = "settings query-parameter additional-params: omit | allow | disallow."
+  type        = string
+  default     = "omit"
+
+  validation {
+    condition     = contains(["omit", "allow", "disallow"], var.api_validation_additional_params)
+    error_message = "api_validation_additional_params must be omit, allow, or disallow."
+  }
+}

--- a/terraform/modules/http-lb/variables_api_validation.tf
+++ b/terraform/modules/http-lb/variables_api_validation.tf
@@ -1,9 +1,9 @@
 # ---------------------------------------------------------------------------
-# OpenAPI validation enforcement (Coverage Batch A). Shared config for BOTH the
-# api_specification validation arms: validation_all_spec_endpoints (one validation_mode
-# for every spec endpoint) and validation_custom_list (per-rule action + shared
-# settings / fall-through). Fixes the correctness gap where all_spec_endpoints
-# hardcoded skip_validation (built inventory but enforced nothing).
+# OpenAPI validation enforcement (Coverage Batch A). Drives validation_all_spec_endpoints
+# (one validation_mode for every spec endpoint, plus fall_through + settings). Fixes the
+# correctness gap where all_spec_endpoints hardcoded skip_validation (built inventory but
+# enforced nothing). Only api_validation_request_properties is ALSO shared with
+# validation_custom_list (whose fall_through/per-rule action stay in its own arm).
 # ---------------------------------------------------------------------------
 
 # The 8 OpenAPI properties the LB can validate (request or response side).
@@ -72,6 +72,11 @@ variable "api_validation_response_properties" {
       contains(["PROPERTY_QUERY_PARAMETERS", "PROPERTY_PATH_PARAMETERS", "PROPERTY_CONTENT_TYPE", "PROPERTY_COOKIE_PARAMETERS", "PROPERTY_HTTP_HEADERS", "PROPERTY_HTTP_BODY", "PROPERTY_SECURITY_SCHEMA", "PROPERTY_RESPONSE_CODE"], p)
     ])
     error_message = "each api_validation_response_properties value must be a valid PROPERTY_* enum."
+  }
+
+  validation {
+    condition     = length(var.api_validation_response_properties) > 0
+    error_message = "api_validation_response_properties must be non-empty (SizeAtLeast 1) when response validation is active."
   }
 }
 

--- a/terraform/modules/http-lb/variables_api_validation.tf
+++ b/terraform/modules/http-lb/variables_api_validation.tf
@@ -4,16 +4,11 @@
 # correctness gap where all_spec_endpoints hardcoded skip_validation (built inventory but
 # enforced nothing). Only api_validation_request_properties is ALSO shared with
 # validation_custom_list (whose fall_through/per-rule action stay in its own arm).
+# The 8 OpenAPI properties the LB can validate (request or response side):
+# PROPERTY_QUERY_PARAMETERS, PROPERTY_PATH_PARAMETERS, PROPERTY_CONTENT_TYPE,
+# PROPERTY_COOKIE_PARAMETERS, PROPERTY_HTTP_HEADERS, PROPERTY_HTTP_BODY,
+# PROPERTY_SECURITY_SCHEMA, PROPERTY_RESPONSE_CODE.
 # ---------------------------------------------------------------------------
-
-# The 8 OpenAPI properties the LB can validate (request or response side).
-locals {
-  _api_validation_properties = [
-    "PROPERTY_QUERY_PARAMETERS", "PROPERTY_PATH_PARAMETERS", "PROPERTY_CONTENT_TYPE",
-    "PROPERTY_COOKIE_PARAMETERS", "PROPERTY_HTTP_HEADERS", "PROPERTY_HTTP_BODY",
-    "PROPERTY_SECURITY_SCHEMA", "PROPERTY_RESPONSE_CODE",
-  ]
-}
 
 # Request-side enforcement for validation_all_spec_endpoints:
 #   skip   -> validation_mode { skip_validation {} }               (no enforcement)

--- a/terraform/tests/api_validation.tftest.hcl
+++ b/terraform/tests/api_validation.tftest.hcl
@@ -1,0 +1,155 @@
+# Plan-level tests for OpenAPI validation enforcement (Batch A): validation_mode
+# (request/response skip|block|report), fall_through (allow|custom), and settings
+# (oversized-body, additional-params) on api_specification. Targets ./modules/http-lb.
+variables {
+  namespace         = "webapp-api-protection"
+  lb_domains        = ["www.f5-sales-demo.com"]
+  origin_ip         = "203.0.113.10"
+  origin_port       = 80
+  health_check_path = "/health"
+  labels            = {}
+  csd_enabled       = false
+  mud_enabled       = false
+}
+
+# Default: all_spec_endpoints with no enforcement opt-in = skip (the pre-fix behavior,
+# now explicit + advertised via the output, not silently hardcoded).
+run "validation_default_skip_no_enforce" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_definition_choice        = "specification"
+    api_specification_validation = "all_spec_endpoints"
+  }
+  assert {
+    condition     = output.api_validation_enforces == false && output.api_validation_request_mode == "skip"
+    error_message = "default all_spec_endpoints must render skip (no enforcement) explicitly"
+  }
+}
+
+# The correctness fix: request block/report actually enforces.
+run "validation_request_block_enforces" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_definition_choice        = "specification"
+    api_specification_validation = "all_spec_endpoints"
+    api_validation_request_mode  = "block"
+  }
+  assert {
+    condition     = output.api_validation_enforces == true
+    error_message = "request_mode=block must enforce (validation_mode_active + enforcement_block)"
+  }
+}
+
+run "validation_request_report_enforces" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_definition_choice             = "specification"
+    api_specification_validation      = "all_spec_endpoints"
+    api_validation_request_mode       = "report"
+    api_validation_request_properties = ["PROPERTY_HTTP_BODY", "PROPERTY_HTTP_HEADERS", "PROPERTY_CONTENT_TYPE"]
+  }
+  assert {
+    condition     = output.api_validation_enforces == true
+    error_message = "request_mode=report must render validation_mode_active + enforcement_report"
+  }
+}
+
+run "validation_response_block_enforces" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_definition_choice        = "specification"
+    api_specification_validation = "all_spec_endpoints"
+    api_validation_response_mode = "block"
+  }
+  assert {
+    condition     = output.api_validation_enforces == true && output.api_validation_response_mode == "block"
+    error_message = "response_mode=block must enforce (response_validation_mode_active)"
+  }
+}
+
+# Fall-through custom + settings render a valid plan.
+run "validation_fall_through_custom" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_definition_choice        = "specification"
+    api_specification_validation = "all_spec_endpoints"
+    api_validation_request_mode  = "block"
+    api_validation_fall_through  = "custom"
+    validation_custom_rules      = [{ path = "/api/legacy", methods = ["GET"], action = "report" }]
+  }
+  assert {
+    condition     = output.api_validation_fall_through == "custom"
+    error_message = "fall_through=custom must render fall_through_mode_custom with rules"
+  }
+}
+
+run "validation_settings_render" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_definition_choice            = "specification"
+    api_specification_validation     = "all_spec_endpoints"
+    api_validation_request_mode      = "block"
+    api_validation_oversized_body    = "fail"
+    api_validation_additional_params = "disallow"
+  }
+  assert {
+    condition     = output.api_validation_enforces == true
+    error_message = "settings (oversized_body + additional_params) must render a valid plan"
+  }
+}
+
+# --- validation failures ---
+run "validation_rejects_bad_request_mode" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { api_validation_request_mode = "enforce" }
+  expect_failures = [var.api_validation_request_mode]
+}
+
+run "validation_rejects_bad_response_mode" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { api_validation_response_mode = "maybe" }
+  expect_failures = [var.api_validation_response_mode]
+}
+
+run "validation_rejects_bad_fall_through" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { api_validation_fall_through = "deny" }
+  expect_failures = [var.api_validation_fall_through]
+}
+
+run "validation_rejects_bad_oversized_body" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { api_validation_oversized_body = "truncate" }
+  expect_failures = [var.api_validation_oversized_body]
+}
+
+run "validation_rejects_bad_additional_params" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { api_validation_additional_params = "strip" }
+  expect_failures = [var.api_validation_additional_params]
+}
+
+run "validation_rejects_bad_property_enum" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { api_validation_request_properties = ["PROPERTY_NOT_REAL"] }
+  expect_failures = [var.api_validation_request_properties]
+}
+
+run "validation_rejects_empty_request_properties" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { api_validation_request_properties = [] }
+  expect_failures = [var.api_validation_request_properties]
+}

--- a/terraform/tests/api_validation.tftest.hcl
+++ b/terraform/tests/api_validation.tftest.hcl
@@ -153,3 +153,22 @@ run "validation_rejects_empty_request_properties" {
   variables { api_validation_request_properties = [] }
   expect_failures = [var.api_validation_request_properties]
 }
+
+run "validation_rejects_empty_response_properties" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { api_validation_response_properties = [] }
+  expect_failures = [var.api_validation_response_properties]
+}
+
+run "validation_rejects_custom_fall_through_without_rules" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_definition_choice        = "specification"
+    api_specification_validation = "all_spec_endpoints"
+    api_validation_fall_through  = "custom"
+    # validation_custom_rules defaults to [] -> precondition must fail
+  }
+  expect_failures = [xcsh_http_loadbalancer.this]
+}

--- a/terraform/variables_api_definition.tf
+++ b/terraform/variables_api_definition.tf
@@ -49,7 +49,7 @@ variable "api_definition_schema_origin" {
 }
 
 variable "api_specification_validation" {
-  description = "api_specification validation_target_choice: disabled or all_spec_endpoints."
+  description = "api_specification validation_target_choice: disabled | all_spec_endpoints | custom_list. all_spec_endpoints/custom_list enforcement is controlled by the api_validation_* vars (request/response mode, properties, fall-through, settings)."
   type        = string
   default     = "disabled"
 }

--- a/terraform/variables_api_validation.tf
+++ b/terraform/variables_api_validation.tf
@@ -1,0 +1,45 @@
+# OpenAPI validation enforcement (Batch A) root passthrough. Validations live in the
+# module (modules/http-lb/variables_api_validation.tf). Defaults keep validation as
+# skip/omit so an all_spec_endpoints or custom_list config that does not opt into
+# enforcement stays 0-change.
+variable "api_validation_request_mode" {
+  description = "all_spec_endpoints request validation: skip | block | report."
+  type        = string
+  default     = "skip"
+}
+
+variable "api_validation_request_properties" {
+  description = "Request properties to validate when request_mode=block|report."
+  type        = list(string)
+  default     = ["PROPERTY_QUERY_PARAMETERS", "PROPERTY_PATH_PARAMETERS", "PROPERTY_HTTP_HEADERS", "PROPERTY_HTTP_BODY"]
+}
+
+variable "api_validation_response_mode" {
+  description = "all_spec_endpoints response validation: omit | skip | block | report."
+  type        = string
+  default     = "omit"
+}
+
+variable "api_validation_response_properties" {
+  description = "Response properties to validate when response_mode=block|report."
+  type        = list(string)
+  default     = ["PROPERTY_HTTP_BODY", "PROPERTY_RESPONSE_CODE"]
+}
+
+variable "api_validation_fall_through" {
+  description = "Fall-through for unlisted endpoints: allow | custom."
+  type        = string
+  default     = "allow"
+}
+
+variable "api_validation_oversized_body" {
+  description = "settings.oversized_body: omit | fail | skip."
+  type        = string
+  default     = "omit"
+}
+
+variable "api_validation_additional_params" {
+  description = "settings query-parameter additional-params: omit | allow | disallow."
+  type        = string
+  default     = "omit"
+}

--- a/tests/test_api_definition_pairs.py
+++ b/tests/test_api_definition_pairs.py
@@ -1,0 +1,69 @@
+"""Unit tests for the API Definition (SP2) all-pairs generator.
+
+Backfilled in Coverage Batch A — the SP2 generator shipped without a unit test
+(unlike the SP1/SP3/SP4/SP5 generators), leaving its dedup + constraint-reconciliation
+logic unverified.
+"""
+
+import itertools
+import json
+from typing import Any, cast
+
+from api_definition_pairs import DIMENSIONS, all_pairs, build, payloads
+
+
+def json_dump(obj: object) -> str:
+    return json.dumps(obj, sort_keys=True)
+
+
+def test_covers_all_pairs() -> None:
+    """Every value-pair from distinct dimensions co-occurs in at least one row."""
+    rows = all_pairs(DIMENSIONS)
+    names = list(DIMENSIONS)
+    for i, j in itertools.combinations(range(len(names)), 2):
+        for vi in DIMENSIONS[names[i]]:
+            for vj in DIMENSIONS[names[j]]:
+                assert any(r[names[i]] == vi and r[names[j]] == vj for r in rows), (
+                    f"pair ({names[i]}={vi}, {names[j]}={vj}) uncovered"
+                )
+
+
+def test_deterministic() -> None:
+    """build() is stable across calls (no RNG / set-iteration leakage)."""
+    first = json_dump(build())
+    assert json_dump(build()) == first
+    assert json_dump(build()) == first
+
+
+def test_dedup_no_identical_payloads() -> None:
+    """The reconciliation dedup collapses byte-identical payloads."""
+    seen = set()
+    for v in build():
+        key = json_dump(cast("dict[str, Any]", v["vars"]))
+        assert key not in seen, f"duplicate payload: {v['name']}"
+        seen.add(key)
+
+
+def test_canonical_restore_is_last() -> None:
+    """The final variant restores canonical (definition/discovery off)."""
+    assert build()[-1]["name"] == "canonical-restore"
+
+
+def test_blindfold_token_is_skip() -> None:
+    """A blindfold access_token row is flagged skip (F5 XC 500 platform limit)."""
+    saw_blindfold = False
+    for row in all_pairs(DIMENSIONS):
+        _, skip = payloads(row)
+        if row.get("token_method") == "blindfold" and row.get("integration") != "off":
+            saw_blindfold = True
+            assert skip, "blindfold access_token variant must carry a skip reason"
+    assert saw_blindfold, "generator never produced a blindfold integration row"
+
+
+def test_secret_never_holds_real_token() -> None:
+    """The manifest carries only the swagger placeholder / no real secret value."""
+    for v in build():
+        blob = json_dump(cast("dict[str, Any]", v["vars"]))
+        assert "ghp_" not in blob, (
+            f"real GitHub token leaked into manifest: {v['name']}"
+        )


### PR DESCRIPTION
## Summary
Coverage Batch A — fixes the OpenAPI validation **correctness bug** and parameterizes the full validation surface on the LB `api_specification`. Closes #49.

**The bug:** `validation_all_spec_endpoints` hardcoded `validation_mode { skip_validation {} }` — selecting it built the API inventory but **enforced nothing**. Now it actually enforces.

## What's parameterized (DRY across both validation arms)
- **request** `validation_mode`: `skip | block | report` + `request_validation_properties` (8-value enum)
- **response** validation: `omit | skip | block | report` + `response_validation_properties`
- **settings**: `oversized_body` fail/skip/omit; query-param additional-params allow/disallow/omit
- **fall_through_mode**: allow | custom (`fall_through_mode_custom` with `action_block/report/skip` rules)
- `validation_custom_list` now shares `request_validation_properties` (was hardcoded)

## Quick wins (from the coverage audit)
- Backfilled `tests/test_api_definition_pairs.py` (the SP2 generator was the only one without a unit test).
- Fixed the stale root doc for `api_specification_validation`.

## Verification
- 15 plan-tests (`api_validation.tftest.hcl`, incl. 8 negative `expect_failures`) + 12 existing definition tests + 6 new generator tests — all pass; `terraform fmt`/ruff/mypy clean; defaults **0-change**.
- **Live-verified**: `all_spec_endpoints` + `request_mode=block` renders `validation_mode_active` + `enforcement_block` (+ `response_validation_mode_active`) on the LB — apply idempotent + round-trip-import clean. **No provider change needed** (v3.71.4 covers the nested oneofs).
- Whole-branch review: no Critical/Important; addressed 3 sub-threshold notes (response-properties SizeAtLeast guard, fall-through-custom precondition, faithful `enforces` output).

First of the 5 coverage-remediation batches (B rate-limit, C sensitive-data, D matchers, E SCM to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)