### PR TITLE
feat(service-policy): SPol-1 foundation — xcsh_service_policy module + LB wiring

### DIFF
--- a/scripts/service-policy-matrix.sh
+++ b/scripts/service-policy-matrix.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# service_policy (SPol-1) live coverage-matrix harness.
+#
+# Cycles a LIVE standalone xcsh_service_policy ("matrix-spol") and the LB
+# service_policies_choice wiring through the all-pairs + canonical variant set
+# (scripts/service_policy_pairs.py) and verifies each variant (a) applies,
+# (b) is idempotent (immediate plan = No changes), and (c) is round-trip-import
+# clean (state rm -> import -> plan clean) for the service policy. Entitlement/
+# permission-rejected arms are recorded SKIP (not FAIL). Ends on the
+# canonical-restore variant so the live LB is left at the server default (no
+# service policy attached; nothing created). Results append to
+# reports/service-policy-matrix.txt.
+#
+# Requires the provider release carrying the SPol-1 import-suppression seed
+# (>= v3.72.4) so the server-default empty markers do not drift on import.
+#
+# Pre-prod tenant, in-place on the live LB (per the approved spec). Sequential —
+# no concurrent terraform against the shared azurerm state.
+#
+# Usage: service-policy-matrix.sh [START [END]]  (inclusive 0-based index range).
+set -uo pipefail
+
+cd "$(dirname "$0")/../terraform" || exit 1
+ARM_ACCESS_KEY=$(az storage account keys list -n f5salesdemotfstate -g f5-sales-demo-tfstate --query "[0].value" -o tsv)
+export ARM_ACCESS_KEY
+
+NS="webapp-api-protection"
+SPOL_ADDR="module.http_lb.xcsh_service_policy.this[\"matrix-spol\"]"
+SPOL_ID="${NS}/matrix-spol"
+COMMON=(-input=false -lock=true
+  -var 'lb_domains=["www.f5-sales-demo.com","api.f5-sales-demo.com"]'
+  -var 'subscription_id=75f86c46-9cbc-4f6c-85ea-195e3d3c8ac0')
+VARDIR=/tmp/service-policy-variants
+REPORT=../reports/service-policy-matrix.txt
+mkdir -p ../reports
+
+START="${1:-0}"
+END="${2:-9999}"
+
+GATED_RE='entitlement|not subscribed|not entitled|not enabled for|permission denied|unauthorized|AS_NOT_SUBSCRIBED|status: 401|status: 403'
+
+count=$(python3 ../scripts/service_policy_pairs.py --emit "$VARDIR")
+echo "generated $count variants into $VARDIR (running [$START..$END])"
+
+round_trip() {
+  local label="$1" vf="$2"
+  # Skip variants that create no service policy (canonical-restore): nothing to import.
+  if ! terraform state list | grep -qF "$SPOL_ADDR"; then
+    echo "PASS $label (no-policy variant, nothing to import)" >>"$REPORT"
+    return
+  fi
+  terraform state rm "$SPOL_ADDR" >/dev/null 2>&1 || {
+    echo "FAIL $label state-rm" >>"$REPORT"
+    return
+  }
+  terraform import "${COMMON[@]}" -var-file="$vf" "$SPOL_ADDR" "$SPOL_ID" >/tmp/spol-import.log 2>&1 || {
+    echo "FAIL $label import ($(grep -iE 'error' /tmp/spol-import.log | head -1 | cut -c1-80))" >>"$REPORT"
+    return
+  }
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$vf" >/tmp/spol-rt-plan.log 2>&1
+  case $? in
+  0) echo "PASS $label" >>"$REPORT" ;;
+  2) echo "FAIL $label import-drift" >>"$REPORT" ;;
+  *) echo "FAIL $label rt-plan-error" >>"$REPORT" ;;
+  esac
+}
+
+while read -r idx name vf; do
+  [ "$idx" -lt "$START" ] && continue
+  [ "$idx" -gt "$END" ] && continue
+  label="$idx-$name"
+  echo "--- $label ---"
+  if ! terraform apply -auto-approve "${COMMON[@]}" -var-file="${VARDIR}/${vf}" >/tmp/spol-apply.log 2>&1; then
+    if grep -qiE "$GATED_RE" /tmp/spol-apply.log; then
+      echo "SKIP $label gated-arm ($(grep -oiE "$GATED_RE" /tmp/spol-apply.log | head -1))" >>"$REPORT"
+    else
+      echo "FAIL $label apply ($(grep -iE 'error' /tmp/spol-apply.log | head -1 | cut -c1-80))" >>"$REPORT"
+    fi
+    continue
+  fi
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="${VARDIR}/${vf}" >/tmp/spol-plan.log 2>&1
+  case $? in
+  0) round_trip "$label" "${VARDIR}/${vf}" ;;
+  2) echo "FAIL $label not-idempotent" >>"$REPORT" ;;
+  *) echo "FAIL $label plan-error" >>"$REPORT" ;;
+  esac
+done <"${VARDIR}/manifest.txt"
+
+echo "===== SERVICE POLICY MATRIX RESULTS ($START..$END) ====="
+cat "$REPORT"
+echo "PASS=$(grep -c '^PASS ' "$REPORT") FAIL=$(grep -c '^FAIL ' "$REPORT") SKIP=$(grep -c '^SKIP ' "$REPORT")"

