### PR TITLE
Coverage Batch B: full rate-limiting surface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,3 +202,6 @@ pi-*.html
 packages/coding-agent/src/internal-urls/docs-index.generated.ts
 packages/coding-agent/src/internal-urls/build-info.generated.ts
 packages/typescript-edit-benchmark/runs/
+
+# Superpowers SDD scratch (session-local ledger)
+.superpowers/

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -135,6 +135,14 @@ module "http_lb" {
   rate_limit_unit                    = var.rate_limit_unit
   rate_limit_period_multiplier       = var.rate_limit_period_multiplier
   rate_limit_burst_multiplier        = var.rate_limit_burst_multiplier
+  rate_limit_ip_allowed_prefixes     = var.rate_limit_ip_allowed_prefixes
+  rate_limit_custom_ip_prefix_sets   = var.rate_limit_custom_ip_prefix_sets
+  rate_limit_policy_refs             = var.rate_limit_policy_refs
+  api_rate_limit_endpoint_rules      = var.api_rate_limit_endpoint_rules
+  api_rate_limit_bypass_rules        = var.api_rate_limit_bypass_rules
+  api_rate_limit_server_url_rules    = var.api_rate_limit_server_url_rules
+  rate_limiters                      = var.rate_limiters
+  rate_limiter_policies              = var.rate_limiter_policies
   sensitive_data_compliances         = var.sensitive_data_compliances
   sensitive_data_disabled_predefined = var.sensitive_data_disabled_predefined
   sensitive_data_policy_choice       = var.sensitive_data_policy_choice

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -757,13 +757,465 @@ resource "xcsh_http_loadbalancer" "this" {
   dynamic "rate_limit" {
     for_each = var.rate_limit_choice == "rate_limit" ? [1] : []
     content {
-      no_ip_allowed_list {}
-      no_policies {}
+      # IP-allow-list oneof: no_ip_allowed_list (default) | ip_allowed_list (inline
+      # prefixes) | custom_ip_allowed_list (refs to ip_prefix_set objects).
+      dynamic "no_ip_allowed_list" {
+        for_each = (length(var.rate_limit_ip_allowed_prefixes) == 0 && length(var.rate_limit_custom_ip_prefix_sets) == 0) ? [1] : []
+        content {}
+      }
+      dynamic "ip_allowed_list" {
+        for_each = length(var.rate_limit_ip_allowed_prefixes) > 0 ? [1] : []
+        content {
+          prefixes = var.rate_limit_ip_allowed_prefixes
+        }
+      }
+      dynamic "custom_ip_allowed_list" {
+        for_each = length(var.rate_limit_custom_ip_prefix_sets) > 0 ? [1] : []
+        content {
+          dynamic "rate_limiter_allowed_prefixes" {
+            for_each = var.rate_limit_custom_ip_prefix_sets
+            content {
+              name      = rate_limiter_allowed_prefixes.value.name
+              namespace = coalesce(rate_limiter_allowed_prefixes.value.namespace, var.namespace)
+            }
+          }
+        }
+      }
+
+      # policies oneof: no_policies (default) | policies (refs to xcsh_rate_limiter_policy).
+      dynamic "no_policies" {
+        for_each = length(var.rate_limit_policy_refs) == 0 ? [1] : []
+        content {}
+      }
+      dynamic "policies" {
+        for_each = length(var.rate_limit_policy_refs) > 0 ? [1] : []
+        content {
+          dynamic "policies" {
+            for_each = var.rate_limit_policy_refs
+            iterator = pol
+            content {
+              name      = xcsh_rate_limiter_policy.this[pol.value].name
+              namespace = var.namespace
+            }
+          }
+        }
+      }
+
       rate_limiter {
         total_number      = var.rate_limit_total_number
         unit              = var.rate_limit_unit
         period_multiplier = var.rate_limit_period_multiplier
         burst_multiplier  = var.rate_limit_burst_multiplier
+      }
+    }
+  }
+
+  # Per-endpoint API rate limiting (Coverage Batch B, api_rate_limit arm). Selected
+  # with rate_limit_choice="api_rate_limit". api_endpoint_rules + bypass rules +
+  # server_url_rules, each with the shared client_matcher oneof (any_client default,
+  # import-suppressed). See variables_api_rate_limit.tf.
+  dynamic "api_rate_limit" {
+    for_each = var.rate_limit_choice == "api_rate_limit" ? [1] : []
+    content {
+      dynamic "api_endpoint_rules" {
+        for_each = var.api_rate_limit_endpoint_rules
+        iterator = ep
+        content {
+          api_endpoint_path = ep.value.api_endpoint_path
+          specific_domain   = ep.value.specific_domain
+          dynamic "any_domain" {
+            for_each = ep.value.specific_domain == null ? [1] : []
+            content {}
+          }
+          dynamic "api_endpoint_method" {
+            for_each = length(ep.value.methods) > 0 ? [1] : []
+            content {
+              methods        = ep.value.methods
+              invert_matcher = ep.value.methods_invert
+            }
+          }
+          dynamic "ref_rate_limiter" {
+            for_each = ep.value.ref_rate_limiter != null ? [1] : []
+            content {
+              name      = xcsh_rate_limiter.this[ep.value.ref_rate_limiter].name
+              namespace = var.namespace
+            }
+          }
+          dynamic "inline_rate_limiter" {
+            for_each = ep.value.inline_threshold != null ? [1] : []
+            content {
+              threshold = ep.value.inline_threshold
+              unit      = ep.value.inline_unit
+              dynamic "use_http_lb_user_id" {
+                for_each = ep.value.inline_user_id == "http_lb" ? [1] : []
+                content {}
+              }
+              dynamic "ref_user_id" {
+                for_each = ep.value.inline_user_id == "ref" ? [1] : []
+                content {
+                  name      = ep.value.inline_user_ref
+                  namespace = var.namespace
+                }
+              }
+            }
+          }
+          dynamic "client_matcher" {
+            for_each = ep.value.client_matcher != null && ep.value.client_matcher.mode != null ? [ep.value.client_matcher] : []
+            iterator = cm
+            content {
+              dynamic "any_ip" {
+                for_each = cm.value.mode == "any_ip" ? [1] : []
+                content {}
+              }
+              dynamic "asn_list" {
+                for_each = cm.value.mode == "asn_list" ? [1] : []
+                content { as_numbers = cm.value.as_numbers }
+              }
+              dynamic "asn_matcher" {
+                for_each = cm.value.mode == "asn_matcher" ? [1] : []
+                content {
+                  dynamic "asn_sets" {
+                    for_each = cm.value.asn_sets
+                    content {
+                      name      = asn_sets.value.name
+                      namespace = coalesce(asn_sets.value.namespace, var.namespace)
+                    }
+                  }
+                }
+              }
+              dynamic "client_selector" {
+                for_each = cm.value.mode == "client_selector" ? [1] : []
+                content { expressions = cm.value.selector_expressions }
+              }
+              dynamic "ip_matcher" {
+                for_each = cm.value.mode == "ip_matcher" ? [1] : []
+                content {
+                  invert_matcher = cm.value.ip_invert
+                  dynamic "prefix_sets" {
+                    for_each = cm.value.ip_prefix_sets
+                    content {
+                      name      = prefix_sets.value.name
+                      namespace = coalesce(prefix_sets.value.namespace, var.namespace)
+                    }
+                  }
+                }
+              }
+              dynamic "ip_prefix_list" {
+                for_each = cm.value.mode == "ip_prefix_list" ? [1] : []
+                content {
+                  ip_prefixes  = cm.value.ip_prefixes
+                  invert_match = cm.value.ip_invert
+                }
+              }
+              dynamic "ip_threat_category_list" {
+                for_each = cm.value.mode == "ip_threat_category_list" ? [1] : []
+                content { ip_threat_categories = cm.value.ip_threat_categories }
+              }
+              dynamic "tls_fingerprint_matcher" {
+                for_each = cm.value.mode == "tls_fingerprint_matcher" ? [1] : []
+                content {
+                  classes         = length(cm.value.tls_classes) > 0 ? cm.value.tls_classes : null
+                  exact_values    = length(cm.value.tls_exact_values) > 0 ? cm.value.tls_exact_values : null
+                  excluded_values = length(cm.value.tls_excluded_values) > 0 ? cm.value.tls_excluded_values : null
+                }
+              }
+            }
+          }
+          dynamic "request_matcher" {
+            for_each = ep.value.request_matcher != null ? [ep.value.request_matcher] : []
+            iterator = rm
+            content {
+              dynamic "cookie_matchers" {
+                for_each = rm.value.cookies
+                iterator = m
+                content {
+                  name           = m.value.name
+                  invert_matcher = m.value.invert
+                  dynamic "check_present" {
+                    for_each = m.value.presence == "present" ? [1] : []
+                    content {}
+                  }
+                  dynamic "check_not_present" {
+                    for_each = m.value.presence == "absent" ? [1] : []
+                    content {}
+                  }
+                  dynamic "item" {
+                    for_each = m.value.presence == "match" ? [1] : []
+                    content {
+                      exact_values = length(m.value.exact_values) > 0 ? m.value.exact_values : null
+                      regex_values = length(m.value.regex_values) > 0 ? m.value.regex_values : null
+                    }
+                  }
+                }
+              }
+              dynamic "headers" {
+                for_each = rm.value.headers
+                iterator = m
+                content {
+                  name           = m.value.name
+                  invert_matcher = m.value.invert
+                  dynamic "check_present" {
+                    for_each = m.value.presence == "present" ? [1] : []
+                    content {}
+                  }
+                  dynamic "check_not_present" {
+                    for_each = m.value.presence == "absent" ? [1] : []
+                    content {}
+                  }
+                  dynamic "item" {
+                    for_each = m.value.presence == "match" ? [1] : []
+                    content {
+                      exact_values = length(m.value.exact_values) > 0 ? m.value.exact_values : null
+                      regex_values = length(m.value.regex_values) > 0 ? m.value.regex_values : null
+                    }
+                  }
+                }
+              }
+              dynamic "jwt_claims" {
+                for_each = rm.value.jwt_claims
+                iterator = m
+                content {
+                  name           = m.value.name
+                  invert_matcher = m.value.invert
+                  dynamic "check_present" {
+                    for_each = m.value.presence == "present" ? [1] : []
+                    content {}
+                  }
+                  dynamic "check_not_present" {
+                    for_each = m.value.presence == "absent" ? [1] : []
+                    content {}
+                  }
+                  dynamic "item" {
+                    for_each = m.value.presence == "match" ? [1] : []
+                    content {
+                      exact_values = length(m.value.exact_values) > 0 ? m.value.exact_values : null
+                      regex_values = length(m.value.regex_values) > 0 ? m.value.regex_values : null
+                    }
+                  }
+                }
+              }
+              dynamic "query_params" {
+                for_each = rm.value.query_params
+                iterator = m
+                content {
+                  key            = m.value.name
+                  invert_matcher = m.value.invert
+                  dynamic "check_present" {
+                    for_each = m.value.presence == "present" ? [1] : []
+                    content {}
+                  }
+                  dynamic "check_not_present" {
+                    for_each = m.value.presence == "absent" ? [1] : []
+                    content {}
+                  }
+                  dynamic "item" {
+                    for_each = m.value.presence == "match" ? [1] : []
+                    content {
+                      exact_values = length(m.value.exact_values) > 0 ? m.value.exact_values : null
+                      regex_values = length(m.value.regex_values) > 0 ? m.value.regex_values : null
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      dynamic "bypass_rate_limiting_rules" {
+        for_each = length(var.api_rate_limit_bypass_rules) > 0 ? [1] : []
+        content {
+          dynamic "bypass_rate_limiting_rules" {
+            for_each = var.api_rate_limit_bypass_rules
+            iterator = bp
+            content {
+              base_path       = bp.value.target == "base_path" ? bp.value.base_path : null
+              specific_domain = bp.value.specific_domain
+              dynamic "any_domain" {
+                for_each = bp.value.specific_domain == null ? [1] : []
+                content {}
+              }
+              dynamic "any_url" {
+                for_each = bp.value.target == "any_url" ? [1] : []
+                content {}
+              }
+              dynamic "api_endpoint" {
+                for_each = bp.value.target == "api_endpoint" ? [1] : []
+                content {
+                  path    = bp.value.endpoint_path
+                  methods = length(bp.value.endpoint_methods) > 0 ? bp.value.endpoint_methods : null
+                }
+              }
+              dynamic "api_groups" {
+                for_each = bp.value.target == "api_groups" ? [1] : []
+                content { api_groups = bp.value.api_groups }
+              }
+              dynamic "client_matcher" {
+                for_each = bp.value.client_matcher != null && bp.value.client_matcher.mode != null ? [bp.value.client_matcher] : []
+                iterator = cm
+                content {
+                  dynamic "any_ip" {
+                    for_each = cm.value.mode == "any_ip" ? [1] : []
+                    content {}
+                  }
+                  dynamic "asn_list" {
+                    for_each = cm.value.mode == "asn_list" ? [1] : []
+                    content { as_numbers = cm.value.as_numbers }
+                  }
+                  dynamic "asn_matcher" {
+                    for_each = cm.value.mode == "asn_matcher" ? [1] : []
+                    content {
+                      dynamic "asn_sets" {
+                        for_each = cm.value.asn_sets
+                        content {
+                          name      = asn_sets.value.name
+                          namespace = coalesce(asn_sets.value.namespace, var.namespace)
+                        }
+                      }
+                    }
+                  }
+                  dynamic "client_selector" {
+                    for_each = cm.value.mode == "client_selector" ? [1] : []
+                    content { expressions = cm.value.selector_expressions }
+                  }
+                  dynamic "ip_matcher" {
+                    for_each = cm.value.mode == "ip_matcher" ? [1] : []
+                    content {
+                      invert_matcher = cm.value.ip_invert
+                      dynamic "prefix_sets" {
+                        for_each = cm.value.ip_prefix_sets
+                        content {
+                          name      = prefix_sets.value.name
+                          namespace = coalesce(prefix_sets.value.namespace, var.namespace)
+                        }
+                      }
+                    }
+                  }
+                  dynamic "ip_prefix_list" {
+                    for_each = cm.value.mode == "ip_prefix_list" ? [1] : []
+                    content {
+                      ip_prefixes  = cm.value.ip_prefixes
+                      invert_match = cm.value.ip_invert
+                    }
+                  }
+                  dynamic "ip_threat_category_list" {
+                    for_each = cm.value.mode == "ip_threat_category_list" ? [1] : []
+                    content { ip_threat_categories = cm.value.ip_threat_categories }
+                  }
+                  dynamic "tls_fingerprint_matcher" {
+                    for_each = cm.value.mode == "tls_fingerprint_matcher" ? [1] : []
+                    content {
+                      classes         = length(cm.value.tls_classes) > 0 ? cm.value.tls_classes : null
+                      exact_values    = length(cm.value.tls_exact_values) > 0 ? cm.value.tls_exact_values : null
+                      excluded_values = length(cm.value.tls_excluded_values) > 0 ? cm.value.tls_excluded_values : null
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      dynamic "server_url_rules" {
+        for_each = var.api_rate_limit_server_url_rules
+        iterator = su
+        content {
+          api_group       = su.value.api_group
+          base_path       = su.value.base_path
+          specific_domain = su.value.specific_domain
+          dynamic "any_domain" {
+            for_each = su.value.specific_domain == null ? [1] : []
+            content {}
+          }
+          dynamic "ref_rate_limiter" {
+            for_each = su.value.ref_rate_limiter != null ? [1] : []
+            content {
+              name      = xcsh_rate_limiter.this[su.value.ref_rate_limiter].name
+              namespace = var.namespace
+            }
+          }
+          dynamic "inline_rate_limiter" {
+            for_each = su.value.inline_threshold != null ? [1] : []
+            content {
+              threshold = su.value.inline_threshold
+              unit      = su.value.inline_unit
+              dynamic "use_http_lb_user_id" {
+                for_each = su.value.inline_user_id == "http_lb" ? [1] : []
+                content {}
+              }
+              dynamic "ref_user_id" {
+                for_each = su.value.inline_user_id == "ref" ? [1] : []
+                content {
+                  name      = su.value.inline_user_ref
+                  namespace = var.namespace
+                }
+              }
+            }
+          }
+          dynamic "client_matcher" {
+            for_each = su.value.client_matcher != null && su.value.client_matcher.mode != null ? [su.value.client_matcher] : []
+            iterator = cm
+            content {
+              dynamic "any_ip" {
+                for_each = cm.value.mode == "any_ip" ? [1] : []
+                content {}
+              }
+              dynamic "asn_list" {
+                for_each = cm.value.mode == "asn_list" ? [1] : []
+                content { as_numbers = cm.value.as_numbers }
+              }
+              dynamic "asn_matcher" {
+                for_each = cm.value.mode == "asn_matcher" ? [1] : []
+                content {
+                  dynamic "asn_sets" {
+                    for_each = cm.value.asn_sets
+                    content {
+                      name      = asn_sets.value.name
+                      namespace = coalesce(asn_sets.value.namespace, var.namespace)
+                    }
+                  }
+                }
+              }
+              dynamic "client_selector" {
+                for_each = cm.value.mode == "client_selector" ? [1] : []
+                content { expressions = cm.value.selector_expressions }
+              }
+              dynamic "ip_matcher" {
+                for_each = cm.value.mode == "ip_matcher" ? [1] : []
+                content {
+                  invert_matcher = cm.value.ip_invert
+                  dynamic "prefix_sets" {
+                    for_each = cm.value.ip_prefix_sets
+                    content {
+                      name      = prefix_sets.value.name
+                      namespace = coalesce(prefix_sets.value.namespace, var.namespace)
+                    }
+                  }
+                }
+              }
+              dynamic "ip_prefix_list" {
+                for_each = cm.value.mode == "ip_prefix_list" ? [1] : []
+                content {
+                  ip_prefixes  = cm.value.ip_prefixes
+                  invert_match = cm.value.ip_invert
+                }
+              }
+              dynamic "ip_threat_category_list" {
+                for_each = cm.value.mode == "ip_threat_category_list" ? [1] : []
+                content { ip_threat_categories = cm.value.ip_threat_categories }
+              }
+              dynamic "tls_fingerprint_matcher" {
+                for_each = cm.value.mode == "tls_fingerprint_matcher" ? [1] : []
+                content {
+                  classes         = length(cm.value.tls_classes) > 0 ? cm.value.tls_classes : null
+                  exact_values    = length(cm.value.tls_exact_values) > 0 ? cm.value.tls_exact_values : null
+                  excluded_values = length(cm.value.tls_excluded_values) > 0 ? cm.value.tls_excluded_values : null
+                }
+              }
+            }
+          }
+        }
       }
     }
   }
@@ -1053,6 +1505,43 @@ resource "xcsh_http_loadbalancer" "this" {
     precondition {
       condition     = var.api_validation_fall_through != "custom" || length(var.validation_custom_rules) > 0
       error_message = "api_validation_fall_through=\"custom\" requires at least one validation_custom_rules entry."
+    }
+
+    # rate_limit.policies references standalone rate_limiter_policies by name; each ref
+    # must resolve to a created policy, and policies only apply on the rate_limit arm.
+    precondition {
+      condition     = length(var.rate_limit_ip_allowed_prefixes) == 0 || length(var.rate_limit_custom_ip_prefix_sets) == 0
+      error_message = "set only one of rate_limit_ip_allowed_prefixes (inline) or rate_limit_custom_ip_prefix_sets (refs), not both."
+    }
+    precondition {
+      condition     = length(var.rate_limit_policy_refs) == 0 || var.rate_limit_choice == "rate_limit"
+      error_message = "rate_limit_policy_refs requires rate_limit_choice=\"rate_limit\"."
+    }
+    precondition {
+      condition     = (length(var.rate_limit_ip_allowed_prefixes) == 0 && length(var.rate_limit_custom_ip_prefix_sets) == 0) || var.rate_limit_choice == "rate_limit"
+      error_message = "rate_limit_ip_allowed_prefixes / rate_limit_custom_ip_prefix_sets require rate_limit_choice=\"rate_limit\"."
+    }
+    precondition {
+      condition     = var.rate_limit_choice != "api_rate_limit" || (length(var.api_rate_limit_endpoint_rules) + length(var.api_rate_limit_bypass_rules) + length(var.api_rate_limit_server_url_rules)) > 0
+      error_message = "rate_limit_choice=\"api_rate_limit\" requires at least one api_rate_limit_endpoint_rules / bypass_rules / server_url_rules entry."
+    }
+    precondition {
+      condition     = alltrue([for r in var.rate_limit_policy_refs : contains([for p in var.rate_limiter_policies : p.name], r)])
+      error_message = "every rate_limit_policy_refs entry must name a rate_limiter_policies entry."
+    }
+
+    # The api_rate_limit rule lists only apply on the api_rate_limit arm, and every
+    # ref_rate_limiter must resolve to a created xcsh_rate_limiter.
+    precondition {
+      condition     = var.rate_limit_choice == "api_rate_limit" || (length(var.api_rate_limit_endpoint_rules) == 0 && length(var.api_rate_limit_bypass_rules) == 0 && length(var.api_rate_limit_server_url_rules) == 0)
+      error_message = "api_rate_limit_* rules require rate_limit_choice=\"api_rate_limit\"."
+    }
+    precondition {
+      condition = alltrue(concat(
+        [for r in var.api_rate_limit_endpoint_rules : contains(keys(xcsh_rate_limiter.this), r.ref_rate_limiter) if r.ref_rate_limiter != null],
+        [for r in var.api_rate_limit_server_url_rules : contains(keys(xcsh_rate_limiter.this), r.ref_rate_limiter) if r.ref_rate_limiter != null],
+      ))
+      error_message = "every api_rate_limit ref_rate_limiter must name a rate_limiters entry."
     }
   }
 }

--- a/terraform/modules/http-lb/outputs_rate_limiter.tf
+++ b/terraform/modules/http-lb/outputs_rate_limiter.tf
@@ -1,0 +1,10 @@
+# Standalone rate-limiter outputs (Coverage Batch B) — names for wiring/assertions.
+output "rate_limiter_names" {
+  description = "Names of the standalone xcsh_rate_limiter resources created."
+  value       = sort([for rl in xcsh_rate_limiter.this : rl.name])
+}
+
+output "rate_limiter_count" {
+  description = "Number of standalone xcsh_rate_limiter resources created."
+  value       = length(xcsh_rate_limiter.this)
+}

--- a/terraform/modules/http-lb/outputs_rate_limiter_policy.tf
+++ b/terraform/modules/http-lb/outputs_rate_limiter_policy.tf
@@ -1,0 +1,10 @@
+# Standalone rate-limiter policy outputs (Coverage Batch B).
+output "rate_limiter_policy_names" {
+  description = "Names of the standalone xcsh_rate_limiter_policy resources created."
+  value       = sort([for p in xcsh_rate_limiter_policy.this : p.name])
+}
+
+output "rate_limiter_policy_count" {
+  description = "Number of standalone xcsh_rate_limiter_policy resources created."
+  value       = length(xcsh_rate_limiter_policy.this)
+}

--- a/terraform/modules/http-lb/rate_limiter.tf
+++ b/terraform/modules/http-lb/rate_limiter.tf
@@ -1,0 +1,66 @@
+# Standalone reusable rate limiters (Coverage Batch B). See variables_rate_limiter.tf.
+# for_each keyed by name so policies/api_rate_limit can reference a specific limiter
+# via xcsh_rate_limiter.this[<name>].
+resource "xcsh_rate_limiter" "this" {
+  for_each = { for rl in var.rate_limiters : rl.name => rl }
+
+  name      = each.value.name
+  namespace = var.namespace
+
+  dynamic "limits" {
+    for_each = each.value.limits
+    content {
+      total_number      = limits.value.total_number
+      unit              = limits.value.unit
+      burst_multiplier  = limits.value.burst_multiplier
+      period_multiplier = limits.value.period_multiplier
+
+      # action oneof: block (with a duration in the chosen unit) | disabled.
+      dynamic "action_block" {
+        for_each = limits.value.action == "block" ? [1] : []
+        content {
+          dynamic "hours" {
+            for_each = limits.value.action_block_unit == "hours" ? [1] : []
+            content {
+              duration = limits.value.action_block_duration
+            }
+          }
+          dynamic "minutes" {
+            for_each = limits.value.action_block_unit == "minutes" ? [1] : []
+            content {
+              duration = limits.value.action_block_duration
+            }
+          }
+          dynamic "seconds" {
+            for_each = limits.value.action_block_unit == "seconds" ? [1] : []
+            content {
+              duration = limits.value.action_block_duration
+            }
+          }
+        }
+      }
+      dynamic "disabled" {
+        for_each = limits.value.action == "disabled" ? [1] : []
+        content {}
+      }
+
+      # burst-algorithm oneof: leaky_bucket | token_bucket (omit => server default).
+      dynamic "leaky_bucket" {
+        for_each = limits.value.algorithm == "leaky_bucket" ? [1] : []
+        content {}
+      }
+      dynamic "token_bucket" {
+        for_each = limits.value.algorithm == "token_bucket" ? [1] : []
+        content {}
+      }
+    }
+  }
+
+  dynamic "user_identification" {
+    for_each = each.value.user_identification
+    content {
+      name      = user_identification.value.name
+      namespace = coalesce(user_identification.value.namespace, var.namespace)
+    }
+  }
+}

--- a/terraform/modules/http-lb/rate_limiter_policy.tf
+++ b/terraform/modules/http-lb/rate_limiter_policy.tf
@@ -1,0 +1,169 @@
+# Standalone rate-limiter policies (Coverage Batch B). See variables_rate_limiter_policy.tf.
+# for_each keyed by name so the LB rate_limit.policies arm can reference a specific
+# policy via xcsh_rate_limiter_policy.this[<name>].
+#
+# Optional list attributes are emitted as null (not []) when empty: F5 XC omits empty
+# lists on read, so forcing [] into the plan drifts against the read-back (plan []
+# vs state null => "inconsistent result after apply"). null matches the API's omit.
+resource "xcsh_rate_limiter_policy" "this" {
+  for_each = { for p in var.rate_limiter_policies : p.name => p }
+
+  name      = each.value.name
+  namespace = var.namespace
+
+  # server scope oneof
+  dynamic "any_server" {
+    for_each = each.value.server_scope == "any_server" ? [1] : []
+    content {}
+  }
+  dynamic "server_name_matcher" {
+    for_each = each.value.server_scope == "name_matcher" ? [1] : []
+    content {
+      exact_values = length(each.value.server_name_exact) > 0 ? each.value.server_name_exact : null
+      regex_values = length(each.value.server_name_regex) > 0 ? each.value.server_name_regex : null
+    }
+  }
+  dynamic "server_selector" {
+    for_each = each.value.server_scope == "selector" ? [1] : []
+    content {
+      expressions = length(each.value.server_selector) > 0 ? each.value.server_selector : null
+    }
+  }
+
+  dynamic "rules" {
+    for_each = each.value.rules
+    content {
+      metadata {
+        name = rules.value.name
+      }
+      spec {
+        # --- action oneof ---
+        dynamic "apply_rate_limiter" {
+          for_each = rules.value.action == "apply" ? [1] : []
+          content {}
+        }
+        dynamic "bypass_rate_limiter" {
+          for_each = rules.value.action == "bypass" ? [1] : []
+          content {}
+        }
+        dynamic "custom_rate_limiter" {
+          for_each = rules.value.action == "custom" ? [1] : []
+          content {
+            name      = xcsh_rate_limiter.this[rules.value.custom_rate_limiter].name
+            namespace = var.namespace
+          }
+        }
+
+        # --- ASN client matcher oneof (omit => server-default any_asn, import-suppressed) ---
+        dynamic "asn_list" {
+          for_each = rules.value.asn == "list" ? [1] : []
+          content {
+            as_numbers = rules.value.asn_numbers
+          }
+        }
+        dynamic "asn_matcher" {
+          for_each = rules.value.asn == "matcher" ? [1] : []
+          content {
+            dynamic "asn_sets" {
+              for_each = rules.value.asn_sets
+              content {
+                name      = asn_sets.value.name
+                namespace = coalesce(asn_sets.value.namespace, var.namespace)
+              }
+            }
+          }
+        }
+
+        # --- IP client matcher oneof (omit => server-default any_ip, import-suppressed) ---
+        dynamic "ip_prefix_list" {
+          for_each = rules.value.ip == "prefix_list" ? [1] : []
+          content {
+            ip_prefixes  = rules.value.ip_prefixes
+            invert_match = rules.value.ip_invert
+          }
+        }
+        dynamic "ip_matcher" {
+          for_each = rules.value.ip == "matcher" ? [1] : []
+          content {
+            invert_matcher = rules.value.ip_invert
+            dynamic "prefix_sets" {
+              for_each = rules.value.ip_sets
+              content {
+                name      = prefix_sets.value.name
+                namespace = coalesce(prefix_sets.value.namespace, var.namespace)
+              }
+            }
+          }
+        }
+
+        # --- Country client matcher oneof (omit => server-default any_country, import-suppressed) ---
+        dynamic "country_list" {
+          for_each = rules.value.country == "list" ? [1] : []
+          content {
+            country_codes = rules.value.countries
+            invert_match  = rules.value.country_invert
+          }
+        }
+
+        # --- request matchers ---
+        dynamic "http_method" {
+          for_each = length(rules.value.http_methods) > 0 ? [1] : []
+          content {
+            methods        = rules.value.http_methods
+            invert_matcher = rules.value.http_methods_invert
+          }
+        }
+        dynamic "path" {
+          for_each = (length(rules.value.path_exact) + length(rules.value.path_prefixes) + length(rules.value.path_regex) + length(rules.value.path_suffix)) > 0 ? [1] : []
+          content {
+            exact_values   = length(rules.value.path_exact) > 0 ? rules.value.path_exact : null
+            prefix_values  = length(rules.value.path_prefixes) > 0 ? rules.value.path_prefixes : null
+            regex_values   = length(rules.value.path_regex) > 0 ? rules.value.path_regex : null
+            suffix_values  = length(rules.value.path_suffix) > 0 ? rules.value.path_suffix : null
+            invert_matcher = rules.value.path_invert
+          }
+        }
+        dynamic "domain_matcher" {
+          for_each = (length(rules.value.domain_exact) + length(rules.value.domain_regex)) > 0 ? [1] : []
+          content {
+            exact_values = length(rules.value.domain_exact) > 0 ? rules.value.domain_exact : null
+            regex_values = length(rules.value.domain_regex) > 0 ? rules.value.domain_regex : null
+          }
+        }
+        dynamic "headers" {
+          for_each = rules.value.headers
+          content {
+            name           = headers.value.name
+            invert_matcher = headers.value.invert
+            dynamic "check_present" {
+              for_each = headers.value.presence == "present" ? [1] : []
+              content {}
+            }
+            dynamic "check_not_present" {
+              for_each = headers.value.presence == "absent" ? [1] : []
+              content {}
+            }
+            dynamic "item" {
+              for_each = headers.value.presence == "match" ? [1] : []
+              content {
+                exact_values = length(headers.value.exact_values) > 0 ? headers.value.exact_values : null
+                regex_values = length(headers.value.regex_values) > 0 ? headers.value.regex_values : null
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  # A rule referencing a custom rate limiter requires that limiter to exist.
+  lifecycle {
+    precondition {
+      condition = alltrue([
+        for r in each.value.rules :
+        r.action != "custom" || contains(keys(xcsh_rate_limiter.this), r.custom_rate_limiter)
+      ])
+      error_message = "rate_limiter_policy '${each.value.name}' has a rule with action=custom referencing a custom_rate_limiter not present in var.rate_limiters."
+    }
+  }
+}

--- a/terraform/modules/http-lb/variables_api_rate_limit.tf
+++ b/terraform/modules/http-lb/variables_api_rate_limit.tf
@@ -1,0 +1,250 @@
+# ---------------------------------------------------------------------------
+# Per-endpoint API rate limiting (Coverage Batch B) — the api_rate_limit arm of
+# rate_limit_choice (the 3rd arm alongside rate_limit and the disable default).
+# Selected with rate_limit_choice = "api_rate_limit". Carries:
+#   api_endpoint_rules[]        - per endpoint: path/domain/method + a limiter
+#                                 (ref or inline) + client_matcher + request_matcher
+#   bypass_rate_limiting_rules[]- exempt endpoints/URLs/groups from rate limiting
+#   server_url_rules[]          - per base_path/api_group + limiter + client_matcher
+#
+# The client_matcher oneof (shared by all three rule kinds) selects on the caller:
+#   any_client (omit) | any_ip | asn_list | asn_matcher | client_selector |
+#   ip_matcher | ip_prefix_list | ip_threat_category_list | tls_fingerprint_matcher
+# Server-default any_client/any_ip markers are import-suppressed, so omit=0-change.
+# ---------------------------------------------------------------------------
+
+variable "api_rate_limit_endpoint_rules" {
+  description = "api_rate_limit.api_endpoint_rules: per-endpoint rate limits (path/method/domain + ref_rate_limiter or inline limiter + optional client_matcher/request_matcher)."
+  type = list(object({
+    api_endpoint_path = string
+    methods           = optional(list(string), [])
+    methods_invert    = optional(bool, false)
+    specific_domain   = optional(string) # null => any_domain
+    # limiter oneof: ref_rate_limiter (a var.rate_limiters name) OR inline_*
+    ref_rate_limiter = optional(string)
+    inline_threshold = optional(number)
+    inline_unit      = optional(string, "MINUTE")  # SECOND | MINUTE | HOUR
+    inline_user_id   = optional(string, "http_lb") # http_lb | ref
+    inline_user_ref  = optional(string)            # user_identification ref name (inline_user_id=ref)
+    client_matcher = optional(object({
+      mode                 = optional(string) # any_ip|asn_list|asn_matcher|client_selector|ip_matcher|ip_prefix_list|ip_threat_category_list|tls_fingerprint_matcher
+      as_numbers           = optional(list(number), [])
+      asn_sets             = optional(list(object({ name = string, namespace = optional(string) })), [])
+      selector_expressions = optional(list(string), [])
+      ip_prefix_sets       = optional(list(object({ name = string, namespace = optional(string) })), [])
+      ip_prefixes          = optional(list(string), [])
+      ip_invert            = optional(bool, false)
+      ip_threat_categories = optional(list(string), [])
+      tls_classes          = optional(list(string), [])
+      tls_exact_values     = optional(list(string), [])
+      tls_excluded_values  = optional(list(string), [])
+    }))
+    request_matcher = optional(object({
+      cookies      = optional(list(object({ name = string, invert = optional(bool, false), presence = optional(string, "match"), exact_values = optional(list(string), []), regex_values = optional(list(string), []) })), [])
+      headers      = optional(list(object({ name = string, invert = optional(bool, false), presence = optional(string, "match"), exact_values = optional(list(string), []), regex_values = optional(list(string), []) })), [])
+      jwt_claims   = optional(list(object({ name = string, invert = optional(bool, false), presence = optional(string, "match"), exact_values = optional(list(string), []), regex_values = optional(list(string), []) })), [])
+      query_params = optional(list(object({ name = string, invert = optional(bool, false), presence = optional(string, "match"), exact_values = optional(list(string), []), regex_values = optional(list(string), []) })), [])
+    }))
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for r in var.api_rate_limit_endpoint_rules :
+      (r.ref_rate_limiter != null) != (r.inline_threshold != null)
+    ])
+    error_message = "each api_rate_limit_endpoint_rules entry must set exactly one of ref_rate_limiter or inline_threshold."
+  }
+
+  validation {
+    condition = alltrue([
+      for r in var.api_rate_limit_endpoint_rules :
+      r.inline_threshold == null || contains(["SECOND", "MINUTE", "HOUR"], r.inline_unit)
+    ])
+    error_message = "api_rate_limit_endpoint_rules inline_unit must be SECOND, MINUTE, or HOUR."
+  }
+
+  validation {
+    condition = alltrue([
+      for r in var.api_rate_limit_endpoint_rules :
+      r.inline_user_id == "http_lb" || (r.inline_user_id == "ref" && r.inline_user_ref != null)
+    ])
+    error_message = "api_rate_limit_endpoint_rules inline_user_id must be http_lb, or ref with inline_user_ref set."
+  }
+
+  validation {
+    condition = alltrue([
+      for r in var.api_rate_limit_endpoint_rules :
+      r.client_matcher == null || r.client_matcher.mode == null || contains(["any_ip", "asn_list", "asn_matcher", "client_selector", "ip_matcher", "ip_prefix_list", "ip_threat_category_list", "tls_fingerprint_matcher"], r.client_matcher.mode)
+    ])
+    error_message = "api_rate_limit_endpoint_rules client_matcher.mode is invalid (omit=any_client)."
+  }
+
+  validation {
+    condition = alltrue([
+      for r in var.api_rate_limit_endpoint_rules :
+      r.client_matcher == null || r.client_matcher.mode == null || (
+        (r.client_matcher.mode != "asn_list" || length(r.client_matcher.as_numbers) > 0) &&
+        (r.client_matcher.mode != "asn_matcher" || length(r.client_matcher.asn_sets) > 0) &&
+        (r.client_matcher.mode != "client_selector" || length(r.client_matcher.selector_expressions) > 0) &&
+        (r.client_matcher.mode != "ip_matcher" || length(r.client_matcher.ip_prefix_sets) > 0) &&
+        (r.client_matcher.mode != "ip_prefix_list" || length(r.client_matcher.ip_prefixes) > 0) &&
+        (r.client_matcher.mode != "ip_threat_category_list" || length(r.client_matcher.ip_threat_categories) > 0)
+      )
+    ])
+    error_message = "api_rate_limit_endpoint_rules: a selected client_matcher.mode needs its payload list (asn_list⇒as_numbers, asn_matcher⇒asn_sets, client_selector⇒selector_expressions, ip_matcher⇒ip_prefix_sets, ip_prefix_list⇒ip_prefixes, ip_threat_category_list⇒ip_threat_categories)."
+  }
+}
+
+variable "api_rate_limit_bypass_rules" {
+  description = "api_rate_limit.bypass_rate_limiting_rules: endpoints/URLs/API groups exempt from rate limiting."
+  type = list(object({
+    specific_domain = optional(string) # null => any_domain
+    # url oneof: any_url | base_path (prefix) | api_endpoint {path, methods} | api_groups
+    target           = optional(string, "any_url") # any_url | base_path | api_endpoint | api_groups
+    base_path        = optional(string)            # required when target=base_path
+    endpoint_path    = optional(string)
+    endpoint_methods = optional(list(string), [])
+    api_groups       = optional(list(string), [])
+    client_matcher = optional(object({
+      mode                 = optional(string)
+      as_numbers           = optional(list(number), [])
+      asn_sets             = optional(list(object({ name = string, namespace = optional(string) })), [])
+      selector_expressions = optional(list(string), [])
+      ip_prefix_sets       = optional(list(object({ name = string, namespace = optional(string) })), [])
+      ip_prefixes          = optional(list(string), [])
+      ip_invert            = optional(bool, false)
+      ip_threat_categories = optional(list(string), [])
+      tls_classes          = optional(list(string), [])
+      tls_exact_values     = optional(list(string), [])
+      tls_excluded_values  = optional(list(string), [])
+    }))
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for r in var.api_rate_limit_bypass_rules : contains(["any_url", "base_path", "api_endpoint", "api_groups"], r.target)
+    ])
+    error_message = "api_rate_limit_bypass_rules target must be any_url, base_path, api_endpoint, or api_groups."
+  }
+
+  validation {
+    condition = alltrue([
+      for r in var.api_rate_limit_bypass_rules : r.target != "base_path" || r.base_path != null
+    ])
+    error_message = "api_rate_limit_bypass_rules with target=base_path require base_path."
+  }
+
+  validation {
+    condition = alltrue([
+      for r in var.api_rate_limit_bypass_rules : r.target != "api_endpoint" || r.endpoint_path != null
+    ])
+    error_message = "api_rate_limit_bypass_rules with target=api_endpoint require endpoint_path."
+  }
+
+  validation {
+    condition = alltrue([
+      for r in var.api_rate_limit_bypass_rules : r.target != "api_groups" || length(r.api_groups) > 0
+    ])
+    error_message = "api_rate_limit_bypass_rules with target=api_groups require a non-empty api_groups list."
+  }
+
+  validation {
+    condition = alltrue([
+      for r in var.api_rate_limit_bypass_rules :
+      r.client_matcher == null || r.client_matcher.mode == null || contains(["any_ip", "asn_list", "asn_matcher", "client_selector", "ip_matcher", "ip_prefix_list", "ip_threat_category_list", "tls_fingerprint_matcher"], r.client_matcher.mode)
+    ])
+    error_message = "api_rate_limit_bypass_rules client_matcher.mode is invalid (omit=any_client)."
+  }
+
+  validation {
+    condition = alltrue([
+      for r in var.api_rate_limit_bypass_rules :
+      r.client_matcher == null || r.client_matcher.mode == null || (
+        (r.client_matcher.mode != "asn_list" || length(r.client_matcher.as_numbers) > 0) &&
+        (r.client_matcher.mode != "asn_matcher" || length(r.client_matcher.asn_sets) > 0) &&
+        (r.client_matcher.mode != "client_selector" || length(r.client_matcher.selector_expressions) > 0) &&
+        (r.client_matcher.mode != "ip_matcher" || length(r.client_matcher.ip_prefix_sets) > 0) &&
+        (r.client_matcher.mode != "ip_prefix_list" || length(r.client_matcher.ip_prefixes) > 0) &&
+        (r.client_matcher.mode != "ip_threat_category_list" || length(r.client_matcher.ip_threat_categories) > 0)
+      )
+    ])
+    error_message = "api_rate_limit_bypass_rules: a selected client_matcher.mode needs its payload list (see endpoint-rules message)."
+  }
+}
+
+variable "api_rate_limit_server_url_rules" {
+  description = "api_rate_limit.server_url_rules: per base_path/api_group rate limits (limiter + optional client_matcher)."
+  type = list(object({
+    api_group        = optional(string)
+    base_path        = optional(string)
+    specific_domain  = optional(string) # null => any_domain
+    ref_rate_limiter = optional(string)
+    inline_threshold = optional(number)
+    inline_unit      = optional(string, "MINUTE")
+    inline_user_id   = optional(string, "http_lb")
+    inline_user_ref  = optional(string)
+    client_matcher = optional(object({
+      mode                 = optional(string)
+      as_numbers           = optional(list(number), [])
+      asn_sets             = optional(list(object({ name = string, namespace = optional(string) })), [])
+      selector_expressions = optional(list(string), [])
+      ip_prefix_sets       = optional(list(object({ name = string, namespace = optional(string) })), [])
+      ip_prefixes          = optional(list(string), [])
+      ip_invert            = optional(bool, false)
+      ip_threat_categories = optional(list(string), [])
+      tls_classes          = optional(list(string), [])
+      tls_exact_values     = optional(list(string), [])
+      tls_excluded_values  = optional(list(string), [])
+    }))
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for r in var.api_rate_limit_server_url_rules :
+      (r.ref_rate_limiter != null) != (r.inline_threshold != null)
+    ])
+    error_message = "each api_rate_limit_server_url_rules entry must set exactly one of ref_rate_limiter or inline_threshold."
+  }
+
+  validation {
+    condition = alltrue([
+      for r in var.api_rate_limit_server_url_rules :
+      r.inline_threshold == null || contains(["SECOND", "MINUTE", "HOUR"], r.inline_unit)
+    ])
+    error_message = "api_rate_limit_server_url_rules inline_unit must be SECOND, MINUTE, or HOUR."
+  }
+
+  validation {
+    condition = alltrue([
+      for r in var.api_rate_limit_server_url_rules :
+      r.inline_user_id == "http_lb" || (r.inline_user_id == "ref" && r.inline_user_ref != null)
+    ])
+    error_message = "api_rate_limit_server_url_rules inline_user_id must be http_lb, or ref with inline_user_ref set."
+  }
+
+  validation {
+    condition = alltrue([
+      for r in var.api_rate_limit_server_url_rules :
+      r.client_matcher == null || r.client_matcher.mode == null || contains(["any_ip", "asn_list", "asn_matcher", "client_selector", "ip_matcher", "ip_prefix_list", "ip_threat_category_list", "tls_fingerprint_matcher"], r.client_matcher.mode)
+    ])
+    error_message = "api_rate_limit_server_url_rules client_matcher.mode is invalid (omit=any_client)."
+  }
+
+  validation {
+    condition = alltrue([
+      for r in var.api_rate_limit_server_url_rules :
+      r.client_matcher == null || r.client_matcher.mode == null || (
+        (r.client_matcher.mode != "asn_list" || length(r.client_matcher.as_numbers) > 0) &&
+        (r.client_matcher.mode != "asn_matcher" || length(r.client_matcher.asn_sets) > 0) &&
+        (r.client_matcher.mode != "client_selector" || length(r.client_matcher.selector_expressions) > 0) &&
+        (r.client_matcher.mode != "ip_matcher" || length(r.client_matcher.ip_prefix_sets) > 0) &&
+        (r.client_matcher.mode != "ip_prefix_list" || length(r.client_matcher.ip_prefixes) > 0) &&
+        (r.client_matcher.mode != "ip_threat_category_list" || length(r.client_matcher.ip_threat_categories) > 0)
+      )
+    ])
+    error_message = "api_rate_limit_server_url_rules: a selected client_matcher.mode needs its payload list (see endpoint-rules message)."
+  }
+}

--- a/terraform/modules/http-lb/variables_rate_limit.tf
+++ b/terraform/modules/http-lb/variables_rate_limit.tf
@@ -7,13 +7,13 @@
 # (server-scoped, references a separate xcsh_rate_limiter) are advanced paths
 # deferred this cycle — see docs/superpowers/plans/sp3-findings.md.
 variable "rate_limit_choice" {
-  description = "rate_limit_choice: disable (server default, suppressed) or rate_limit (inline request rate limiter)."
+  description = "rate_limit_choice: disable (server default, suppressed), rate_limit (inline request rate limiter), or api_rate_limit (per-endpoint rules)."
   type        = string
   default     = "disable"
 
   validation {
-    condition     = contains(["disable", "rate_limit"], var.rate_limit_choice)
-    error_message = "rate_limit_choice must be \"disable\" or \"rate_limit\"."
+    condition     = contains(["disable", "rate_limit", "api_rate_limit"], var.rate_limit_choice)
+    error_message = "rate_limit_choice must be \"disable\", \"rate_limit\", or \"api_rate_limit\"."
   }
 }
 
@@ -23,8 +23,8 @@ variable "rate_limit_total_number" {
   default     = 100
 
   validation {
-    condition     = var.rate_limit_total_number >= 1
-    error_message = "rate_limit_total_number must be >= 1."
+    condition     = var.rate_limit_total_number >= 1 && var.rate_limit_total_number <= 8192
+    error_message = "rate_limit_total_number must be between 1 and 8192 (F5 XC inline rate_limiter cap)."
   }
 }
 
@@ -59,4 +59,30 @@ variable "rate_limit_burst_multiplier" {
     condition     = var.rate_limit_burst_multiplier >= 1
     error_message = "rate_limit_burst_multiplier must be >= 1."
   }
+}
+
+# --- LB rate_limit allow-list + policy refs (Coverage Batch B) ---
+# The rate_limit block carries an IP-allow-list oneof (no_ip_allowed_list default |
+# ip_allowed_list inline prefixes | custom_ip_allowed_list refs to ip_prefix_set) and a
+# policies oneof (no_policies default | policies refs to xcsh_rate_limiter_policy).
+# Empty defaults keep the SP3 behavior (no_ip_allowed_list + no_policies), 0-change.
+variable "rate_limit_ip_allowed_prefixes" {
+  description = "rate_limit.ip_allowed_list.prefixes: IP prefixes exempt from rate limiting. Empty => no_ip_allowed_list (unless custom sets are used)."
+  type        = list(string)
+  default     = []
+}
+
+variable "rate_limit_custom_ip_prefix_sets" {
+  description = "rate_limit.custom_ip_allowed_list.rate_limiter_allowed_prefixes: references to existing ip_prefix_set objects exempt from rate limiting."
+  type = list(object({
+    name      = string
+    namespace = optional(string)
+  }))
+  default = []
+}
+
+variable "rate_limit_policy_refs" {
+  description = "rate_limit.policies: names of var.rate_limiter_policies to attach. Empty => no_policies."
+  type        = list(string)
+  default     = []
 }

--- a/terraform/modules/http-lb/variables_rate_limiter.tf
+++ b/terraform/modules/http-lb/variables_rate_limiter.tf
@@ -1,0 +1,83 @@
+# ---------------------------------------------------------------------------
+# Standalone reusable rate limiters (Coverage Batch B). Creates xcsh_rate_limiter
+# objects that other resources reference by name: xcsh_rate_limiter_policy rules
+# (apply_rate_limiter / custom_rate_limiter) and the LB api_rate_limit arm
+# (ref_rate_limiter). Default [] creates none (0-change).
+#
+# Each limits[] entry carries two INDEPENDENT server oneofs plus the rate scalars:
+#   - action:    "block" -> action_block { <action_block_unit> { duration } }
+#                "disabled" -> disabled {}                 (null omits the arm)
+#   - algorithm: "leaky_bucket" | "token_bucket"           (null omits => server default)
+# unit is SECOND | MINUTE | HOUR (the standalone schema does NOT accept DAY).
+# ---------------------------------------------------------------------------
+variable "rate_limiters" {
+  description = "Standalone xcsh_rate_limiter definitions (referenced by rate-limiter policies and the api_rate_limit arm), keyed by name."
+  type = list(object({
+    name = string
+    limits = optional(list(object({
+      total_number          = number
+      unit                  = optional(string, "MINUTE") # SECOND | MINUTE | HOUR
+      burst_multiplier      = optional(number)
+      period_multiplier     = optional(number)
+      action                = optional(string)            # block | disabled | null(omit)
+      action_block_unit     = optional(string, "seconds") # hours | minutes | seconds
+      action_block_duration = optional(number)
+      algorithm             = optional(string) # leaky_bucket | token_bucket | null(omit)
+    })), [])
+    user_identification = optional(list(object({
+      name      = string
+      namespace = optional(string) # defaults to the LB namespace
+    })), [])
+  }))
+  default = []
+
+  validation {
+    condition     = length(var.rate_limiters) == length(distinct([for rl in var.rate_limiters : rl.name]))
+    error_message = "rate_limiters names must be unique."
+  }
+
+  validation {
+    condition = alltrue([
+      for rl in var.rate_limiters : alltrue([
+        for l in rl.limits : contains(["SECOND", "MINUTE", "HOUR"], l.unit)
+      ])
+    ])
+    error_message = "rate_limiters limits.unit must be SECOND, MINUTE, or HOUR (DAY is not accepted by xcsh_rate_limiter)."
+  }
+
+  validation {
+    condition = alltrue([
+      for rl in var.rate_limiters : alltrue([
+        for l in rl.limits : l.total_number >= 1
+      ])
+    ])
+    error_message = "rate_limiters limits.total_number must be >= 1."
+  }
+
+  validation {
+    condition = alltrue([
+      for rl in var.rate_limiters : alltrue([
+        for l in rl.limits : l.action == null || contains(["block", "disabled"], l.action)
+      ])
+    ])
+    error_message = "rate_limiters limits.action must be \"block\", \"disabled\", or null."
+  }
+
+  validation {
+    condition = alltrue([
+      for rl in var.rate_limiters : alltrue([
+        for l in rl.limits : l.action != "block" || (l.action_block_duration != null && contains(["hours", "minutes", "seconds"], l.action_block_unit))
+      ])
+    ])
+    error_message = "when limits.action=\"block\", action_block_duration is required and action_block_unit must be hours, minutes, or seconds."
+  }
+
+  validation {
+    condition = alltrue([
+      for rl in var.rate_limiters : alltrue([
+        for l in rl.limits : l.algorithm == null || contains(["leaky_bucket", "token_bucket"], l.algorithm)
+      ])
+    ])
+    error_message = "rate_limiters limits.algorithm must be \"leaky_bucket\", \"token_bucket\", or null."
+  }
+}

--- a/terraform/modules/http-lb/variables_rate_limiter_policy.tf
+++ b/terraform/modules/http-lb/variables_rate_limiter_policy.tf
@@ -1,0 +1,168 @@
+# ---------------------------------------------------------------------------
+# Standalone rate-limiter policies (Coverage Batch B). Creates xcsh_rate_limiter_policy
+# objects referenced by the LB rate_limit.policies arm. A policy scopes to a set of
+# servers (any_server | server_name_matcher | server_selector) and carries ordered
+# rules[]; each rule combines match conditions with an action:
+#   action = "apply"  -> apply_rate_limiter {}   (apply the server-default limiter)
+#            "bypass" -> bypass_rate_limiter {}  (skip rate limiting)
+#            "custom" -> custom_rate_limiter ref -> a var.rate_limiters entry (by name)
+# Rule match conditions (all optional; omit => match all):
+#   asn:     "any" | "list" (asn_numbers) | "matcher" (asn_sets refs)
+#   ip:      "any" | "prefix_list" (ip_prefixes) | "matcher" (ip_prefix_sets refs)
+#   country: "any" | "list" (country_codes)
+#   http_methods, path_* , domain_* , headers[]
+# Default [] creates no policies (0-change).
+# ---------------------------------------------------------------------------
+variable "rate_limiter_policies" {
+  description = "Standalone xcsh_rate_limiter_policy definitions (referenced by LB rate_limit.policies), keyed by name."
+  type = list(object({
+    name              = string
+    server_scope      = optional(string, "any_server") # any_server | name_matcher | selector
+    server_name_exact = optional(list(string), [])
+    server_name_regex = optional(list(string), [])
+    server_selector   = optional(list(string), []) # label expressions for server_selector
+    rules = optional(list(object({
+      name                = string
+      action              = optional(string, "apply") # apply | bypass | custom
+      custom_rate_limiter = optional(string)          # name of a var.rate_limiters entry (action=custom)
+      # client matchers. Omit to match any: the server-default any_asn/any_ip/any_country
+      # markers are import-suppressed, so an omitted matcher round-trips 0-change.
+      asn            = optional(string) # list | matcher | null(omit=any)
+      asn_numbers    = optional(list(number), [])
+      asn_sets       = optional(list(object({ name = string, namespace = optional(string) })), [])
+      ip             = optional(string) # prefix_list | matcher | null(omit=any)
+      ip_prefixes    = optional(list(string), [])
+      ip_invert      = optional(bool, false)
+      ip_sets        = optional(list(object({ name = string, namespace = optional(string) })), [])
+      country        = optional(string) # list | null(omit=any)
+      countries      = optional(list(string), [])
+      country_invert = optional(bool, false)
+      # request matchers
+      http_methods        = optional(list(string), [])
+      http_methods_invert = optional(bool, false)
+      path_exact          = optional(list(string), [])
+      path_prefixes       = optional(list(string), [])
+      path_regex          = optional(list(string), [])
+      path_suffix         = optional(list(string), [])
+      path_invert         = optional(bool, false)
+      domain_exact        = optional(list(string), [])
+      domain_regex        = optional(list(string), [])
+      headers = optional(list(object({
+        name         = string
+        invert       = optional(bool, false)
+        presence     = optional(string, "match") # present | absent | match
+        exact_values = optional(list(string), [])
+        regex_values = optional(list(string), [])
+      })), [])
+    })), [])
+  }))
+  default = []
+
+  validation {
+    condition     = length(var.rate_limiter_policies) == length(distinct([for p in var.rate_limiter_policies : p.name]))
+    error_message = "rate_limiter_policies names must be unique."
+  }
+
+  validation {
+    condition = alltrue([
+      for p in var.rate_limiter_policies : contains(["any_server", "name_matcher", "selector"], p.server_scope)
+    ])
+    error_message = "rate_limiter_policies server_scope must be any_server, name_matcher, or selector."
+  }
+
+  validation {
+    condition = alltrue([
+      for p in var.rate_limiter_policies : alltrue([
+        for r in p.rules : contains(["apply", "bypass", "custom"], r.action)
+      ])
+    ])
+    error_message = "rate_limiter_policies rules.action must be apply, bypass, or custom."
+  }
+
+  validation {
+    condition = alltrue([
+      for p in var.rate_limiter_policies : alltrue([
+        for r in p.rules : r.action != "custom" || (r.custom_rate_limiter != null && r.custom_rate_limiter != "")
+      ])
+    ])
+    error_message = "rate_limiter_policies rules with action=custom must set custom_rate_limiter (a rate_limiters name)."
+  }
+
+  validation {
+    condition = alltrue([
+      for p in var.rate_limiter_policies : alltrue([
+        for r in p.rules : r.asn == null || contains(["list", "matcher"], r.asn)
+      ])
+    ])
+    error_message = "rate_limiter_policies rules.asn must be list, matcher, or null (omit=match any)."
+  }
+
+  validation {
+    condition = alltrue([
+      for p in var.rate_limiter_policies : alltrue([
+        for r in p.rules : r.ip == null || contains(["prefix_list", "matcher"], r.ip)
+      ])
+    ])
+    error_message = "rate_limiter_policies rules.ip must be prefix_list, matcher, or null (omit=match any)."
+  }
+
+  validation {
+    condition = alltrue([
+      for p in var.rate_limiter_policies : alltrue([
+        for r in p.rules : r.country == null || contains(["list"], r.country)
+      ])
+    ])
+    error_message = "rate_limiter_policies rules.country must be list or null (omit=match any)."
+  }
+
+  # F5 XC CountryCode is an enum; codes take the COUNTRY_<ISO> form (e.g. COUNTRY_US),
+  # not the bare ISO code. Guard the prefix to catch the common "US"/"CA" mistake early.
+  validation {
+    condition = alltrue([
+      for p in var.rate_limiter_policies : alltrue([
+        for r in p.rules : alltrue([
+          for c in r.countries : startswith(c, "COUNTRY_")
+        ])
+      ])
+    ])
+    error_message = "rate_limiter_policies rules.countries must be F5 XC CountryCode enums (COUNTRY_<ISO>, e.g. COUNTRY_US)."
+  }
+
+  validation {
+    condition = alltrue([
+      for p in var.rate_limiter_policies : alltrue([
+        for r in p.rules : alltrue([
+          for h in r.headers : contains(["present", "absent", "match"], h.presence)
+        ])
+      ])
+    ])
+    error_message = "rate_limiter_policies rules.headers.presence must be present, absent, or match."
+  }
+
+  validation {
+    condition = alltrue([
+      for p in var.rate_limiter_policies : alltrue([
+        for r in p.rules : length(p.rules) == length(distinct([for x in p.rules : x.name]))
+      ])
+    ])
+    error_message = "rate_limiter_policies rule names must be unique within a policy."
+  }
+
+  # A selected list-bearing matcher arm must carry a non-empty payload — an empty
+  # asn_list/ip_prefix_list/country_list (or a *_matcher with no set refs) is an
+  # API-invalid object. Mirrors the action=block/custom payload guards above.
+  validation {
+    condition = alltrue([
+      for p in var.rate_limiter_policies : alltrue([
+        for r in p.rules : (
+          (r.asn != "list" || length(r.asn_numbers) > 0) &&
+          (r.asn != "matcher" || length(r.asn_sets) > 0) &&
+          (r.ip != "prefix_list" || length(r.ip_prefixes) > 0) &&
+          (r.ip != "matcher" || length(r.ip_sets) > 0) &&
+          (r.country != "list" || length(r.countries) > 0)
+        )
+      ])
+    ])
+    error_message = "rate_limiter_policies: a selected matcher arm needs its payload (asn=list⇒asn_numbers, asn=matcher⇒asn_sets, ip=prefix_list⇒ip_prefixes, ip=matcher⇒ip_sets, country=list⇒countries)."
+  }
+}

--- a/terraform/tests/rate_limiting.tftest.hcl
+++ b/terraform/tests/rate_limiting.tftest.hcl
@@ -1,0 +1,651 @@
+# Plan-level tests for the full rate-limiting surface (Coverage Batch B):
+# standalone xcsh_rate_limiter (Stage 1), xcsh_rate_limiter_policy (Stage 2),
+# LB rate_limit allow-lists/policies (Stage 3), and the api_rate_limit arm (Stage 4).
+# Targets ./modules/http-lb. Defaults keep everything off (0-change).
+variables {
+  namespace         = "webapp-api-protection"
+  lb_domains        = ["www.f5-sales-demo.com"]
+  origin_ip         = "203.0.113.10"
+  origin_port       = 80
+  health_check_path = "/health"
+  labels            = {}
+  csd_enabled       = false
+  mud_enabled       = false
+}
+
+# --- Stage 1: standalone xcsh_rate_limiter ---
+
+run "rate_limiter_none_by_default" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  assert {
+    condition     = output.rate_limiter_count == 0
+    error_message = "no standalone rate limiters by default (0-change)"
+  }
+}
+
+run "rate_limiter_basic_render" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limiters = [{
+      name   = "rl-basic"
+      limits = [{ total_number = 100, unit = "MINUTE" }]
+    }]
+  }
+  assert {
+    condition     = output.rate_limiter_count == 1 && contains(output.rate_limiter_names, "rl-basic")
+    error_message = "rl-basic must render one xcsh_rate_limiter"
+  }
+  assert {
+    condition     = xcsh_rate_limiter.this["rl-basic"].limits[0].total_number == 100
+    error_message = "limits.total_number must plumb through"
+  }
+}
+
+run "rate_limiter_action_block_and_token_bucket" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limiters = [{
+      name = "rl-strict"
+      limits = [{
+        total_number          = 10
+        unit                  = "SECOND"
+        action                = "block"
+        action_block_unit     = "minutes"
+        action_block_duration = 5
+        algorithm             = "token_bucket"
+      }]
+    }]
+  }
+  assert {
+    condition     = xcsh_rate_limiter.this["rl-strict"].limits[0].action_block != null && xcsh_rate_limiter.this["rl-strict"].limits[0].action_block.minutes.duration == 5 && xcsh_rate_limiter.this["rl-strict"].limits[0].action_block.hours == null
+    error_message = "action=block/minutes must render action_block.minutes.duration=5 and no hours"
+  }
+  assert {
+    condition     = xcsh_rate_limiter.this["rl-strict"].limits[0].token_bucket != null && xcsh_rate_limiter.this["rl-strict"].limits[0].leaky_bucket == null
+    error_message = "algorithm=token_bucket must render token_bucket only"
+  }
+}
+
+run "rate_limiter_multiple_unique" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limiters = [
+      { name = "rl-a", limits = [{ total_number = 5, unit = "SECOND" }] },
+      { name = "rl-b", limits = [{ total_number = 50, unit = "HOUR" }] },
+    ]
+  }
+  assert {
+    condition     = output.rate_limiter_count == 2
+    error_message = "two distinct rate limiters must render"
+  }
+}
+
+# --- Stage 1 validation failures ---
+
+run "rate_limiter_rejects_day_unit" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limiters = [{ name = "rl-day", limits = [{ total_number = 1, unit = "DAY" }] }]
+  }
+  expect_failures = [var.rate_limiters]
+}
+
+run "rate_limiter_rejects_duplicate_names" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limiters = [
+      { name = "dup", limits = [{ total_number = 1 }] },
+      { name = "dup", limits = [{ total_number = 2 }] },
+    ]
+  }
+  expect_failures = [var.rate_limiters]
+}
+
+run "rate_limiter_rejects_block_without_duration" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limiters = [{ name = "rl-bad", limits = [{ total_number = 1, action = "block" }] }]
+  }
+  expect_failures = [var.rate_limiters]
+}
+
+run "rate_limiter_rejects_bad_algorithm" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limiters = [{ name = "rl-bad", limits = [{ total_number = 1, algorithm = "sieve" }] }]
+  }
+  expect_failures = [var.rate_limiters]
+}
+
+run "rate_limiter_rejects_zero_total" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limiters = [{ name = "rl-zero", limits = [{ total_number = 0 }] }]
+  }
+  expect_failures = [var.rate_limiters]
+}
+
+# --- Stage 2: standalone xcsh_rate_limiter_policy ---
+
+run "rate_limiter_policy_none_by_default" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  assert {
+    condition     = output.rate_limiter_policy_count == 0
+    error_message = "no rate-limiter policies by default (0-change)"
+  }
+}
+
+run "rate_limiter_policy_apply_any_server" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limiter_policies = [{
+      name  = "rlp-basic"
+      rules = [{ name = "r1", action = "apply", http_methods = ["GET", "POST"] }]
+    }]
+  }
+  assert {
+    condition     = output.rate_limiter_policy_count == 1 && contains(output.rate_limiter_policy_names, "rlp-basic")
+    error_message = "rlp-basic must render one policy"
+  }
+  assert {
+    condition     = xcsh_rate_limiter_policy.this["rlp-basic"].any_server != null
+    error_message = "default server_scope must render any_server"
+  }
+  assert {
+    condition     = xcsh_rate_limiter_policy.this["rlp-basic"].rules[0].spec.apply_rate_limiter != null && toset(xcsh_rate_limiter_policy.this["rlp-basic"].rules[0].spec.http_method.methods) == toset(["GET", "POST"])
+    error_message = "rule must render apply_rate_limiter + http_method"
+  }
+}
+
+run "rate_limiter_policy_custom_and_matchers" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limiters = [{ name = "rl-x", limits = [{ total_number = 5, unit = "SECOND" }] }]
+    rate_limiter_policies = [{
+      name              = "rlp-custom"
+      server_scope      = "name_matcher"
+      server_name_exact = ["api.f5-sales-demo.com"]
+      rules = [{
+        name                = "deny-legacy"
+        action              = "custom"
+        custom_rate_limiter = "rl-x"
+        ip                  = "prefix_list"
+        ip_prefixes         = ["10.0.0.0/8"]
+        country             = "list"
+        countries           = ["COUNTRY_US", "COUNTRY_CA"]
+        path_prefixes       = ["/api/legacy"]
+        headers             = [{ name = "x-debug", presence = "present" }]
+      }]
+    }]
+  }
+  assert {
+    condition     = toset(xcsh_rate_limiter_policy.this["rlp-custom"].server_name_matcher.exact_values) == toset(["api.f5-sales-demo.com"])
+    error_message = "server_scope=name_matcher must render server_name_matcher"
+  }
+  assert {
+    condition     = xcsh_rate_limiter_policy.this["rlp-custom"].rules[0].spec.custom_rate_limiter.name == "rl-x"
+    error_message = "action=custom must reference the rl-x rate limiter"
+  }
+  assert {
+    condition     = toset(xcsh_rate_limiter_policy.this["rlp-custom"].rules[0].spec.ip_prefix_list.ip_prefixes) == toset(["10.0.0.0/8"]) && toset(xcsh_rate_limiter_policy.this["rlp-custom"].rules[0].spec.country_list.country_codes) == toset(["COUNTRY_US", "COUNTRY_CA"])
+    error_message = "ip=prefix_list + country=list must render inline matchers"
+  }
+  assert {
+    condition     = xcsh_rate_limiter_policy.this["rlp-custom"].rules[0].spec.headers[0].check_present != null
+    error_message = "headers presence=present must render check_present"
+  }
+}
+
+run "rate_limiter_policy_selector_and_ref_matchers" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limiter_policies = [{
+      name            = "rlp-sel"
+      server_scope    = "selector"
+      server_selector = ["app in (api)"]
+      rules = [{
+        name     = "asn-ip-ref"
+        action   = "bypass"
+        asn      = "matcher"
+        asn_sets = [{ name = "corp-asns" }]
+        ip       = "matcher"
+        ip_sets  = [{ name = "corp-prefixes" }]
+      }]
+    }]
+  }
+  assert {
+    condition     = toset(xcsh_rate_limiter_policy.this["rlp-sel"].server_selector.expressions) == toset(["app in (api)"])
+    error_message = "server_scope=selector must render server_selector"
+  }
+  assert {
+    condition     = xcsh_rate_limiter_policy.this["rlp-sel"].rules[0].spec.bypass_rate_limiter != null && xcsh_rate_limiter_policy.this["rlp-sel"].rules[0].spec.asn_matcher != null && xcsh_rate_limiter_policy.this["rlp-sel"].rules[0].spec.ip_matcher != null
+    error_message = "bypass + asn_matcher + ip_matcher (ref sets) must render"
+  }
+}
+
+# --- Stage 2 validation failures ---
+
+run "rate_limiter_policy_rejects_bad_server_scope" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limiter_policies = [{ name = "bad", server_scope = "everything" }]
+  }
+  expect_failures = [var.rate_limiter_policies]
+}
+
+run "rate_limiter_policy_rejects_bad_action" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limiter_policies = [{ name = "bad", rules = [{ name = "r", action = "throttle" }] }]
+  }
+  expect_failures = [var.rate_limiter_policies]
+}
+
+run "rate_limiter_policy_rejects_custom_without_ref" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limiter_policies = [{ name = "bad", rules = [{ name = "r", action = "custom" }] }]
+  }
+  expect_failures = [var.rate_limiter_policies]
+}
+
+run "rate_limiter_policy_rejects_dup_rule_names" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limiter_policies = [{ name = "p", rules = [{ name = "r", action = "apply" }, { name = "r", action = "bypass" }] }]
+  }
+  expect_failures = [var.rate_limiter_policies]
+}
+
+run "rate_limiter_policy_rejects_custom_missing_limiter" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    # action=custom references rl-missing, which is not in var.rate_limiters -> precondition fails
+    rate_limiter_policies = [{ name = "p", rules = [{ name = "r", action = "custom", custom_rate_limiter = "rl-missing" }] }]
+  }
+  expect_failures = [xcsh_rate_limiter_policy.this]
+}
+
+run "rate_limiter_policy_rejects_bare_country_code" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limiter_policies = [{ name = "p", rules = [{ name = "r", action = "apply", country = "list", countries = ["US"] }] }]
+  }
+  expect_failures = [var.rate_limiter_policies]
+}
+
+# --- Stage 3: LB rate_limit allow-lists + policy refs ---
+
+run "rate_limit_default_no_lists" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { rate_limit_choice = "rate_limit" }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.rate_limit.no_ip_allowed_list != null && xcsh_http_loadbalancer.this.rate_limit.no_policies != null
+    error_message = "rate_limit defaults must render no_ip_allowed_list + no_policies (0-change vs SP3)"
+  }
+}
+
+run "rate_limit_inline_ip_allowed_list" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limit_choice              = "rate_limit"
+    rate_limit_ip_allowed_prefixes = ["192.0.2.0/24", "198.51.100.0/24"]
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.rate_limit.ip_allowed_list != null && toset(xcsh_http_loadbalancer.this.rate_limit.ip_allowed_list.prefixes) == toset(["192.0.2.0/24", "198.51.100.0/24"]) && xcsh_http_loadbalancer.this.rate_limit.no_ip_allowed_list == null
+    error_message = "inline prefixes must render ip_allowed_list, not no_ip_allowed_list"
+  }
+}
+
+run "rate_limit_custom_ip_allowed_list" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limit_choice                = "rate_limit"
+    rate_limit_custom_ip_prefix_sets = [{ name = "corp-prefixes" }]
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.rate_limit.custom_ip_allowed_list != null && xcsh_http_loadbalancer.this.rate_limit.custom_ip_allowed_list.rate_limiter_allowed_prefixes[0].name == "corp-prefixes"
+    error_message = "custom sets must render custom_ip_allowed_list.rate_limiter_allowed_prefixes"
+  }
+}
+
+run "rate_limit_with_policies" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limit_choice      = "rate_limit"
+    rate_limit_policy_refs = ["rlp-a"]
+    rate_limiter_policies  = [{ name = "rlp-a", rules = [{ name = "r", action = "apply" }] }]
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.rate_limit.policies != null && xcsh_http_loadbalancer.this.rate_limit.policies.policies[0].name == "rlp-a" && xcsh_http_loadbalancer.this.rate_limit.no_policies == null
+    error_message = "policy refs must render policies.policies, not no_policies"
+  }
+}
+
+# --- Stage 3 validation / precondition failures ---
+
+run "rate_limit_rejects_both_ip_lists" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limit_choice                = "rate_limit"
+    rate_limit_ip_allowed_prefixes   = ["192.0.2.0/24"]
+    rate_limit_custom_ip_prefix_sets = [{ name = "corp" }]
+  }
+  expect_failures = [xcsh_http_loadbalancer.this]
+}
+
+run "rate_limit_rejects_policy_ref_without_arm" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limit_choice      = "disable"
+    rate_limit_policy_refs = ["rlp-a"]
+    rate_limiter_policies  = [{ name = "rlp-a", rules = [{ name = "r", action = "apply" }] }]
+  }
+  expect_failures = [xcsh_http_loadbalancer.this]
+}
+
+run "rate_limit_rejects_unknown_policy_ref" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limit_choice      = "rate_limit"
+    rate_limit_policy_refs = ["ghost"]
+  }
+  expect_failures = [xcsh_http_loadbalancer.this]
+}
+
+# --- Stage 4: LB api_rate_limit arm (per-endpoint) ---
+
+run "api_rate_limit_endpoint_ref_and_matchers" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limit_choice = "api_rate_limit"
+    rate_limiters     = [{ name = "rl-api", limits = [{ total_number = 10, unit = "MINUTE" }] }]
+    api_rate_limit_endpoint_rules = [{
+      api_endpoint_path = "/api/orders"
+      methods           = ["POST"]
+      ref_rate_limiter  = "rl-api"
+      client_matcher = {
+        mode        = "ip_prefix_list"
+        ip_prefixes = ["203.0.113.0/24"]
+      }
+      request_matcher = {
+        headers = [{ name = "x-tenant", presence = "present" }]
+      }
+    }]
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.api_rate_limit != null && xcsh_http_loadbalancer.this.rate_limit == null
+    error_message = "rate_limit_choice=api_rate_limit must render api_rate_limit, not rate_limit"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.api_rate_limit.api_endpoint_rules[0].ref_rate_limiter.name == "rl-api" && xcsh_http_loadbalancer.this.api_rate_limit.api_endpoint_rules[0].api_endpoint_path == "/api/orders"
+    error_message = "endpoint rule must reference rl-api on /api/orders"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.api_rate_limit.api_endpoint_rules[0].client_matcher.ip_prefix_list != null && xcsh_http_loadbalancer.this.api_rate_limit.api_endpoint_rules[0].any_domain != null
+    error_message = "endpoint rule must render ip_prefix_list client_matcher + any_domain default"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.api_rate_limit.api_endpoint_rules[0].request_matcher.headers[0].check_present != null
+    error_message = "request_matcher header presence=present must render check_present"
+  }
+}
+
+run "api_rate_limit_endpoint_inline_and_asn_matcher" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limit_choice = "api_rate_limit"
+    api_rate_limit_endpoint_rules = [{
+      api_endpoint_path = "/api/login"
+      specific_domain   = "api.f5-sales-demo.com"
+      inline_threshold  = 5
+      inline_unit       = "MINUTE"
+      client_matcher = {
+        mode     = "asn_matcher"
+        asn_sets = [{ name = "corp-asns" }]
+      }
+    }]
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.api_rate_limit.api_endpoint_rules[0].inline_rate_limiter.threshold == 5 && xcsh_http_loadbalancer.this.api_rate_limit.api_endpoint_rules[0].inline_rate_limiter.use_http_lb_user_id != null
+    error_message = "inline limiter must render threshold + use_http_lb_user_id default"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.api_rate_limit.api_endpoint_rules[0].specific_domain == "api.f5-sales-demo.com" && xcsh_http_loadbalancer.this.api_rate_limit.api_endpoint_rules[0].client_matcher.asn_matcher != null
+    error_message = "specific_domain attr + asn_matcher ref must render"
+  }
+}
+
+run "api_rate_limit_bypass_and_server_url" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limit_choice = "api_rate_limit"
+    rate_limiters     = [{ name = "rl-su", limits = [{ total_number = 20, unit = "MINUTE" }] }]
+    api_rate_limit_endpoint_rules = [{
+      api_endpoint_path = "/api/x"
+      inline_threshold  = 1
+    }]
+    api_rate_limit_bypass_rules = [{
+      base_path        = "/api/health"
+      target           = "api_endpoint"
+      endpoint_path    = "/api/health"
+      endpoint_methods = ["GET"]
+    }]
+    api_rate_limit_server_url_rules = [{
+      base_path        = "/api/v2"
+      ref_rate_limiter = "rl-su"
+      client_matcher   = { mode = "tls_fingerprint_matcher", tls_classes = ["Automated"] }
+    }]
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.api_rate_limit.bypass_rate_limiting_rules.bypass_rate_limiting_rules[0].api_endpoint != null
+    error_message = "bypass rule target=api_endpoint must render api_endpoint"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.api_rate_limit.server_url_rules[0].ref_rate_limiter.name == "rl-su" && xcsh_http_loadbalancer.this.api_rate_limit.server_url_rules[0].client_matcher.tls_fingerprint_matcher != null
+    error_message = "server_url rule must render ref limiter + tls_fingerprint_matcher"
+  }
+}
+
+# --- Stage 4 validation / precondition failures ---
+
+run "api_rate_limit_rejects_both_limiters" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limit_choice             = "api_rate_limit"
+    rate_limiters                 = [{ name = "rl", limits = [{ total_number = 1 }] }]
+    api_rate_limit_endpoint_rules = [{ api_endpoint_path = "/x", ref_rate_limiter = "rl", inline_threshold = 5 }]
+  }
+  expect_failures = [var.api_rate_limit_endpoint_rules]
+}
+
+run "api_rate_limit_rejects_neither_limiter" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limit_choice             = "api_rate_limit"
+    api_rate_limit_endpoint_rules = [{ api_endpoint_path = "/x" }]
+  }
+  expect_failures = [var.api_rate_limit_endpoint_rules]
+}
+
+run "api_rate_limit_rejects_bad_bypass_target" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limit_choice           = "api_rate_limit"
+    api_rate_limit_bypass_rules = [{ base_path = "/x", target = "whatever" }]
+  }
+  expect_failures = [var.api_rate_limit_bypass_rules]
+}
+
+run "api_rate_limit_rejects_rules_without_arm" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limit_choice             = "rate_limit"
+    api_rate_limit_endpoint_rules = [{ api_endpoint_path = "/x", inline_threshold = 1 }]
+  }
+  expect_failures = [xcsh_http_loadbalancer.this]
+}
+
+run "api_rate_limit_rejects_unknown_ref" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limit_choice             = "api_rate_limit"
+    api_rate_limit_endpoint_rules = [{ api_endpoint_path = "/x", ref_rate_limiter = "ghost" }]
+  }
+  expect_failures = [xcsh_http_loadbalancer.this]
+}
+
+# --- Review-driven negative coverage (Batch B) ---
+
+run "server_url_rejects_both_limiters" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limit_choice               = "api_rate_limit"
+    rate_limiters                   = [{ name = "rl", limits = [{ total_number = 1 }] }]
+    api_rate_limit_server_url_rules = [{ base_path = "/v2", ref_rate_limiter = "rl", inline_threshold = 5 }]
+  }
+  expect_failures = [var.api_rate_limit_server_url_rules]
+}
+
+run "server_url_rejects_bad_inline_unit" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limit_choice               = "api_rate_limit"
+    api_rate_limit_server_url_rules = [{ base_path = "/v2", inline_threshold = 5, inline_unit = "DAY" }]
+  }
+  expect_failures = [var.api_rate_limit_server_url_rules]
+}
+
+run "server_url_rejects_ref_user_without_ref" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limit_choice               = "api_rate_limit"
+    api_rate_limit_server_url_rules = [{ base_path = "/v2", inline_threshold = 5, inline_user_id = "ref" }]
+  }
+  expect_failures = [var.api_rate_limit_server_url_rules]
+}
+
+run "bypass_rejects_bad_client_matcher_mode" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limit_choice           = "api_rate_limit"
+    api_rate_limit_bypass_rules = [{ target = "any_url", client_matcher = { mode = "ip_prefixlist" } }]
+  }
+  expect_failures = [var.api_rate_limit_bypass_rules]
+}
+
+run "bypass_rejects_base_path_target_without_base_path" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limit_choice           = "api_rate_limit"
+    api_rate_limit_bypass_rules = [{ target = "base_path" }]
+  }
+  expect_failures = [var.api_rate_limit_bypass_rules]
+}
+
+run "bypass_rejects_api_groups_target_without_groups" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limit_choice           = "api_rate_limit"
+    api_rate_limit_bypass_rules = [{ target = "api_groups" }]
+  }
+  expect_failures = [var.api_rate_limit_bypass_rules]
+}
+
+run "endpoint_rejects_client_matcher_empty_payload" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limit_choice = "api_rate_limit"
+    api_rate_limit_endpoint_rules = [{
+      api_endpoint_path = "/x"
+      inline_threshold  = 1
+      client_matcher    = { mode = "ip_prefix_list" } # ip_prefixes empty
+    }]
+  }
+  expect_failures = [var.api_rate_limit_endpoint_rules]
+}
+
+run "policy_rejects_list_arm_empty_payload" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limiter_policies = [{ name = "p", rules = [{ name = "r", action = "apply", asn = "list" }] }] # asn_numbers empty
+  }
+  expect_failures = [var.rate_limiter_policies]
+}
+
+run "api_rate_limit_arm_rejects_empty" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { rate_limit_choice = "api_rate_limit" } # no rules of any kind
+  expect_failures = [xcsh_http_loadbalancer.this]
+}
+
+run "rate_limit_ip_allowed_rejects_off_arm" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limit_choice              = "api_rate_limit"
+    rate_limit_ip_allowed_prefixes = ["192.0.2.0/24"]
+    api_rate_limit_endpoint_rules  = [{ api_endpoint_path = "/x", inline_threshold = 1 }]
+  }
+  expect_failures = [xcsh_http_loadbalancer.this]
+}
+
+run "server_url_client_matcher_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    rate_limit_choice = "api_rate_limit"
+    api_rate_limit_server_url_rules = [{
+      base_path        = "/v3"
+      inline_threshold = 10
+      client_matcher   = { mode = "ip_prefix_list", ip_prefixes = ["10.1.0.0/16"] }
+    }]
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.api_rate_limit.server_url_rules[0].client_matcher.ip_prefix_list != null
+    error_message = "server_url client_matcher must render (positive coverage for the bypass/server_url matcher path)"
+  }
+}

