### PR TITLE
Coverage Batch G: external secret-backend fields (store_provider/decryption_provider/provider_ref)

### DIFF
--- a/terraform/modules/http-lb/locals_api.tf
+++ b/terraform/modules/http-lb/locals_api.tf
@@ -23,6 +23,10 @@ locals {
         ? "string:///${base64encode(s.plaintext)}"
       : null)
       location = s.method == "blindfold" ? s.location : null
+      # Optional external secret-management backend refs (Batch G); null unless set.
+      store_provider      = s.method == "blindfold" ? s.store_provider : null
+      decryption_provider = s.method == "blindfold" ? s.decryption_provider : null
+      provider_ref        = s.method == "clear" ? s.provider_ref : null
     }
   }
 
@@ -36,7 +40,8 @@ locals {
 
   # Precomputed single-element (or empty) selectors for the SCM token secret arm, so
   # each of the 7 provider arms renders the same compact blindfold/clear dynamic pair
-  # (one selection expression, not a repeated ternary per arm).
-  scm_token_blindfold = local.scm_token.use_blindfold ? [local.scm_token.location] : []
-  scm_token_clear     = local.scm_token.use_blindfold ? [] : [local.scm_token.url]
+  # (one selection expression, not a repeated ternary per arm). The element is the whole
+  # rendered secret so each block can also emit the optional backend fields (Batch G).
+  scm_token_blindfold = local.scm_token.use_blindfold ? [local.scm_token] : []
+  scm_token_clear     = local.scm_token.use_blindfold ? [] : [local.scm_token]
 }

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -480,13 +480,16 @@ resource "xcsh_http_loadbalancer" "this" {
                     dynamic "blindfold_secret_info" {
                       for_each = local.api_crawler_password_secret.use_blindfold ? [1] : []
                       content {
-                        location = local.api_crawler_password_secret.location
+                        location            = local.api_crawler_password_secret.location
+                        store_provider      = local.api_crawler_password_secret.store_provider
+                        decryption_provider = local.api_crawler_password_secret.decryption_provider
                       }
                     }
                     dynamic "clear_secret_info" {
                       for_each = local.api_crawler_password_secret.use_blindfold ? [] : [1]
                       content {
-                        url = local.api_crawler_password_secret.url
+                        url          = local.api_crawler_password_secret.url
+                        provider_ref = local.api_crawler_password_secret.provider_ref
                       }
                     }
                   }

--- a/terraform/modules/http-lb/scm.tf
+++ b/terraform/modules/http-lb/scm.tf
@@ -20,13 +20,16 @@ resource "xcsh_code_base_integration" "this" {
           dynamic "blindfold_secret_info" {
             for_each = local.scm_token_blindfold
             content {
-              location = blindfold_secret_info.value
+              location            = blindfold_secret_info.value.location
+              store_provider      = blindfold_secret_info.value.store_provider
+              decryption_provider = blindfold_secret_info.value.decryption_provider
             }
           }
           dynamic "clear_secret_info" {
             for_each = local.scm_token_clear
             content {
-              url = clear_secret_info.value
+              url          = clear_secret_info.value.url
+              provider_ref = clear_secret_info.value.provider_ref
             }
           }
         }
@@ -41,13 +44,16 @@ resource "xcsh_code_base_integration" "this" {
           dynamic "blindfold_secret_info" {
             for_each = local.scm_token_blindfold
             content {
-              location = blindfold_secret_info.value
+              location            = blindfold_secret_info.value.location
+              store_provider      = blindfold_secret_info.value.store_provider
+              decryption_provider = blindfold_secret_info.value.decryption_provider
             }
           }
           dynamic "clear_secret_info" {
             for_each = local.scm_token_clear
             content {
-              url = clear_secret_info.value
+              url          = clear_secret_info.value.url
+              provider_ref = clear_secret_info.value.provider_ref
             }
           }
         }
@@ -60,13 +66,16 @@ resource "xcsh_code_base_integration" "this" {
           dynamic "blindfold_secret_info" {
             for_each = local.scm_token_blindfold
             content {
-              location = blindfold_secret_info.value
+              location            = blindfold_secret_info.value.location
+              store_provider      = blindfold_secret_info.value.store_provider
+              decryption_provider = blindfold_secret_info.value.decryption_provider
             }
           }
           dynamic "clear_secret_info" {
             for_each = local.scm_token_clear
             content {
-              url = clear_secret_info.value
+              url          = clear_secret_info.value.url
+              provider_ref = clear_secret_info.value.provider_ref
             }
           }
         }