--- a/scripts/service_policy_pairs.py
+++ b/scripts/service_policy_pairs.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Generate the service_policy foundation (SPol-1) coverage matrix.
+
+Coverage model (mirrors scripts/api_protection_pairs.py):
+  * all-pairs (pairwise, AETG greedy) over the SPol-1 outer dimensions, so every pair
+    of option-values co-occurs in at least one variant;
+  * PLUS the canonical restore end state (no service policy created, LB back to the
+    server default service_policies_from_namespace).
+
+Pairwise dimensions:
+  rule_handling  allow_all | deny_all | rule_list   (xcsh_service_policy rule-handling oneof)
+  server_scope   any_server | selector              (server-scope oneof; any_server omitted)
+  lb_choice      omit | none | active               (LB service_policies_choice arm)
+
+payloads() reconciles the module's constraints so every emitted variant is a valid root
+config, and dedups byte-identical payloads. Secret-free. Deterministic (no RNG).
+
+Output: JSON array of {"name", "vars"} to stdout, or files via --emit.
+"""
+
+import itertools
+import json
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+POLICY_NAME = "matrix-spol"
+
+DIMENSIONS = {
+    "rule_handling": ["allow_all", "deny_all", "rule_list"],
+    "server_scope": ["any_server", "selector"],
+    "lb_choice": ["omit", "none", "active"],
+}
+
+
+def _best_value(
+    values: list[str],
+    idx: int,
+    row: dict[int, str],
+    uncovered: set[tuple[int, str, int, str]],
+) -> str:
+    """Pick the value for dimension idx covering the most still-uncovered pairs."""
+    best_val, best_gain = values[0], -1
+    for val in values:
+        gain = 0
+        for pidx, pval in row.items():
+            a, b = sorted([(pidx, pval), (idx, val)])
+            if (a[0], a[1], b[0], b[1]) in uncovered:
+                gain += 1
+        if gain > best_gain:
+            best_gain, best_val = gain, val
+    return best_val
+
+
+def all_pairs(dims: dict[str, list[str]]) -> list[dict[str, str]]:
+    """Return AETG-style greedy all-pairs rows ({dim: value})."""
+    names = list(dims)
+    uncovered: set[tuple[int, str, int, str]] = set()
+    for i, j in itertools.combinations(range(len(names)), 2):
+        for vi in dims[names[i]]:
+            for vj in dims[names[j]]:
+                uncovered.add((i, vi, j, vj))
+
+    rows = []
+    while uncovered:
+        si, sv, sj, sv2 = min(uncovered)
+        row = {si: sv, sj: sv2}
+        for idx, name in enumerate(names):
+            if idx not in row:
+                row[idx] = _best_value(dims[name], idx, row, uncovered)
+        for i, j in itertools.combinations(sorted(row), 2):
+            uncovered.discard((i, row[i], j, row[j]))
+        rows.append({names[k]: v for k, v in row.items()})
+    return rows
+
+
+def payloads(v: Mapping[str, object]) -> dict[str, object]:
+    """Expand a pairwise row into real tfvars."""
+    pol: dict[str, object] = {
+        "name": POLICY_NAME,
+        "rule_handling": v["rule_handling"],
+        "server_scope": v["server_scope"],
+    }
+    if v.get("rule_handling") == "rule_list":
+        pol["rules"] = [{"name": "r0", "action": "ALLOW"}]
+    if v.get("server_scope") == "selector":
+        pol["server_selector"] = ["app in (webapp)"]
+
+    out: dict[str, object] = {
+        "service_policies": [pol],
+        "service_policies_choice": v["lb_choice"],
+    }
+    if v.get("lb_choice") == "active":
+        out["service_policy_active"] = [POLICY_NAME]
+    return out
+
+
+def canonical() -> dict[str, object]:
+    """Return the live-canonical end state (no service policy; LB server default)."""
+    return {
+        "service_policies": [],
+        "service_policies_choice": "omit",
+        "service_policy_active": [],
+    }
+
+
+def build() -> list[dict[str, object]]:
+    """Build the ordered variant manifest (all-pairs + canonical restore), deduped."""
+    variants: list[dict[str, object]] = []
+    seen: set[str] = set()
+    idx = 0
+    for row in all_pairs(DIMENSIONS):
+        vars_ = payloads(row)
+        key = json.dumps(vars_, sort_keys=True)
+        if key in seen:
+            continue
+        seen.add(key)
+        variants.append({"name": f"pair-{idx:03d}", "vars": vars_})
+        idx += 1
+    variants.append({"name": "canonical-restore", "vars": canonical()})
+    return variants
+
+
+def emit(directory: str) -> int:
+    """Write one <NNN>-<name>.tfvars.json per variant plus manifest.txt."""
+    out_dir = Path(directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for existing in out_dir.iterdir():
+        if existing.name.endswith(".tfvars.json") or existing.name == "manifest.txt":
+            existing.unlink()
+    variants = build()
+    named = [(f"{i:03d}-{v['name']}.tfvars.json", v) for i, v in enumerate(variants)]
+    for fname, v in named:
+        (out_dir / fname).write_text(json.dumps(v["vars"], indent=2) + "\n")
+    lines = [f"{i:03d} {v['name']} {fname} LIVE" for i, (fname, v) in enumerate(named)]
+    (out_dir / "manifest.txt").write_text("\n".join(lines) + "\n")
+    return len(variants)
+
+
+def main(argv: list[str]) -> None:
+    """CLI: --count, --emit <dir>, else JSON to stdout."""
+    match argv[1:]:
+        case ["--count"]:
+            sys.stdout.write(f"{len(build())}\n")
+        case ["--emit", directory]:
+            sys.stdout.write(f"{emit(directory)}\n")
+        case _:
+            json.dump(build(), sys.stdout, indent=2)
+            sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -158,6 +158,12 @@ module "http_lb" {
   app_api_groups                     = var.app_api_groups
   validation_custom_rules            = var.validation_custom_rules
 
+  # Service policies (SPol effort) passthrough. Defaults create nothing and emit no LB
+  # block (server default service_policies_from_namespace, import-suppressed => 0-change).
+  service_policies        = var.service_policies
+  service_policies_choice = var.service_policies_choice
+  service_policy_active   = var.service_policy_active
+
   # API Testing (SP4) passthrough. Defaults keep it off (disable_api_testing
   # suppressed => 0-change) and create no standalone resource.
   api_testing_choice              = var.api_testing_choice

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -442,6 +442,29 @@ resource "xcsh_http_loadbalancer" "this" {
     namespace = xcsh_app_firewall.this.namespace
   }
 
+  # Service policies (SPol effort) — service_policies_choice oneof:
+  #   omit   => emit neither arm; server applies default service_policies_from_namespace
+  #             (import-suppressed) — a 0-change no-op.
+  #   none   => no_service_policies {} (also import-suppressed on the empty arm).
+  #   active => active_service_policies referencing var.service_policy_active in order
+  #             (evaluation is top-to-bottom). tenant is Computed — omit it.
+  dynamic "no_service_policies" {
+    for_each = var.service_policies_choice == "none" ? [1] : []
+    content {}
+  }
+  dynamic "active_service_policies" {
+    for_each = var.service_policies_choice == "active" ? [1] : []
+    content {
+      dynamic "policies" {
+        for_each = var.service_policy_active
+        content {
+          name      = xcsh_service_policy.this[policies.value].name
+          namespace = var.namespace
+        }
+      }
+    }
+  }
+
   # Enable API Discovery — learn the API schema from live traffic. This is the
   # discovery oneof (enable vs disable_api_discovery); independent of
   # api_specification / xcsh_api_definition (that path is enforcement, not
@@ -1895,6 +1918,21 @@ resource "xcsh_http_loadbalancer" "this" {
     precondition {
       condition     = alltrue([for r in var.rate_limit_policy_refs : contains([for p in var.rate_limiter_policies : p.name], r)])
       error_message = "every rate_limit_policy_refs entry must name a rate_limiter_policies entry."
+    }
+
+    # active_service_policies references standalone service_policies by name, in order;
+    # every ref must resolve to a created policy, and names only apply on the active arm.
+    precondition {
+      condition     = alltrue([for r in var.service_policy_active : contains([for p in var.service_policies : p.name], r)])
+      error_message = "every service_policy_active entry must name a service_policies entry."
+    }
+    precondition {
+      condition     = length(var.service_policy_active) == 0 || var.service_policies_choice == "active"
+      error_message = "service_policy_active requires service_policies_choice=\"active\"."
+    }
+    precondition {
+      condition     = var.service_policies_choice != "active" || length(var.service_policy_active) > 0
+      error_message = "service_policies_choice=\"active\" requires at least one service_policy_active entry."
     }
 
     # The api_rate_limit rule lists only apply on the api_rate_limit arm, and every

--- a/terraform/modules/http-lb/outputs_service_policy.tf
+++ b/terraform/modules/http-lb/outputs_service_policy.tf
@@ -1,0 +1,5 @@
+# Created service policy names, for reference/verification (SPol effort).
+output "service_policy_names" {
+  description = "Names of the created xcsh_service_policy objects, keyed by name."
+  value       = { for k, p in xcsh_service_policy.this : k => p.name }
+}

--- a/terraform/modules/http-lb/service_policy.tf
+++ b/terraform/modules/http-lb/service_policy.tf
@@ -1,0 +1,81 @@
+# Standalone service policies (SPol effort). See variables_service_policy.tf.
+# for_each keyed by name so the LB active_service_policies arm can reference a specific
+# policy via xcsh_service_policy.this[<name>].
+#
+# Optional list attributes are emitted as null (not []) when empty: F5 XC omits empty
+# lists on read, so forcing [] into the plan drifts against the read-back. null matches
+# the API's omit.
+#
+# Server-scope oneof: omitting every arm (server_scope="any_server") leaves the server to
+# apply its default any_server {}, which the provider suppresses on import (SPol-1 Layer 1
+# seed) — so we emit NO server block for that arm and stay import-clean.
+resource "xcsh_service_policy" "this" {
+  for_each = { for p in var.service_policies : p.name => p }
+
+  name      = each.value.name
+  namespace = var.namespace
+
+  # --- server scope oneof (omit any_server => server default, import-suppressed) ---
+  server_name = each.value.server_scope == "name" ? each.value.server_name : null
+
+  dynamic "server_name_matcher" {
+    for_each = each.value.server_scope == "name_matcher" ? [1] : []
+    content {
+      exact_values = length(each.value.server_name_exact) > 0 ? each.value.server_name_exact : null
+      regex_values = length(each.value.server_name_regex) > 0 ? each.value.server_name_regex : null
+    }
+  }
+  dynamic "server_selector" {
+    for_each = each.value.server_scope == "selector" ? [1] : []
+    content {
+      expressions = length(each.value.server_selector) > 0 ? each.value.server_selector : null
+    }
+  }
+
+  # --- rule-handling oneof (exactly one arm) ---
+  dynamic "allow_all_requests" {
+    for_each = each.value.rule_handling == "allow_all" ? [1] : []
+    content {}
+  }
+  dynamic "deny_all_requests" {
+    for_each = each.value.rule_handling == "deny_all" ? [1] : []
+    content {}
+  }
+  dynamic "allow_list" {
+    for_each = each.value.rule_handling == "allow_list" ? [1] : []
+    content {}
+  }
+  dynamic "deny_list" {
+    for_each = each.value.rule_handling == "deny_list" ? [1] : []
+    content {}
+  }
+  dynamic "rule_list" {
+    for_each = each.value.rule_handling == "rule_list" ? [1] : []
+    content {
+      dynamic "rules" {
+        for_each = each.value.rules
+        content {
+          metadata {
+            name = rules.value.name
+          }
+          spec {
+            action = rules.value.action
+          }
+        }
+      }
+    }
+  }
+
+  # rule_list must carry at least one rule (an empty rule_list {} is meaningless and the
+  # API rejects it); server_scope="name" needs a server_name.
+  lifecycle {
+    precondition {
+      condition     = each.value.rule_handling != "rule_list" || length(each.value.rules) > 0
+      error_message = "service_policy '${each.value.name}' uses rule_handling=\"rule_list\" but has no rules."
+    }
+    precondition {
+      condition     = each.value.server_scope != "name" || (each.value.server_name != null && each.value.server_name != "")
+      error_message = "service_policy '${each.value.name}' uses server_scope=\"name\" but server_name is unset."
+    }
+  }
+}

--- a/terraform/modules/http-lb/variables_service_policy.tf
+++ b/terraform/modules/http-lb/variables_service_policy.tf
@@ -1,0 +1,58 @@
+# Service policies (SPol effort). Standalone xcsh_service_policy objects created by
+# service_policy.tf (for_each by name), attached to the LB via the service_policies_choice
+# oneof in main.tf. SPol-1 (foundation) covers the two outer oneofs — rule-handling and
+# server scope — plus a minimal rule_list; per-rule matchers/actions/constraints land in
+# SPol-2..4. Defaults create nothing and emit no LB block (0-change; server default
+# service_policies_from_namespace, import-suppressed).
+
+variable "service_policies" {
+  description = "Standalone xcsh_service_policy objects to create. Each selects a rule-handling arm and a server-scope arm; rule_list supplies inline rules."
+  type = list(object({
+    name              = string
+    rule_handling     = optional(string, "allow_all")  # allow_all|deny_all|allow_list|deny_list|rule_list
+    server_scope      = optional(string, "any_server") # any_server|name|name_matcher|selector
+    server_name       = optional(string)
+    server_name_exact = optional(list(string), [])
+    server_name_regex = optional(list(string), [])
+    server_selector   = optional(list(string), [])
+    rules = optional(list(object({
+      name   = string
+      action = optional(string, "DENY") # DENY|ALLOW|NEXT_POLICY (provider-validated)
+    })), [])
+  }))
+  default = []
+
+  validation {
+    condition     = alltrue([for p in var.service_policies : contains(["allow_all", "deny_all", "allow_list", "deny_list", "rule_list"], p.rule_handling)])
+    error_message = "each service_policies[].rule_handling must be allow_all, deny_all, allow_list, deny_list, or rule_list."
+  }
+
+  validation {
+    condition     = alltrue([for p in var.service_policies : contains(["any_server", "name", "name_matcher", "selector"], p.server_scope)])
+    error_message = "each service_policies[].server_scope must be any_server, name, name_matcher, or selector."
+  }
+
+  # rule_list is the only arm that carries rules; a stray rules list on another arm is a
+  # config error (the rule would be silently dropped).
+  validation {
+    condition     = alltrue([for p in var.service_policies : length(coalesce(p.rules, [])) == 0 || p.rule_handling == "rule_list"])
+    error_message = "service_policies[].rules is only valid when rule_handling=\"rule_list\"."
+  }
+}
+
+variable "service_policies_choice" {
+  description = "LB service_policies_choice arm: omit (server default service_policies_from_namespace, import-clean), none (no_service_policies), or active (active_service_policies referencing service_policy_active)."
+  type        = string
+  default     = "omit"
+
+  validation {
+    condition     = contains(["omit", "none", "active"], var.service_policies_choice)
+    error_message = "service_policies_choice must be omit, none, or active."
+  }
+}
+
+variable "service_policy_active" {
+  description = "Ordered service policy names (from service_policies) to attach when service_policies_choice=active. Order is load-bearing: policies are evaluated top-to-bottom."
+  type        = list(string)
+  default     = []
+}

--- a/terraform/modules/http-lb/versions.tf
+++ b/terraform/modules/http-lb/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     xcsh = {
       source  = "f5-sales-demo/xcsh"
-      version = ">= 3.64.0"
+      version = ">= 3.72.4"
     }
   }
 }

--- a/terraform/tests/service_policy.tftest.hcl
+++ b/terraform/tests/service_policy.tftest.hcl
@@ -1,0 +1,161 @@
+# Plan-level tests for the service_policy foundation (SPol-1): the standalone
+# xcsh_service_policy rule-handling + server-scope oneofs and the LB
+# service_policies_choice wiring. Targets ./modules/http-lb. command = plan (no creds).
+variables {
+  namespace         = "webapp-api-protection"
+  lb_domains        = ["www.f5-sales-demo.com"]
+  origin_ip         = "203.0.113.10"
+  origin_port       = 80
+  health_check_path = "/health"
+  labels            = {}
+  csd_enabled       = false
+  mud_enabled       = false
+}
+
+# --- render: rule_list arm with an ALLOW rule ---
+run "rule_list_action_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{
+      name          = "spol-rules"
+      rule_handling = "rule_list"
+      rules         = [{ name = "allow-one", action = "ALLOW" }]
+    }]
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol-rules"].rule_list.rules[0].spec.action == "ALLOW"
+    error_message = "rule_list rule action must render ALLOW"
+  }
+}
+
+# --- render: allow_all arm emits the empty marker ---
+run "allow_all_arm_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{ name = "spol-allow", rule_handling = "allow_all" }]
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol-allow"].allow_all_requests != null
+    error_message = "allow_all arm must emit allow_all_requests"
+  }
+}
+
+# --- render: server_selector scope ---
+run "server_selector_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{
+      name            = "spol-srv"
+      rule_handling   = "allow_all"
+      server_scope    = "selector"
+      server_selector = ["app in (webapp)"]
+    }]
+  }
+  assert {
+    condition     = length(xcsh_service_policy.this["spol-srv"].server_selector.expressions) == 1
+    error_message = "server_selector expressions must render"
+  }
+}
+
+# --- render: LB active_service_policies wiring in order ---
+run "lb_active_service_policies_wiring" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies        = [{ name = "spol-a", rule_handling = "allow_all" }]
+    service_policies_choice = "active"
+    service_policy_active   = ["spol-a"]
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.active_service_policies.policies[0].name == "spol-a"
+    error_message = "LB active_service_policies must reference the policy by name"
+  }
+}
+
+# --- 0-change default: no policies, no LB block ---
+run "default_creates_nothing" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  assert {
+    condition     = length(xcsh_service_policy.this) == 0
+    error_message = "default (empty service_policies) must create no service policy"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.active_service_policies == null && xcsh_http_loadbalancer.this.no_service_policies == null
+    error_message = "default service_policies_choice=omit must emit no LB service-policy block"
+  }
+}
+
+# --- validation failures ---
+
+run "rejects_bad_rule_handling" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{ name = "x", rule_handling = "permit_all" }]
+  }
+  expect_failures = [var.service_policies]
+}
+
+run "rejects_bad_server_scope" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{ name = "x", server_scope = "any" }]
+  }
+  expect_failures = [var.service_policies]
+}
+
+run "rejects_rules_on_non_rule_list" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{ name = "x", rule_handling = "allow_all", rules = [{ name = "r" }] }]
+  }
+  expect_failures = [var.service_policies]
+}
+
+run "rejects_bad_choice" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies_choice = "namespace"
+  }
+  expect_failures = [var.service_policies_choice]
+}
+
+# --- precondition failures ---
+
+run "rejects_empty_rule_list" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{ name = "empty", rule_handling = "rule_list", rules = [] }]
+  }
+  expect_failures = [xcsh_service_policy.this]
+}
+
+run "rejects_active_without_names" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies        = [{ name = "spol-a", rule_handling = "allow_all" }]
+    service_policies_choice = "active"
+    service_policy_active   = []
+  }
+  expect_failures = [xcsh_http_loadbalancer.this]
+}
+
+run "rejects_active_name_not_created" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies        = [{ name = "spol-a", rule_handling = "allow_all" }]
+    service_policies_choice = "active"
+    service_policy_active   = ["ghost"]
+  }
+  expect_failures = [xcsh_http_loadbalancer.this]
+}

--- a/terraform/variables_service_policy.tf
+++ b/terraform/variables_service_policy.tf
@@ -1,0 +1,22 @@
+# Root-level service-policy (SPol effort) passthrough to modules/http-lb. The full typed
+# object + validation live once in the module (modules/http-lb/variables_service_policy.tf),
+# so the object var uses type = any; scalar knobs mirror the module defaults. Defaults
+# create nothing and emit no LB block (0-change).
+
+variable "service_policies" {
+  description = "Standalone xcsh_service_policy objects to create (see module for the object shape)."
+  type        = any
+  default     = []
+}
+
+variable "service_policies_choice" {
+  description = "LB service_policies_choice: omit | none | active. Validated in the module."
+  type        = string
+  default     = "omit"
+}
+
+variable "service_policy_active" {
+  description = "Ordered service policy names to attach when service_policies_choice=active."
+  type        = list(string)
+  default     = []
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -38,7 +38,14 @@ terraform {
       # shadowed the outer map var, sending "http_loadbalancer": {} and dropping the LB
       # association -> 400. 3.72.1 names the marshal map var by nesting path so the outer
       # map carries the populated ref, so xcsh_app_api_group applies.
-      version = ">= 3.72.1"
+      #
+      # >= 3.72.4: SPol-1 service_policy foundation (provider #1117, PR #1118). Seeds the
+      # xcsh_service_policy / xcsh_service_policy_rule server-default empty markers
+      # (any_server/any_client/any_asn/any_ip, waf/bot none, mum default, segment
+      # src_any/dst_any/intra_segment, per-list check_present/not_present, 13
+      # request_constraints max_*_none) so the standalone service policies this module
+      # now creates are round-trip-import clean.
+      version = ">= 3.72.4"
     }
     # Azure providers: this plan also deploys its OWN Azure origin server and
     # traffic generator (modules/origin-server, modules/traffic-generator), which


### PR DESCRIPTION
Closes #71. First slice (SPol-1 foundation) of exhaustive `xcsh_service_policy` coverage.

## What

- **modules/http-lb/service_policy.tf** (+ `variables_`/`outputs_`): standalone `xcsh_service_policy` keyed `for_each` by name. Rule-handling oneof (`allow_all`/`deny_all`/`allow_list`/`deny_list`/`rule_list`) and server-scope oneof (`any_server` default / `name` / `name_matcher` / `selector`) via single-knob selectors + dynamic blocks; null-when-empty lists; `lifecycle` preconditions (empty `rule_list`, `server_scope=name` needs `server_name`). `any_server` omitted (server default, import-suppressed).
- **main.tf**: LB `service_policies_choice` wiring — `omit` (server default `service_policies_from_namespace`, import-suppressed) / `none` / `active` (`active_service_policies.policies[]` ordered refs) + referential preconditions.
- **versions.tf**: pin `>= 3.72.4` — the provider release seeding the service_policy import-default suppressions (terraform-provider-xcsh #1118).
- **tests/service_policy.tftest.hcl**: 12 plan-tests — per-arm render, 0-change default, `expect_failures` for every validation/precondition. All pass (`terraform test`).
- **scripts/service_policy_pairs.py** (AETG all-pairs, 9 + canonical) + **service-policy-matrix.sh** (apply → idempotent → import round-trip → canonical restore) for the live matrix.

## Verification

- `terraform fmt`/`validate` clean; `make test` → 12 passed; JSCPD 8.82% (under 10%); codespell/shellcheck/shfmt clean.
- Defaults create nothing and emit no LB block → `terraform plan` is 0-change (canonical LB untouched).

## Follow-up (credentialed)

The live matrix (`bash scripts/service-policy-matrix.sh`, needs `XCSH_API_URL`/`XCSH_API_TOKEN` + `ARM_ACCESS_KEY`) exercises apply→idempotent→import-clean across all variants + canonical restore. It is SPol-1's credentialed verification; it is not a CI gate.

Roadmap: SPol-2 client/asn/ip/tls matchers → SPol-3 request matchers → SPol-4 action-side + request_constraints → SPol-5 behavioral verify + traffic-gen.