--- a/terraform/variables_api_protection.tf
+++ b/terraform/variables_api_protection.tf
@@ -94,3 +94,26 @@ variable "validation_custom_rules" {
   }))
   default = []
 }
+
+# LB rate_limit allow-list + policy refs (Coverage Batch B) root passthrough.
+# Validation lives in the module. Empty defaults keep no_ip_allowed_list + no_policies.
+variable "rate_limit_ip_allowed_prefixes" {
+  description = "rate_limit.ip_allowed_list.prefixes: IP prefixes exempt from rate limiting."
+  type        = list(string)
+  default     = []
+}
+
+variable "rate_limit_custom_ip_prefix_sets" {
+  description = "rate_limit.custom_ip_allowed_list refs to existing ip_prefix_set objects."
+  type = list(object({
+    name      = string
+    namespace = optional(string)
+  }))
+  default = []
+}
+
+variable "rate_limit_policy_refs" {
+  description = "rate_limit.policies: names of rate_limiter_policies to attach to the LB."
+  type        = list(string)
+  default     = []
+}

--- a/terraform/variables_api_rate_limit.tf
+++ b/terraform/variables_api_rate_limit.tf
@@ -1,0 +1,91 @@
+# Root passthrough for the per-endpoint api_rate_limit arm (Coverage Batch B).
+# Validation lives in the module (modules/http-lb/variables_api_rate_limit.tf).
+# Empty defaults keep rate_limit_choice at its default (0-change).
+variable "api_rate_limit_endpoint_rules" {
+  description = "api_rate_limit.api_endpoint_rules passthrough."
+  type = list(object({
+    api_endpoint_path = string
+    methods           = optional(list(string), [])
+    methods_invert    = optional(bool, false)
+    specific_domain   = optional(string)
+    ref_rate_limiter  = optional(string)
+    inline_threshold  = optional(number)
+    inline_unit       = optional(string, "MINUTE")
+    inline_user_id    = optional(string, "http_lb")
+    inline_user_ref   = optional(string)
+    client_matcher = optional(object({
+      mode                 = optional(string)
+      as_numbers           = optional(list(number), [])
+      asn_sets             = optional(list(object({ name = string, namespace = optional(string) })), [])
+      selector_expressions = optional(list(string), [])
+      ip_prefix_sets       = optional(list(object({ name = string, namespace = optional(string) })), [])
+      ip_prefixes          = optional(list(string), [])
+      ip_invert            = optional(bool, false)
+      ip_threat_categories = optional(list(string), [])
+      tls_classes          = optional(list(string), [])
+      tls_exact_values     = optional(list(string), [])
+      tls_excluded_values  = optional(list(string), [])
+    }))
+    request_matcher = optional(object({
+      cookies      = optional(list(object({ name = string, invert = optional(bool, false), presence = optional(string, "match"), exact_values = optional(list(string), []), regex_values = optional(list(string), []) })), [])
+      headers      = optional(list(object({ name = string, invert = optional(bool, false), presence = optional(string, "match"), exact_values = optional(list(string), []), regex_values = optional(list(string), []) })), [])
+      jwt_claims   = optional(list(object({ name = string, invert = optional(bool, false), presence = optional(string, "match"), exact_values = optional(list(string), []), regex_values = optional(list(string), []) })), [])
+      query_params = optional(list(object({ name = string, invert = optional(bool, false), presence = optional(string, "match"), exact_values = optional(list(string), []), regex_values = optional(list(string), []) })), [])
+    }))
+  }))
+  default = []
+}
+
+variable "api_rate_limit_bypass_rules" {
+  description = "api_rate_limit.bypass_rate_limiting_rules passthrough."
+  type = list(object({
+    base_path        = optional(string)
+    specific_domain  = optional(string)
+    target           = optional(string, "any_url")
+    endpoint_path    = optional(string)
+    endpoint_methods = optional(list(string), [])
+    api_groups       = optional(list(string), [])
+    client_matcher = optional(object({
+      mode                 = optional(string)
+      as_numbers           = optional(list(number), [])
+      asn_sets             = optional(list(object({ name = string, namespace = optional(string) })), [])
+      selector_expressions = optional(list(string), [])
+      ip_prefix_sets       = optional(list(object({ name = string, namespace = optional(string) })), [])
+      ip_prefixes          = optional(list(string), [])
+      ip_invert            = optional(bool, false)
+      ip_threat_categories = optional(list(string), [])
+      tls_classes          = optional(list(string), [])
+      tls_exact_values     = optional(list(string), [])
+      tls_excluded_values  = optional(list(string), [])
+    }))
+  }))
+  default = []
+}
+
+variable "api_rate_limit_server_url_rules" {
+  description = "api_rate_limit.server_url_rules passthrough."
+  type = list(object({
+    api_group        = optional(string)
+    base_path        = optional(string)
+    specific_domain  = optional(string)
+    ref_rate_limiter = optional(string)
+    inline_threshold = optional(number)
+    inline_unit      = optional(string, "MINUTE")
+    inline_user_id   = optional(string, "http_lb")
+    inline_user_ref  = optional(string)
+    client_matcher = optional(object({
+      mode                 = optional(string)
+      as_numbers           = optional(list(number), [])
+      asn_sets             = optional(list(object({ name = string, namespace = optional(string) })), [])
+      selector_expressions = optional(list(string), [])
+      ip_prefix_sets       = optional(list(object({ name = string, namespace = optional(string) })), [])
+      ip_prefixes          = optional(list(string), [])
+      ip_invert            = optional(bool, false)
+      ip_threat_categories = optional(list(string), [])
+      tls_classes          = optional(list(string), [])
+      tls_exact_values     = optional(list(string), [])
+      tls_excluded_values  = optional(list(string), [])
+    }))
+  }))
+  default = []
+}

