### PR TITLE
Coverage Batch F: xcsh_app_api_group (make api_groups_rules.api_group live-usable)

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -155,6 +155,7 @@ module "http_lb" {
   data_guard_rules                   = var.data_guard_rules
   api_protection_rules               = var.api_protection_rules
   api_protection_group_rules         = var.api_protection_group_rules
+  app_api_groups                     = var.app_api_groups
   validation_custom_rules            = var.validation_custom_rules
 
   # API Testing (SP4) passthrough. Defaults keep it off (disable_api_testing

--- a/terraform/modules/http-lb/app_api_group.tf
+++ b/terraform/modules/http-lb/app_api_group.tf
@@ -1,0 +1,39 @@
+# Standalone App API Groups (Coverage Batch F) — xcsh_app_api_group objects that make
+# api_protection_rules.api_groups_rules.api_group referenceable. Each group scopes a
+# set of endpoints on THIS LB via elements (path_regex + methods) and is associated to
+# the load balancer by name. Default [] creates none (0-change).
+#
+# The group references the LB by the static local.lb_name (NOT xcsh_http_loadbalancer.this)
+# so there is no resource-dependency cycle: the LB's api_groups_rules validates the group
+# by name at apply, so groups must exist first — enforced by the LB's depends_on below.
+resource "xcsh_app_api_group" "this" {
+  for_each = { for g in var.app_api_groups : g.name => g }
+
+  name      = each.value.name
+  namespace = var.namespace
+
+  http_loadbalancer {
+    http_loadbalancer {
+      name      = local.lb_name
+      namespace = var.namespace
+    }
+  }
+
+  dynamic "elements" {
+    for_each = each.value.elements
+    content {
+      path_regex = elements.value.path_regex
+      methods    = length(elements.value.methods) > 0 ? elements.value.methods : null
+    }
+  }
+}
+
+output "app_api_group_names" {
+  description = "Names of the standalone xcsh_app_api_group resources created."
+  value       = sort([for g in xcsh_app_api_group.this : g.name])
+}
+
+output "app_api_group_count" {
+  description = "Number of standalone xcsh_app_api_group resources created."
+  value       = length(xcsh_app_api_group.this)
+}

--- a/terraform/modules/http-lb/locals_api.tf
+++ b/terraform/modules/http-lb/locals_api.tf
@@ -26,6 +26,10 @@ locals {
     }
   }
 
+  # LB name — shared by the LB resource and app_api_group (which references the LB by
+  # this static name to avoid a resource-dependency cycle; see app_api_group.tf).
+  lb_name = "webapp-api-protection"
+
   # Named aliases for consumers (keep references stable/short).
   api_crawler_password_secret = local.rendered_secret["api_crawler_password"]
   scm_token                   = local.rendered_secret["code_base_integration_token"]

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -400,9 +400,14 @@ resource "xcsh_api_discovery" "this" {
 }
 
 resource "xcsh_http_loadbalancer" "this" {
-  name      = "webapp-api-protection"
+  name      = local.lb_name
   namespace = var.namespace
   labels    = var.labels
+
+  # api_groups_rules reference app_api_groups by name, which F5 XC validates at LB
+  # apply — so the groups must exist first. app_api_group references the LB by static
+  # name (local.lb_name), not this resource, so there is no cycle.
+  depends_on = [xcsh_app_api_group.this]
 
   domains = var.lb_domains
 

--- a/terraform/modules/http-lb/variables_app_api_group.tf
+++ b/terraform/modules/http-lb/variables_app_api_group.tf
@@ -1,0 +1,39 @@
+# App API Groups (Coverage Batch F). Each entry becomes an xcsh_app_api_group scoping
+# endpoints on this LB; its name is referenceable from api_protection_group_rules.api_group.
+variable "app_api_groups" {
+  description = "xcsh_app_api_group definitions: {name, elements[{path_regex, methods}]}. Referenceable by api_protection_group_rules.api_group."
+  type = list(object({
+    name = string
+    elements = optional(list(object({
+      path_regex = string
+      methods    = optional(list(string), ["ANY"])
+    })), [])
+  }))
+  default = []
+
+  validation {
+    condition     = length(var.app_api_groups) == length(distinct([for g in var.app_api_groups : g.name]))
+    error_message = "app_api_groups names must be unique."
+  }
+
+  validation {
+    condition = alltrue([
+      for g in var.app_api_groups : alltrue([
+        for e in g.elements : alltrue([
+          for m in e.methods :
+          contains(["ANY", "GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH", "COPY"], m)
+        ])
+      ])
+    ])
+    error_message = "app_api_groups elements.methods must be valid HTTP methods (ANY, GET, POST, ...)."
+  }
+
+  validation {
+    condition = alltrue([
+      for g in var.app_api_groups : alltrue([
+        for e in g.elements : e.path_regex != null && e.path_regex != ""
+      ])
+    ])
+    error_message = "app_api_groups elements require a non-empty path_regex."
+  }
+}

--- a/terraform/tests/app_api_group.tftest.hcl
+++ b/terraform/tests/app_api_group.tftest.hcl
@@ -1,0 +1,77 @@
+# Plan-level tests for App API Groups (Coverage Batch F): xcsh_app_api_group render
+# (elements + LB association) and api_protection_group_rules referencing a module-created
+# group. Targets ./modules/http-lb, dummy origin.
+variables {
+  namespace         = "webapp-api-protection"
+  lb_domains        = ["www.f5-sales-demo.com"]
+  origin_ip         = "203.0.113.10"
+  origin_port       = 80
+  health_check_path = "/health"
+  labels            = {}
+  csd_enabled       = false
+  mud_enabled       = false
+}
+
+run "app_api_group_none_by_default" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  assert {
+    condition     = output.app_api_group_count == 0
+    error_message = "no app_api_groups by default (0-change)"
+  }
+}
+
+run "app_api_group_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    app_api_groups = [{
+      name     = "orders-api"
+      elements = [{ path_regex = "/api/orders.*", methods = ["GET", "POST"] }]
+    }]
+  }
+  assert {
+    condition     = output.app_api_group_count == 1 && contains(output.app_api_group_names, "orders-api")
+    error_message = "orders-api group must render"
+  }
+  assert {
+    condition     = xcsh_app_api_group.this["orders-api"].http_loadbalancer.http_loadbalancer.name == "webapp-api-protection" && xcsh_app_api_group.this["orders-api"].elements[0].path_regex == "/api/orders.*"
+    error_message = "group must associate to the LB by name + render elements"
+  }
+}
+
+run "api_groups_rule_references_created_group" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    app_api_groups             = [{ name = "orders-api", elements = [{ path_regex = "/api/orders.*" }] }]
+    api_protection_group_rules = [{ api_group = "orders-api", action = "deny" }]
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.api_protection_rules.api_groups_rules[0].api_group == "orders-api" && xcsh_http_loadbalancer.this.api_protection_rules.api_groups_rules[0].action.deny != null
+    error_message = "api_groups_rules must reference the created group by name with the deny action"
+  }
+}
+
+# --- validation failures ---
+
+run "app_api_group_rejects_dup_names" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { app_api_groups = [{ name = "g" }, { name = "g" }] }
+  expect_failures = [var.app_api_groups]
+}
+
+run "app_api_group_rejects_bad_method" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { app_api_groups = [{ name = "g", elements = [{ path_regex = "/x", methods = ["FETCH"] }] }] }
+  expect_failures = [var.app_api_groups]
+}
+
+run "app_api_group_rejects_empty_path_regex" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { app_api_groups = [{ name = "g", elements = [{ path_regex = "" }] }] }
+  expect_failures = [var.app_api_groups]
+}