@@ -80,13 +89,16 @@ resource "xcsh_code_base_integration" "this" {
           dynamic "blindfold_secret_info" {
             for_each = local.scm_token_blindfold
             content {
-              location = blindfold_secret_info.value
+              location            = blindfold_secret_info.value.location
+              store_provider      = blindfold_secret_info.value.store_provider
+              decryption_provider = blindfold_secret_info.value.decryption_provider
             }
           }
           dynamic "clear_secret_info" {
             for_each = local.scm_token_clear
             content {
-              url = clear_secret_info.value
+              url          = clear_secret_info.value.url
+              provider_ref = clear_secret_info.value.provider_ref
             }
           }
         }
@@ -99,13 +111,16 @@ resource "xcsh_code_base_integration" "this" {
           dynamic "blindfold_secret_info" {
             for_each = local.scm_token_blindfold
             content {
-              location = blindfold_secret_info.value
+              location            = blindfold_secret_info.value.location
+              store_provider      = blindfold_secret_info.value.store_provider
+              decryption_provider = blindfold_secret_info.value.decryption_provider
             }
           }
           dynamic "clear_secret_info" {
             for_each = local.scm_token_clear
             content {
-              url = clear_secret_info.value
+              url          = clear_secret_info.value.url
+              provider_ref = clear_secret_info.value.provider_ref
             }
           }
         }
@@ -119,13 +134,16 @@ resource "xcsh_code_base_integration" "this" {
           dynamic "blindfold_secret_info" {
             for_each = local.scm_token_blindfold
             content {
-              location = blindfold_secret_info.value
+              location            = blindfold_secret_info.value.location
+              store_provider      = blindfold_secret_info.value.store_provider
+              decryption_provider = blindfold_secret_info.value.decryption_provider
             }
           }
           dynamic "clear_secret_info" {
             for_each = local.scm_token_clear
             content {
-              url = clear_secret_info.value
+              url          = clear_secret_info.value.url
+              provider_ref = clear_secret_info.value.provider_ref
             }
           }
         }
@@ -141,13 +159,16 @@ resource "xcsh_code_base_integration" "this" {
           dynamic "blindfold_secret_info" {
             for_each = local.scm_token_blindfold
             content {
-              location = blindfold_secret_info.value
+              location            = blindfold_secret_info.value.location
+              store_provider      = blindfold_secret_info.value.store_provider
+              decryption_provider = blindfold_secret_info.value.decryption_provider
             }
           }
           dynamic "clear_secret_info" {
             for_each = local.scm_token_clear
             content {
-              url = clear_secret_info.value
+              url          = clear_secret_info.value.url
+              provider_ref = clear_secret_info.value.provider_ref
             }
           }
         }

