### PR TITLE
fix(service-policy): rule_list waf_action, provider repin v3.72.5, two-phase teardown

### DIFF
--- a/scripts/service-policy-matrix.sh
+++ b/scripts/service-policy-matrix.sh
@@ -44,8 +44,12 @@ echo "generated $count variants into $VARDIR (running [$START..$END])"
 
 round_trip() {
   local label="$1" vf="$2"
-  # Skip variants that create no service policy (canonical-restore): nothing to import.
-  if ! terraform state list | grep -qF "$SPOL_ADDR"; then
+  # Skip variants that define no service policy (canonical-restore): nothing to import.
+  # Decide from the variant CONFIG (deterministic), not a live `state list` read (which
+  # can transiently return empty and silently skip a real import).
+  local has_policy
+  has_policy=$(python3 -c 'import json,sys; print(len(json.load(open(sys.argv[1])).get("service_policies",[])))' "$vf" 2>/dev/null)
+  if [ "${has_policy:-0}" -eq 0 ]; then
     echo "PASS $label (no-policy variant, nothing to import)" >>"$REPORT"
     return
   fi

--- a/scripts/service-policy-matrix.sh
+++ b/scripts/service-policy-matrix.sh
@@ -65,7 +65,7 @@ round_trip() {
   esac
 }
 
-while read -r idx name vf; do
+while read -r idx name vf _flag; do
   [ "$idx" -lt "$START" ] && continue
   [ "$idx" -gt "$END" ] && continue
   label="$idx-$name"

--- a/scripts/service_policy_pairs.py
+++ b/scripts/service_policy_pairs.py
@@ -107,7 +107,11 @@ def detach() -> dict[str, object]:
     """
     return {
         "service_policies": [
-            {"name": POLICY_NAME, "rule_handling": "allow_all", "server_scope": "any_server"}
+            {
+                "name": POLICY_NAME,
+                "rule_handling": "allow_all",
+                "server_scope": "any_server",
+            }
         ],
         "service_policies_choice": "omit",
         "service_policy_active": [],

--- a/scripts/service_policy_pairs.py
+++ b/scripts/service_policy_pairs.py
@@ -95,6 +95,25 @@ def payloads(v: Mapping[str, object]) -> dict[str, object]:
     return out
 
 
+def detach() -> dict[str, object]:
+    """Detach the policy from the LB while keeping it defined.
+
+    F5 XC refuses to delete a service policy an LB still references (referential
+    integrity), and terraform's single-apply ordering does not reliably update the LB
+    (drop active_service_policies) before destroying the policy — the destroy hits a
+    referential 400 and the provider's bounded delete-retry exhausts. So teardown is
+    two-phase: this detach (LB -> server default, policy kept), then canonical (destroy
+    the now-unreferenced policy). Verified live on f5-sales-demo.
+    """
+    return {
+        "service_policies": [
+            {"name": POLICY_NAME, "rule_handling": "allow_all", "server_scope": "any_server"}
+        ],
+        "service_policies_choice": "omit",
+        "service_policy_active": [],
+    }
+
+
 def canonical() -> dict[str, object]:
     """Return the live-canonical end state (no service policy; LB server default)."""
     return {
@@ -117,6 +136,9 @@ def build() -> list[dict[str, object]]:
         seen.add(key)
         variants.append({"name": f"pair-{idx:03d}", "vars": vars_})
         idx += 1
+    # Two-phase teardown: detach the policy from the LB before destroying it (F5 XC
+    # refuses to delete a referenced policy; see detach()).
+    variants.append({"name": "detach", "vars": detach()})
     variants.append({"name": "canonical-restore", "vars": canonical()})
     return variants
 

--- a/terraform/modules/http-lb/service_policy.tf
+++ b/terraform/modules/http-lb/service_policy.tf
@@ -60,6 +60,12 @@ resource "xcsh_service_policy" "this" {
           }
           spec {
             action = rules.value.action
+            # F5 XC requires an action-side block on every rule; waf_action { none {} }
+            # is the minimal "no WAF action" form (the server-default base member, which
+            # the provider suppresses on import). SPol-4 parameterizes waf/bot/mum actions.
+            waf_action {
+              none {}
+            }
           }
         }
       }

--- a/terraform/modules/http-lb/versions.tf
+++ b/terraform/modules/http-lb/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     xcsh = {
       source  = "f5-sales-demo/xcsh"
-      version = ">= 3.72.4"
+      version = ">= 3.72.5"
     }
   }
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -39,13 +39,14 @@ terraform {
       # association -> 400. 3.72.1 names the marshal map var by nesting path so the outer
       # map carries the populated ref, so xcsh_app_api_group applies.
       #
-      # >= 3.72.4: SPol-1 service_policy foundation (provider #1117, PR #1118). Seeds the
-      # xcsh_service_policy / xcsh_service_policy_rule server-default empty markers
-      # (any_server/any_client/any_asn/any_ip, waf/bot none, mum default, segment
-      # src_any/dst_any/intra_segment, per-list check_present/not_present, 13
-      # request_constraints max_*_none) so the standalone service policies this module
-      # now creates are round-trip-import clean.
-      version = ">= 3.72.4"
+      # >= 3.72.4: SPol-1 service_policy foundation (provider #1118) — seeds the
+      # xcsh_service_policy import-default suppressions.
+      # >= 3.72.5: SPol-1 correction (provider #1122). The v3.72.4 seed over-suppressed —
+      # it dropped DECLARED oneof members (waf_action.none, mum_action.default, segment /
+      # request_constraints bases) on import. Live GET proved only any_server/any_client/
+      # any_asn/any_ip are echoed-on-omit; v3.72.5 suppresses just those, so a rule_list
+      # rule (which must declare waf_action { none {} }) round-trip-imports clean.
+      version = ">= 3.72.5"
     }
     # Azure providers: this plan also deploys its OWN Azure origin server and
     # traffic generator (modules/origin-server, modules/traffic-generator), which


### PR DESCRIPTION
Closes #73. Fixes from the **live matrix + traffic verification** of the merged SPol-1 foundation (#72) on f5-sales-demo — issues that plan-tests and the (rule_list-less) provider acceptance tests missed.

## Findings → fixes
1. **rule_list rejected** (`[BAD_REQUEST] Invalid request parameters`) — F5 XC requires an action-side block on every rule. `service_policy.tf` now emits `waf_action { none {} }` (minimal valid rule; SPol-4 parameterizes waf/bot/mum).
2. **Over-broad v3.72.4 suppressions dropped declared members on import** — repin `>= 3.72.5` (provider #1122: suppress only the echoed-on-omit bases any_server/any_client/any_asn/any_ip; a live GET proved none/default/segment/constraint bases are declared members that return null when omitted).
3. **Destroy-while-attached** — F5 XC won't delete a referenced policy and terraform doesn't detach-before-destroy in one apply (delete-retry exhausts). `service_policy_pairs.py` inserts a `detach` variant before `canonical-restore` (two-phase teardown). Also fixed the matrix runner's 4-column manifest read.

## Live verification (f5-sales-demo, v3.72.5)
- Full matrix (11 variants): apply → idempotent → import round-trip clean, canonical 0-change (re-run on the released provider — see PR checks / matrix report).
- Traffic: `deny_all` attached → **403**; allow_all / rule_list-ALLOW → **200** (LB enforces the policy).
- `make test` → 12 plan-tests pass; JSCPD/lint clean.