### PR TITLE
Coverage Batch C: sensitive-data surface (xcsh_data_type + custom_data_types + disclosure rules)

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -146,6 +146,9 @@ module "http_lb" {
   sensitive_data_compliances         = var.sensitive_data_compliances
   sensitive_data_disabled_predefined = var.sensitive_data_disabled_predefined
   sensitive_data_policy_choice       = var.sensitive_data_policy_choice
+  data_types                         = var.data_types
+  sensitive_data_custom_type_refs    = var.sensitive_data_custom_type_refs
+  sensitive_data_disclosure_rules    = var.sensitive_data_disclosure_rules
   data_guard_rules                   = var.data_guard_rules
   api_protection_rules               = var.api_protection_rules
   validation_custom_rules            = var.validation_custom_rules

--- a/terraform/modules/http-lb/data_type.tf
+++ b/terraform/modules/http-lb/data_type.tf
@@ -1,0 +1,74 @@
+# Standalone custom data types (Coverage Batch C). See variables_data_type.tf.
+# for_each keyed by name so the sensitive_data_policy custom_data_types arm can
+# reference a specific type via xcsh_data_type.this[<name>].
+resource "xcsh_data_type" "this" {
+  for_each = { for d in var.data_types : d.name => d }
+
+  name      = each.value.name
+  namespace = var.namespace
+  # compliances/is_pii/is_sensitive_data are Required on xcsh_data_type — always set
+  # (compliances defaults to [] rather than null).
+  compliances       = each.value.compliances
+  is_pii            = each.value.is_pii
+  is_sensitive_data = each.value.is_sensitive_data
+
+  dynamic "rules" {
+    for_each = each.value.rules
+    content {
+      # type=key -> key_pattern matcher
+      dynamic "key_pattern" {
+        for_each = rules.value.type == "key" ? [1] : []
+        content {
+          regex_value     = rules.value.key_matcher == "regex" ? rules.value.key_regex : null
+          substring_value = rules.value.key_matcher == "substring" ? rules.value.key_substring : null
+          dynamic "exact_values" {
+            for_each = rules.value.key_matcher == "exact" ? [1] : []
+            content {
+              exact_values = rules.value.key_exact
+            }
+          }
+        }
+      }
+      # type=value -> value_pattern matcher
+      dynamic "value_pattern" {
+        for_each = rules.value.type == "value" ? [1] : []
+        content {
+          regex_value     = rules.value.value_matcher == "regex" ? rules.value.value_regex : null
+          substring_value = rules.value.value_matcher == "substring" ? rules.value.value_substring : null
+          dynamic "exact_values" {
+            for_each = rules.value.value_matcher == "exact" ? [1] : []
+            content {
+              exact_values = rules.value.value_exact
+            }
+          }
+        }
+      }
+      # type=key_value -> both key_pattern and value_pattern
+      dynamic "key_value_pattern" {
+        for_each = rules.value.type == "key_value" ? [1] : []
+        content {
+          key_pattern {
+            regex_value     = rules.value.key_matcher == "regex" ? rules.value.key_regex : null
+            substring_value = rules.value.key_matcher == "substring" ? rules.value.key_substring : null
+            dynamic "exact_values" {
+              for_each = rules.value.key_matcher == "exact" ? [1] : []
+              content {
+                exact_values = rules.value.key_exact
+              }
+            }
+          }
+          value_pattern {
+            regex_value     = rules.value.value_matcher == "regex" ? rules.value.value_regex : null
+            substring_value = rules.value.value_matcher == "substring" ? rules.value.value_substring : null
+            dynamic "exact_values" {
+              for_each = rules.value.value_matcher == "exact" ? [1] : []
+              content {
+                exact_values = rules.value.value_exact
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -1235,6 +1235,41 @@ resource "xcsh_http_loadbalancer" "this" {
     }
   }
 
+  # Sensitive-data disclosure (Batch C): for a given api_endpoint (path + methods)
+  # and response body fields, mask or report disclosed sensitive data. Omitted when
+  # the list is empty (0-change).
+  dynamic "sensitive_data_disclosure_rules" {
+    for_each = length(var.sensitive_data_disclosure_rules) > 0 ? [1] : []
+    content {
+      dynamic "sensitive_data_types_in_response" {
+        for_each = var.sensitive_data_disclosure_rules
+        iterator = d
+        content {
+          api_endpoint {
+            methods = length(d.value.methods) > 0 ? d.value.methods : null
+            path    = d.value.path
+          }
+          # body.fields requires >= 1 item; omit the whole body block when no fields
+          # are named (rule then applies to the whole response body).
+          dynamic "body" {
+            for_each = length(d.value.fields) > 0 ? [1] : []
+            content {
+              fields = d.value.fields
+            }
+          }
+          dynamic "mask" {
+            for_each = d.value.action == "mask" ? [1] : []
+            content {}
+          }
+          dynamic "report" {
+            for_each = d.value.action == "report" ? [1] : []
+            content {}
+          }
+        }
+      }
+    }
+  }
+
   # Data Guard — mask sensitive values (credit-card/SSN/...) in responses per
   # domain + path. Omitted when the list is empty (0-change). domain matcher is a
   # oneof (any_domain | exact_value | suffix_value); action is apply_data_guard vs
@@ -1542,6 +1577,14 @@ resource "xcsh_http_loadbalancer" "this" {
         [for r in var.api_rate_limit_server_url_rules : contains(keys(xcsh_rate_limiter.this), r.ref_rate_limiter) if r.ref_rate_limiter != null],
       ))
       error_message = "every api_rate_limit ref_rate_limiter must name a rate_limiters entry."
+    }
+
+    # custom_data_types attach to the standalone sensitive_data_policy, so they need
+    # that policy selected. The ref-exists check lives on xcsh_sensitive_data_policy
+    # (the resource that indexes xcsh_data_type), so it is not duplicated here.
+    precondition {
+      condition     = length(var.sensitive_data_custom_type_refs) == 0 || var.sensitive_data_policy_choice == "custom"
+      error_message = "sensitive_data_custom_type_refs requires sensitive_data_policy_choice=\"custom\"."
     }
   }
 }

--- a/terraform/modules/http-lb/outputs_data_type.tf
+++ b/terraform/modules/http-lb/outputs_data_type.tf
@@ -1,0 +1,10 @@
+# Standalone custom data-type outputs (Coverage Batch C).
+output "data_type_names" {
+  description = "Names of the standalone xcsh_data_type resources created."
+  value       = sort([for d in xcsh_data_type.this : d.name])
+}
+
+output "data_type_count" {
+  description = "Number of standalone xcsh_data_type resources created."
+  value       = length(xcsh_data_type.this)
+}

--- a/terraform/modules/http-lb/sensitive_data_policy.tf
+++ b/terraform/modules/http-lb/sensitive_data_policy.tf
@@ -12,4 +12,25 @@ resource "xcsh_sensitive_data_policy" "this" {
 
   compliances                    = length(var.sensitive_data_compliances) > 0 ? var.sensitive_data_compliances : null
   disabled_predefined_data_types = length(var.sensitive_data_disabled_predefined) > 0 ? var.sensitive_data_disabled_predefined : null
+
+  # custom_data_types (Batch C): attach the standalone xcsh_data_type objects named
+  # in var.sensitive_data_custom_type_refs. Single knob — the ref resolves the
+  # created resource, so they cannot desync.
+  dynamic "custom_data_types" {
+    for_each = var.sensitive_data_custom_type_refs
+    iterator = ref
+    content {
+      custom_data_type_ref {
+        name      = xcsh_data_type.this[ref.value].name
+        namespace = var.namespace
+      }
+    }
+  }
+
+  lifecycle {
+    precondition {
+      condition     = alltrue([for r in var.sensitive_data_custom_type_refs : contains(keys(xcsh_data_type.this), r)])
+      error_message = "every sensitive_data_custom_type_refs entry must name a data_types entry."
+    }
+  }
 }

--- a/terraform/modules/http-lb/variables_data_type.tf
+++ b/terraform/modules/http-lb/variables_data_type.tf
@@ -1,0 +1,87 @@
+# ---------------------------------------------------------------------------
+# Standalone custom data types (Coverage Batch C). Creates xcsh_data_type objects
+# referenced by the sensitive_data_policy custom_data_types arm. Each data type
+# carries compliance tags + is_pii/is_sensitive_data flags and rules[] that match
+# request/response key-value pairs:
+#   type = "key"       -> key_pattern   { <matcher> }
+#          "value"     -> value_pattern { <matcher> }
+#          "key_value" -> key_value_pattern { key_pattern{<km>} value_pattern{<vm>} }
+# where each <matcher> is one of: regex | substring | exact (exact_values list).
+# Default [] creates none (0-change).
+# ---------------------------------------------------------------------------
+variable "data_types" {
+  description = "Standalone xcsh_data_type definitions (referenced by sensitive_data_policy custom_data_types), keyed by name."
+  type = list(object({
+    name              = string
+    compliances       = optional(list(string), [])
+    is_pii            = optional(bool, false)
+    is_sensitive_data = optional(bool, false)
+    rules = optional(list(object({
+      type            = string           # key | value | key_value
+      key_matcher     = optional(string) # regex | substring | exact
+      key_regex       = optional(string)
+      key_substring   = optional(string)
+      key_exact       = optional(list(string), [])
+      value_matcher   = optional(string) # regex | substring | exact
+      value_regex     = optional(string)
+      value_substring = optional(string)
+      value_exact     = optional(list(string), [])
+    })), [])
+  }))
+  default = []
+
+  validation {
+    condition     = length(var.data_types) == length(distinct([for d in var.data_types : d.name]))
+    error_message = "data_types names must be unique."
+  }
+
+  validation {
+    condition = alltrue([
+      for d in var.data_types : alltrue([
+        for c in d.compliances :
+        contains(["GDPR", "CCPA", "PIPEDA", "LGPD", "DPA_UK", "PDPA_SG", "APPI", "HIPAA", "CPRA_2023", "CPA_CO", "SOC2", "PCI_DSS", "ISO_IEC_27001", "ISO_IEC_27701", "EPRIVACY_DIRECTIVE", "GLBA", "SOX"], c)
+      ])
+    ])
+    error_message = "each data_types compliances value must be a valid F5 XC compliance framework."
+  }
+
+  validation {
+    condition = alltrue([
+      for d in var.data_types : alltrue([
+        for r in d.rules : contains(["key", "value", "key_value"], r.type)
+      ])
+    ])
+    error_message = "data_types rules.type must be key, value, or key_value."
+  }
+
+  validation {
+    condition = alltrue([
+      for d in var.data_types : alltrue([
+        for r in d.rules :
+        (r.type == "value" || (r.key_matcher != null && contains(["regex", "substring", "exact"], r.key_matcher))) &&
+        (r.type == "key" || (r.value_matcher != null && contains(["regex", "substring", "exact"], r.value_matcher)))
+      ])
+    ])
+    error_message = "data_types rules require key_matcher (type key/key_value) and/or value_matcher (type value/key_value) to be regex, substring, or exact."
+  }
+
+  validation {
+    condition = alltrue([
+      for d in var.data_types : alltrue([
+        for r in d.rules : (
+          (r.type == "value" || (
+            (r.key_matcher != "regex" || r.key_regex != null) &&
+            (r.key_matcher != "substring" || r.key_substring != null) &&
+            (r.key_matcher != "exact" || length(r.key_exact) > 0)
+          )) &&
+          (r.type == "key" || (
+            (r.value_matcher != "regex" || r.value_regex != null) &&
+            (r.value_matcher != "substring" || r.value_substring != null) &&
+            (r.value_matcher != "exact" || length(r.value_exact) > 0)
+          ))
+        )
+      ])
+    ])
+    error_message = "data_types rules: the chosen matcher needs its payload (regex⇒*_regex, substring⇒*_substring, exact⇒*_exact non-empty)."
+  }
+}

--- a/terraform/modules/http-lb/variables_sensitive_data.tf
+++ b/terraform/modules/http-lb/variables_sensitive_data.tf
@@ -64,3 +64,34 @@ variable "data_guard_rules" {
     error_message = "data_guard_rules with domain_mode exact/suffix require a domain."
   }
 }
+
+# --- Custom data types on the policy + LB response disclosure rules (Batch C) ---
+
+# Names of var.data_types to attach to the sensitive_data_policy as custom_data_types
+# (custom_data_type_ref). Requires sensitive_data_policy_choice="custom". Empty => none.
+variable "sensitive_data_custom_type_refs" {
+  description = "Names of var.data_types to attach to the sensitive_data_policy custom_data_types."
+  type        = list(string)
+  default     = []
+}
+
+# LB sensitive_data_disclosure_rules.sensitive_data_types_in_response: for a given
+# api_endpoint (path + methods) and response body fields, mask or report disclosed
+# sensitive data. Empty => omit the block (0-change).
+variable "sensitive_data_disclosure_rules" {
+  description = "LB response sensitive-data disclosure rules: list of {path, methods, fields, action mask|report}."
+  type = list(object({
+    path    = string
+    methods = optional(list(string), [])
+    fields  = optional(list(string), [])
+    action  = optional(string, "mask") # mask | report
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for r in var.sensitive_data_disclosure_rules : contains(["mask", "report"], r.action)
+    ])
+    error_message = "sensitive_data_disclosure_rules action must be mask or report."
+  }
+}

--- a/terraform/tests/sensitive_data.tftest.hcl
+++ b/terraform/tests/sensitive_data.tftest.hcl
@@ -1,0 +1,197 @@
+# Plan-level tests for the sensitive-data surface (Coverage Batch C): standalone
+# xcsh_data_type, the sensitive_data_policy custom_data_types refs, the LB
+# sensitive_data_disclosure_rules, and disabled_predefined_data_types. Targets
+# ./modules/http-lb. Defaults keep everything off (0-change).
+variables {
+  namespace         = "webapp-api-protection"
+  lb_domains        = ["www.f5-sales-demo.com"]
+  origin_ip         = "203.0.113.10"
+  origin_port       = 80
+  health_check_path = "/health"
+  labels            = {}
+  csd_enabled       = false
+  mud_enabled       = false
+}
+
+# --- standalone xcsh_data_type ---
+
+run "data_type_none_by_default" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  assert {
+    condition     = output.data_type_count == 0
+    error_message = "no data types by default (0-change)"
+  }
+}
+
+run "data_type_key_regex" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    data_types = [{
+      name              = "dt-acct"
+      compliances       = ["PCI_DSS"]
+      is_sensitive_data = true
+      rules             = [{ type = "key", key_matcher = "regex", key_regex = "^account_id$" }]
+    }]
+  }
+  assert {
+    condition     = output.data_type_count == 1 && contains(output.data_type_names, "dt-acct")
+    error_message = "dt-acct must render one xcsh_data_type"
+  }
+  assert {
+    condition     = xcsh_data_type.this["dt-acct"].rules[0].key_pattern.regex_value == "^account_id$" && xcsh_data_type.this["dt-acct"].is_sensitive_data == true
+    error_message = "type=key regex must render key_pattern.regex_value"
+  }
+}
+
+run "data_type_value_substring_and_key_value_exact" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    data_types = [
+      { name = "dt-tok", rules = [{ type = "value", value_matcher = "substring", value_substring = "secret" }] },
+      { name = "dt-kv", rules = [{ type = "key_value", key_matcher = "exact", key_exact = ["ssn"], value_matcher = "regex", value_regex = "\\d{3}-\\d{2}-\\d{4}" }] },
+    ]
+  }
+  assert {
+    condition     = xcsh_data_type.this["dt-tok"].rules[0].value_pattern.substring_value == "secret"
+    error_message = "type=value substring must render value_pattern.substring_value"
+  }
+  assert {
+    condition     = xcsh_data_type.this["dt-kv"].rules[0].key_value_pattern.key_pattern.exact_values != null && xcsh_data_type.this["dt-kv"].rules[0].key_value_pattern.value_pattern.regex_value == "\\d{3}-\\d{2}-\\d{4}"
+    error_message = "type=key_value must render both key_pattern.exact_values + value_pattern.regex_value"
+  }
+}
+
+# --- data_type validation failures ---
+
+run "data_type_rejects_dup_names" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { data_types = [{ name = "dup" }, { name = "dup" }] }
+  expect_failures = [var.data_types]
+}
+
+run "data_type_rejects_bad_compliance" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { data_types = [{ name = "d", compliances = ["NOPE"] }] }
+  expect_failures = [var.data_types]
+}
+
+run "data_type_rejects_bad_rule_type" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { data_types = [{ name = "d", rules = [{ type = "header" }] }] }
+  expect_failures = [var.data_types]
+}
+
+run "data_type_rejects_key_without_matcher" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { data_types = [{ name = "d", rules = [{ type = "key" }] }] }
+  expect_failures = [var.data_types]
+}
+
+run "data_type_rejects_exact_empty_payload" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { data_types = [{ name = "d", rules = [{ type = "key", key_matcher = "exact" }] }] }
+  expect_failures = [var.data_types]
+}
+
+run "data_type_rejects_regex_null_payload" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { data_types = [{ name = "d", rules = [{ type = "key", key_matcher = "regex" }] }] }
+  expect_failures = [var.data_types]
+}
+
+run "data_type_rejects_value_substring_null_payload" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { data_types = [{ name = "d", rules = [{ type = "value", value_matcher = "substring" }] }] }
+  expect_failures = [var.data_types]
+}
+
+# --- policy custom_data_types + disabled_predefined ---
+
+run "policy_custom_data_types_and_disabled_predefined" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    sensitive_data_policy_choice       = "custom"
+    sensitive_data_disabled_predefined = ["EMAIL", "PHONE_NUMBER"]
+    data_types                         = [{ name = "dt-acct", rules = [{ type = "key", key_matcher = "regex", key_regex = "^acct$" }] }]
+    sensitive_data_custom_type_refs    = ["dt-acct"]
+  }
+  assert {
+    condition     = xcsh_sensitive_data_policy.this[0].custom_data_types[0].custom_data_type_ref.name == "dt-acct"
+    error_message = "custom_data_types must reference the dt-acct data_type"
+  }
+  assert {
+    condition     = toset(xcsh_sensitive_data_policy.this[0].disabled_predefined_data_types) == toset(["EMAIL", "PHONE_NUMBER"])
+    error_message = "disabled_predefined_data_types must render on the policy"
+  }
+}
+
+# --- LB sensitive_data_disclosure_rules ---
+
+run "sensitive_data_disclosure_mask_and_report" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    sensitive_data_disclosure_rules = [
+      { path = "/api/users", methods = ["GET"], fields = ["ssn", "dob"], action = "mask" },
+      { path = "/api/audit", action = "report" },
+    ]
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.sensitive_data_disclosure_rules != null && xcsh_http_loadbalancer.this.sensitive_data_disclosure_rules.sensitive_data_types_in_response[0].mask != null
+    error_message = "action=mask must render mask on the first disclosure rule"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.sensitive_data_disclosure_rules.sensitive_data_types_in_response[0].api_endpoint.path == "/api/users" && xcsh_http_loadbalancer.this.sensitive_data_disclosure_rules.sensitive_data_types_in_response[1].report != null
+    error_message = "disclosure rules must render api_endpoint + report arm"
+  }
+  # mask/report are a oneof, and a fieldless rule omits the body block entirely.
+  assert {
+    condition     = xcsh_http_loadbalancer.this.sensitive_data_disclosure_rules.sensitive_data_types_in_response[0].report == null && xcsh_http_loadbalancer.this.sensitive_data_disclosure_rules.sensitive_data_types_in_response[1].mask == null
+    error_message = "mask/report must be mutually exclusive per rule"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.sensitive_data_disclosure_rules.sensitive_data_types_in_response[0].body != null && xcsh_http_loadbalancer.this.sensitive_data_disclosure_rules.sensitive_data_types_in_response[1].body == null
+    error_message = "body block must render when fields are named and be omitted when none are"
+  }
+}
+
+# --- precondition / validation failures ---
+
+run "disclosure_rejects_bad_action" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { sensitive_data_disclosure_rules = [{ path = "/x", action = "hide" }] }
+  expect_failures = [var.sensitive_data_disclosure_rules]
+}
+
+run "custom_type_refs_reject_without_policy" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    sensitive_data_policy_choice    = "default"
+    data_types                      = [{ name = "dt-acct" }]
+    sensitive_data_custom_type_refs = ["dt-acct"]
+  }
+  expect_failures = [xcsh_http_loadbalancer.this]
+}
+
+run "custom_type_refs_reject_unknown" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    sensitive_data_policy_choice    = "custom"
+    sensitive_data_custom_type_refs = ["ghost"]
+  }
+  expect_failures = [xcsh_sensitive_data_policy.this]
+}