--- a/terraform/modules/http-lb/variables_api.tf
+++ b/terraform/modules/http-lb/variables_api.tf
@@ -16,11 +16,15 @@
 # pinned here (produced by scripts/blindfold-seal.sh). This is the F5-documented
 # offline-blindfold pattern and is idempotent + import-clean.
 variable "api_crawler_password" {
-  description = "API crawler login password. clear: set plaintext. blindfold: set location to a pre-sealed 'string:///...' value from scripts/blindfold-seal.sh."
+  description = "API crawler login password. clear: set plaintext (or provider_ref for an external secret-mgmt provider). blindfold: set location to a pre-sealed 'string:///...' value from scripts/blindfold-seal.sh (optionally store_provider/decryption_provider for an external secret backend)."
   type = object({
     method    = optional(string, "clear")
     plaintext = optional(string) # clear arm
     location  = optional(string) # blindfold arm: pre-sealed string:///...
+    # Optional external secret-management backend refs (Batch G):
+    store_provider      = optional(string) # blindfold: store the sealed secret lives in
+    decryption_provider = optional(string) # blindfold: provider that decrypts it
+    provider_ref        = optional(string) # clear: secret-mgmt provider serving the value
   })
   default   = { method = "clear", plaintext = null }
   sensitive = true
@@ -33,6 +37,16 @@ variable "api_crawler_password" {
   validation {
     condition     = var.api_crawler_password.method != "blindfold" || var.api_crawler_password.location != null
     error_message = "blindfold method requires a pre-sealed location (run scripts/blindfold-seal.sh)."
+  }
+
+  validation {
+    condition     = var.api_crawler_password.method == "blindfold" || (var.api_crawler_password.store_provider == null && var.api_crawler_password.decryption_provider == null)
+    error_message = "store_provider/decryption_provider are blindfold-only secret backends."
+  }
+
+  validation {
+    condition     = var.api_crawler_password.method == "clear" || var.api_crawler_password.provider_ref == null
+    error_message = "provider_ref is a clear-secret backend only."
   }
 }
 

--- a/terraform/modules/http-lb/variables_scm.tf
+++ b/terraform/modules/http-lb/variables_scm.tf
@@ -51,11 +51,15 @@ variable "code_base_integration_verify_ssl" {
 }
 
 variable "code_base_integration_access_token" {
-  description = "GitHub access token as a selectable clear/blindfold secret. clear: set plaintext. blindfold: set location to a pre-sealed 'string:///...' from scripts/blindfold-seal.sh."
+  description = "SCM access token/passwd as a selectable clear/blindfold secret. clear: set plaintext (or provider_ref). blindfold: set location to a pre-sealed 'string:///...' from scripts/blindfold-seal.sh (optionally store_provider/decryption_provider for an external secret backend)."
   type = object({
     method    = optional(string, "clear")
     plaintext = optional(string)
     location  = optional(string)
+    # Optional external secret-management backend refs (Batch G):
+    store_provider      = optional(string)
+    decryption_provider = optional(string)
+    provider_ref        = optional(string)
   })
   default   = { method = "clear", plaintext = null }
   sensitive = true
@@ -68,6 +72,16 @@ variable "code_base_integration_access_token" {
   validation {
     condition     = var.code_base_integration_access_token.method != "blindfold" || var.code_base_integration_access_token.location != null
     error_message = "blindfold method requires a pre-sealed location (run scripts/blindfold-seal.sh)."
+  }
+
+  validation {
+    condition     = var.code_base_integration_access_token.method == "blindfold" || (var.code_base_integration_access_token.store_provider == null && var.code_base_integration_access_token.decryption_provider == null)
+    error_message = "store_provider/decryption_provider are blindfold-only secret backends."
+  }
+
+  validation {
+    condition     = var.code_base_integration_access_token.method == "clear" || var.code_base_integration_access_token.provider_ref == null
+    error_message = "provider_ref is a clear-secret backend only."
   }
 }
 

--- a/terraform/tests/secret_backends.tftest.hcl
+++ b/terraform/tests/secret_backends.tftest.hcl
@@ -1,0 +1,101 @@
+# Plan-level tests for the clear/blindfold external secret-backend fields (Coverage
+# Batch G): store_provider/decryption_provider (blindfold) + provider_ref (clear),
+# threaded through the shared rendered_secret convention (crawler + SCM). Asserted on
+# the SCM consumer (accessible path); the crawler uses the identical local. Targets
+# ./modules/http-lb.
+variables {
+  namespace         = "webapp-api-protection"
+  lb_domains        = ["www.f5-sales-demo.com"]
+  origin_ip         = "203.0.113.10"
+  origin_port       = 80
+  health_check_path = "/health"
+  labels            = {}
+  csd_enabled       = false
+  mud_enabled       = false
+}
+
+run "scm_blindfold_backend_fields_render" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    code_base_integration_enabled  = true
+    code_base_integration_username = "f5-sales-demo-bot"
+    code_base_integration_access_token = {
+      method              = "blindfold"
+      location            = "string:///eyJrZXlfdmVyc2lvbiI6MX0="
+      store_provider      = "corp-secret-store"
+      decryption_provider = "corp-kms"
+    }
+  }
+  assert {
+    condition     = xcsh_code_base_integration.this[0].code_base_integration.github.access_token.blindfold_secret_info.store_provider == "corp-secret-store" && xcsh_code_base_integration.this[0].code_base_integration.github.access_token.blindfold_secret_info.decryption_provider == "corp-kms"
+    error_message = "blindfold store_provider + decryption_provider must render"
+  }
+}
+
+run "scm_clear_provider_ref_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    code_base_integration_enabled  = true
+    code_base_integration_username = "f5-sales-demo-bot"
+    code_base_integration_access_token = {
+      method       = "clear"
+      plaintext    = "ghp_example"
+      provider_ref = "corp-secret-provider"
+    }
+  }
+  assert {
+    condition     = xcsh_code_base_integration.this[0].code_base_integration.github.access_token.clear_secret_info.provider_ref == "corp-secret-provider"
+    error_message = "clear provider_ref must render"
+  }
+}
+
+# Regression: base clear/blindfold (no backend fields) still render with null backends.
+run "scm_base_secret_no_backends" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    code_base_integration_enabled      = true
+    code_base_integration_username     = "f5-sales-demo-bot"
+    code_base_integration_access_token = { method = "clear", plaintext = "ghp_example" }
+  }
+  assert {
+    condition     = xcsh_code_base_integration.this[0].code_base_integration.github.access_token.clear_secret_info.provider_ref == null
+    error_message = "base clear secret must render with null provider_ref (0-change for existing configs)"
+  }
+}
+
+# --- validation failures: backend fields only with the matching method ---
+
+run "scm_rejects_store_provider_on_clear" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    code_base_integration_enabled      = true
+    code_base_integration_username     = "f5-sales-demo-bot"
+    code_base_integration_access_token = { method = "clear", plaintext = "x", store_provider = "s" }
+  }
+  expect_failures = [var.code_base_integration_access_token]
+}
+
+run "scm_rejects_provider_ref_on_blindfold" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    code_base_integration_enabled      = true
+    code_base_integration_username     = "f5-sales-demo-bot"
+    code_base_integration_access_token = { method = "blindfold", location = "string:///x", provider_ref = "p" }
+  }
+  expect_failures = [var.code_base_integration_access_token]
+}
+
+run "crawler_rejects_decryption_provider_on_clear" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    api_crawler_domains  = [{ domain = "api.f5-sales-demo.com", user = "probe" }]
+    api_crawler_password = { method = "clear", plaintext = "x", decryption_provider = "kms" }
+  }
+  expect_failures = [var.api_crawler_password]
+}

