### PR TITLE
chore(jscpd): sync *_pairs.py exemption from governance

### DIFF
--- a/.jscpd.json
+++ b/.jscpd.json
@@ -15,6 +15,7 @@
     "**/vendor/**",
     "**/internal/client/**",
     "**/internal/provider/**",
+    "**/*_pairs.py",
     "**/templates/**",
     "**/docs/**"
   ]


### PR DESCRIPTION
Manually propagates the already-merged docs-control canonical `.jscpd.json` (docs-control#646) — adds `**/*_pairs.py` to `ignore`.

The `scripts/*_pairs.py` all-pairs matrix generators are intentionally parallel deterministic tooling, not copy-paste debt. The automated managed-files sync did not land it here (sync PR #66 closed without merging), so this applies it directly. The file now matches the governance canonical (no future drift).

Unblocks the JSCPD gate for Batch G (PR #64).

Closes #67