--- a/terraform/variables_data_type.tf
+++ b/terraform/variables_data_type.tf
@@ -1,0 +1,40 @@
+# Root passthrough for the sensitive-data surface (Coverage Batch C). Validation
+# lives in the module. Defaults keep everything off (0-change).
+variable "data_types" {
+  description = "Standalone xcsh_data_type definitions (referenced by sensitive_data_policy custom_data_types)."
+  type = list(object({
+    name              = string
+    compliances       = optional(list(string), [])
+    is_pii            = optional(bool, false)
+    is_sensitive_data = optional(bool, false)
+    rules = optional(list(object({
+      type            = string
+      key_matcher     = optional(string)
+      key_regex       = optional(string)
+      key_substring   = optional(string)
+      key_exact       = optional(list(string), [])
+      value_matcher   = optional(string)
+      value_regex     = optional(string)
+      value_substring = optional(string)
+      value_exact     = optional(list(string), [])
+    })), [])
+  }))
+  default = []
+}
+
+variable "sensitive_data_custom_type_refs" {
+  description = "Names of data_types to attach to the sensitive_data_policy custom_data_types."
+  type        = list(string)
+  default     = []
+}
+
+variable "sensitive_data_disclosure_rules" {
+  description = "LB response sensitive-data disclosure rules: {path, methods, fields, action mask|report}."
+  type = list(object({
+    path    = string
+    methods = optional(list(string), [])
+    fields  = optional(list(string), [])
+    action  = optional(string, "mask")
+  }))
+  default = []
+}


### PR DESCRIPTION
Closes #55.

**Batch C** of the API-coverage remediation (A #50, B #52 merged). Completes the sensitive-data surface deferred in SP3:

| Surface | Detail |
|---|---|
| standalone `xcsh_data_type` | `compliances` + `is_pii`/`is_sensitive_data` + `rules[]` (key/value/key_value pattern × regex/substring/exact) |
| policy `custom_data_types` | single-knob refs to the `xcsh_data_type` resources (`sensitive_data_custom_type_refs`) |
| LB `sensitive_data_disclosure_rules` | `sensitive_data_types_in_response[]` (api_endpoint path/methods + body fields + mask\|report) |
| `disabled_predefined_data_types` | test coverage |

**Testing:** 15 plan-tests (positive per arm + negative per validation/precondition). Live-verified on `f5-sales-demo`: all three resources apply → idempotent → round-trip import clean; canonical restored 0-change. **No provider change** (`xcsh >= 3.72.0` from Batch B suffices).

**Contract facts encoded as validations:** `is_pii`/`is_sensitive_data`/`compliances` are Required on `xcsh_data_type`; matcher payload required per matcher type; `body.fields` needs ≥1 item so the body block is omitted when no fields are named.

Defaults keep everything off (0-change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)