--- a/terraform/variables_api.tf
+++ b/terraform/variables_api.tf
@@ -47,9 +47,12 @@ variable "api_crawler_domains" {
 variable "api_crawler_password" {
   description = "API crawler login password. clear: set plaintext. blindfold: set location to a pre-sealed 'string:///...' from scripts/blindfold-seal.sh."
   type = object({
-    method    = optional(string, "clear")
-    plaintext = optional(string)
-    location  = optional(string)
+    method              = optional(string, "clear")
+    plaintext           = optional(string)
+    location            = optional(string)
+    store_provider      = optional(string)
+    decryption_provider = optional(string)
+    provider_ref        = optional(string)
   })
   default   = { method = "clear", plaintext = null }
   sensitive = true

--- a/terraform/variables_scm.tf
+++ b/terraform/variables_scm.tf
@@ -40,9 +40,12 @@ variable "code_base_integration_verify_ssl" {
 variable "code_base_integration_access_token" {
   description = "GitHub access token as a selectable clear/blindfold secret (clear: plaintext; blindfold: pre-sealed location)."
   type = object({
-    method    = optional(string, "clear")
-    plaintext = optional(string)
-    location  = optional(string)
+    method              = optional(string, "clear")
+    plaintext           = optional(string)
+    location            = optional(string)
+    store_provider      = optional(string)
+    decryption_provider = optional(string)
+    provider_ref        = optional(string)
   })
   default   = { method = "clear", plaintext = null }
   sensitive = true


### PR DESCRIPTION
Closes #63. Extends the shared clear/blindfold SecretType convention (`local.rendered_secret` — crawler password + all 7 SCM arms) with the external secret-management backend fields deferred from Batch E:

| block | added fields |
|---|---|
| `blindfold_secret_info` | `store_provider`, `decryption_provider` |
| `clear_secret_info` | `provider_ref` |

Threaded once through `rendered_secret` and emitted at every render site. Optional; null/omitted by default (**0-change** for existing configs). Validations: `store_provider`/`decryption_provider` are blindfold-only, `provider_ref` clear-only. **No provider change** (fields already in the schema/marshalling).

**Testing:** 6 plan-tests. Live-verified on `f5-sales-demo`: clear `provider_ref` applies → idempotent → import (write-only secret re-applies, expected); the backend-field structure is accepted by the API (curl 200). Blindfold live-apply inherits the pre-existing "blindfold = XC 500" limit (needs a real sealed blob via `scripts/blindfold-seal.sh`), documented — same precedent as the SP1 crawler blindfold.

> ⚠️ **Do not merge until [docs-control#645](https://github.com/f5-sales-demo/docs-control/issues/645) lands.** `Lint Code Base` (JSCPD) is red at ~10.5%: the 7 SCM secret blocks are inherent HCL dynamic-block duplication (Terraform can't factor `dynamic` blocks), and `.jscpd.json` is governance-locked. #645 requests the IaC exemption (consistent with the existing `internal/provider` generated-code exemption). Code, review, and live-verify are complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)