--- a/terraform/variables_rate_limiter.tf
+++ b/terraform/variables_rate_limiter.tf
@@ -1,0 +1,24 @@
+# Root passthrough for the standalone rate-limiter surface (Coverage Batch B).
+# Validation lives in the module (modules/http-lb/variables_rate_limiter.tf).
+# Default [] creates no standalone rate limiters (0-change).
+variable "rate_limiters" {
+  description = "Standalone xcsh_rate_limiter definitions (referenced by rate-limiter policies and the api_rate_limit arm)."
+  type = list(object({
+    name = string
+    limits = optional(list(object({
+      total_number          = number
+      unit                  = optional(string, "MINUTE")
+      burst_multiplier      = optional(number)
+      period_multiplier     = optional(number)
+      action                = optional(string)
+      action_block_unit     = optional(string, "seconds")
+      action_block_duration = optional(number)
+      algorithm             = optional(string)
+    })), [])
+    user_identification = optional(list(object({
+      name      = string
+      namespace = optional(string)
+    })), [])
+  }))
+  default = []
+}

--- a/terraform/variables_rate_limiter_policy.tf
+++ b/terraform/variables_rate_limiter_policy.tf
@@ -1,0 +1,45 @@
+# Root passthrough for standalone rate-limiter policies (Coverage Batch B).
+# Validation lives in the module (modules/http-lb/variables_rate_limiter_policy.tf).
+# Default [] creates no policies (0-change).
+variable "rate_limiter_policies" {
+  description = "Standalone xcsh_rate_limiter_policy definitions (referenced by LB rate_limit.policies)."
+  type = list(object({
+    name              = string
+    server_scope      = optional(string, "any_server")
+    server_name_exact = optional(list(string), [])
+    server_name_regex = optional(list(string), [])
+    server_selector   = optional(list(string), [])
+    rules = optional(list(object({
+      name                = string
+      action              = optional(string, "apply")
+      custom_rate_limiter = optional(string)
+      asn                 = optional(string)
+      asn_numbers         = optional(list(number), [])
+      asn_sets            = optional(list(object({ name = string, namespace = optional(string) })), [])
+      ip                  = optional(string)
+      ip_prefixes         = optional(list(string), [])
+      ip_invert           = optional(bool, false)
+      ip_sets             = optional(list(object({ name = string, namespace = optional(string) })), [])
+      country             = optional(string)
+      countries           = optional(list(string), [])
+      country_invert      = optional(bool, false)
+      http_methods        = optional(list(string), [])
+      http_methods_invert = optional(bool, false)
+      path_exact          = optional(list(string), [])
+      path_prefixes       = optional(list(string), [])
+      path_regex          = optional(list(string), [])
+      path_suffix         = optional(list(string), [])
+      path_invert         = optional(bool, false)
+      domain_exact        = optional(list(string), [])
+      domain_regex        = optional(list(string), [])
+      headers = optional(list(object({
+        name         = string
+        invert       = optional(bool, false)
+        presence     = optional(string, "match")
+        exact_values = optional(list(string), [])
+        regex_values = optional(list(string), [])
+      })), [])
+    })), [])
+  }))
+  default = []
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -23,7 +23,15 @@ terraform {
       # nested in LIST elements (domains[].credentials[]) and preserves list-element empty
       # markers' absence, + suppresses `standard` on import. SP4 matrix idempotent +
       # round-trip-import clean.
-      version = ">= 3.71.4"
+      #
+      # >= 3.72.0: Coverage Batch B rate limiting (provider #1104, PR #1105). A
+      # standalone xcsh_rate_limiter_policy rule that omits a client matcher drifted on
+      # import (server materializes the any_asn/any_country/any_ip base marker of each
+      # client-matcher oneof; cascaded custom_rate_limiter.tenant to known-after-apply).
+      # 3.72.0 suppresses those RateLimiterPolicy markers on import, so the standalone
+      # policy round-trips 0-change. LB rate_limit allow-lists/policies + api_rate_limit
+      # arm needed no provider change (any_client/any_ip already suppressed).
+      version = ">= 3.72.0"
     }
     # Azure providers: this plan also deploys its OWN Azure origin server and
     # traffic generator (modules/origin-server, modules/traffic-generator), which


### PR DESCRIPTION
Closes #51.

**Batch B** of the API-coverage remediation (Batch A = validation enforcement, #50). Exposes the full F5 XC rate-limiting configuration:

| Stage | Surface |
|---|---|
| 1 | standalone `xcsh_rate_limiter` (limits + action/algorithm oneofs + user_identification) |
| 2 | standalone `xcsh_rate_limiter_policy` (server scope + rules: action + asn/ip/country/http_method/path/domain/header matchers) |
| 3 | LB `rate_limit` `ip_allowed_list` / `custom_ip_allowed_list` / `policies` |
| 4 | LB `api_rate_limit` arm — `api_endpoint_rules` (+ full `client_matcher` + `request_matcher`), `bypass_rate_limiting_rules`, `server_url_rules` |

**Testing:** 45 plan-tests (positive render per arm + negative per validation/precondition). Live-verified on `f5-sales-demo` `webapp-api-protection`: every stage apply → idempotent re-plan → round-trip import clean; canonical LB restored 0-change.

**Provider lock-step:** requires `xcsh >= 3.72.0` (#1105/#1104) — suppresses the `RateLimiterPolicy` server-default client-matcher markers (`any_asn`/`any_country`/`any_ip`) on import. The LB `rate_limit`/`api_rate_limit` arms needed no provider change.

**Contract facts encoded as validations:** country codes `COUNTRY_<ISO>`; inline `total_number` cap 8192; bypass `base_path` is a url-oneof arm; optional lists emit `null`-when-empty; cross-var preconditions for feature-on and ref-exists.

Defaults keep everything off (0-change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)