--- a/terraform/variables_app_api_group.tf
+++ b/terraform/variables_app_api_group.tf
@@ -1,0 +1,7 @@
+# Root passthrough for App API Groups (Coverage Batch F). Thin passthrough: the full
+# object type + validation live in the module (modules/http-lb/variables_app_api_group.tf).
+variable "app_api_groups" {
+  description = "xcsh_app_api_group definitions passthrough (typed+validated in the module)."
+  type        = any
+  default     = []
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -31,7 +31,14 @@ terraform {
       # 3.72.0 suppresses those RateLimiterPolicy markers on import, so the standalone
       # policy round-trips 0-change. LB rate_limit allow-lists/policies + api_rate_limit
       # arm needed no provider change (any_client/any_ip already suppressed).
-      version = ">= 3.72.0"
+      #
+      # >= 3.72.1: Coverage Batch F app_api_group (provider #1108, PR #1109). Marshalling
+      # a single nested block whose child is another single block with the SAME GoName
+      # (F5 XC view-ref wrappers, e.g. xcsh_app_api_group http_loadbalancer{http_loadbalancer{}})
+      # shadowed the outer map var, sending "http_loadbalancer": {} and dropping the LB
+      # association -> 400. 3.72.1 names the marshal map var by nesting path so the outer
+      # map carries the populated ref, so xcsh_app_api_group applies.
+      version = ">= 3.72.1"
     }
     # Azure providers: this plan also deploys its OWN Azure origin server and
     # traffic generator (modules/origin-server, modules/traffic-generator), which


### PR DESCRIPTION
Closes #61. Follow-on to live-verify Batch D's `api_protection_rules.api_groups_rules` against a **real** API group.

**Finding:** a referenceable named `api_group` comes from the `app_api_group` object (`elements` + LB association), not discovery alone (discovery = inventory). So this adds **`xcsh_app_api_group`** to the module and wires `api_protection_group_rules.api_group` to reference it.

**Cycle-avoidance design:** the group associates to the LB via the static `local.lb_name` (never the `xcsh_http_loadbalancer.this` resource), and the LB `depends_on` the groups. So groups are created **before** the LB validates `api_groups_rules` (F5 XC returns 400 on a missing/unassociated group), and teardown removes the LB rule before destroying the group. No dependency cycle.

**Provider lock-step (`>= 3.72.1`, #1109/#1108):** live testing surfaced a codegen bug — marshalling a single nested block wrapping a same-named single block (`http_loadbalancer { http_loadbalancer {} }`) shadowed the outer map, sending `{}` and dropping the association → 400. Fixed by naming the marshal var per nesting path (fixes every view-ref wrapper).

**Testing:** 6 plan-tests. Live-verified on `f5-sales-demo`: group created first (no 400) → apply → idempotent → group import 0-change → canonical restored. Defaults create no groups (0-change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)