### PR TITLE
feat(service-policy): SPol-2 rule client/asn/ip/tls matchers (inline arms)

### DIFF
--- a/scripts/service-policy-matrix.sh
+++ b/scripts/service-policy-matrix.sh
@@ -25,13 +25,17 @@ ARM_ACCESS_KEY=$(az storage account keys list -n f5salesdemotfstate -g f5-sales-
 export ARM_ACCESS_KEY
 
 NS="webapp-api-protection"
-SPOL_ADDR="module.http_lb.xcsh_service_policy.this[\"matrix-spol\"]"
-SPOL_ID="${NS}/matrix-spol"
+# Overridable so the same runner drives the SPol-1 outer-oneof matrix and the SPol-2
+# matcher matrix (service_policy_matcher_pairs.py, policy "matrix-spol-m").
+PAIRS_SCRIPT="${PAIRS_SCRIPT:-service_policy_pairs.py}"
+SPOL_NAME="${SPOL_NAME:-matrix-spol}"
+VARDIR="${VARDIR:-/tmp/service-policy-variants}"
+SPOL_ADDR="module.http_lb.xcsh_service_policy.this[\"${SPOL_NAME}\"]"
+SPOL_ID="${NS}/${SPOL_NAME}"
 COMMON=(-input=false -lock=true
   -var 'lb_domains=["www.f5-sales-demo.com","api.f5-sales-demo.com"]'
   -var 'subscription_id=75f86c46-9cbc-4f6c-85ea-195e3d3c8ac0')
-VARDIR=/tmp/service-policy-variants
-REPORT=../reports/service-policy-matrix.txt
+REPORT="../reports/${REPORT_NAME:-service-policy-matrix.txt}"
 mkdir -p ../reports
 
 START="${1:-0}"
@@ -39,7 +43,7 @@ END="${2:-9999}"
 
 GATED_RE='entitlement|not subscribed|not entitled|not enabled for|permission denied|unauthorized|AS_NOT_SUBSCRIBED|status: 401|status: 403'
 
-count=$(python3 ../scripts/service_policy_pairs.py --emit "$VARDIR")
+count=$(python3 "../scripts/${PAIRS_SCRIPT}" --emit "$VARDIR")
 echo "generated $count variants into $VARDIR (running [$START..$END])"
 
 round_trip() {

--- a/scripts/service_policy_matcher_pairs.py
+++ b/scripts/service_policy_matcher_pairs.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Generate the service_policy rule-matcher (SPol-2) coverage matrix.
+
+AETG all-pairs over the four per-rule matcher oneofs, each variant a rule_list policy
+with one rule exercising the (client, asn, ip, tls) combination, LB-detached
+(service_policies_choice=omit) so the standalone policy destroys cleanly without the
+two-phase detach the attached case needs. Plus canonical restore.
+
+Matcher dimensions (inline arms; asn_matcher/ip_matcher bgp_asn_set/ip_prefix_set refs
+are SPol-2b):
+  client  any | selector | name | name_matcher | ip_threat
+  asn     any | list
+  ip      any | prefix_list
+  tls     none | matcher | ja4
+
+Deterministic (no RNG). Output: JSON to stdout, or files via --emit.
+"""
+
+import itertools
+import json
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+POLICY_NAME = "matrix-spol-m"
+
+DIMENSIONS = {
+    "client": ["any", "selector", "name", "name_matcher", "ip_threat"],
+    "asn": ["any", "list"],
+    "ip": ["any", "prefix_list"],
+    "tls": ["none", "matcher", "ja4"],
+}
+
+
+def _best_value(
+    values: list[str],
+    idx: int,
+    row: dict[int, str],
+    uncovered: set[tuple[int, str, int, str]],
+) -> str:
+    """Pick the value for dimension idx covering the most still-uncovered pairs."""
+    best_val, best_gain = values[0], -1
+    for val in values:
+        gain = 0
+        for pidx, pval in row.items():
+            a, b = sorted([(pidx, pval), (idx, val)])
+            if (a[0], a[1], b[0], b[1]) in uncovered:
+                gain += 1
+        if gain > best_gain:
+            best_gain, best_val = gain, val
+    return best_val
+
+
+def all_pairs(dims: dict[str, list[str]]) -> list[dict[str, str]]:
+    """Return AETG-style greedy all-pairs rows ({dim: value})."""
+    names = list(dims)
+    uncovered: set[tuple[int, str, int, str]] = set()
+    for i, j in itertools.combinations(range(len(names)), 2):
+        for vi in dims[names[i]]:
+            for vj in dims[names[j]]:
+                uncovered.add((i, vi, j, vj))
+
+    rows = []
+    while uncovered:
+        si, sv, sj, sv2 = min(uncovered)
+        row = {si: sv, sj: sv2}
+        for idx, name in enumerate(names):
+            if idx not in row:
+                row[idx] = _best_value(dims[name], idx, row, uncovered)
+        for i, j in itertools.combinations(sorted(row), 2):
+            uncovered.discard((i, row[i], j, row[j]))
+        rows.append({names[k]: v for k, v in row.items()})
+    return rows
+
+
+def rule(v: Mapping[str, object]) -> dict[str, object]:
+    """Build one rule from a matcher row."""
+    r: dict[str, object] = {"name": "r0", "action": "DENY", "client": v["client"]}
+    if v["client"] == "selector":
+        r["client_selector"] = ["app in (webapp)"]
+    elif v["client"] == "name":
+        r["client_name"] = "known-client"
+    elif v["client"] == "name_matcher":
+        r["client_name_exact"] = ["known-client"]
+    elif v["client"] == "ip_threat":
+        r["ip_threat_categories"] = ["BOTNETS"]
+
+    r["asn"] = v["asn"]
+    if v["asn"] == "list":
+        r["asn_numbers"] = [64512]
+
+    r["ip"] = v["ip"]
+    if v["ip"] == "prefix_list":
+        r["ip_prefixes"] = ["10.0.0.0/8"]
+
+    r["tls"] = v["tls"]
+    if v["tls"] == "matcher":
+        r["tls_classes"] = ["TRICKBOT"]
+    elif v["tls"] == "ja4":
+        r["ja4_exact"] = ["t13d1516h2_8daaf6152771_b186095e22b6"]
+    return r
+
+
+def payloads(v: Mapping[str, object]) -> dict[str, object]:
+    """Expand a matcher row into real tfvars (rule_list policy, LB-detached)."""
+    return {
+        "service_policies": [
+            {"name": POLICY_NAME, "rule_handling": "rule_list", "rules": [rule(v)]}
+        ],
+        "service_policies_choice": "omit",
+    }
+
+
+def canonical() -> dict[str, object]:
+    """Live-canonical end state (no service policy; LB server default)."""
+    return {"service_policies": [], "service_policies_choice": "omit"}
+
+
+def build() -> list[dict[str, object]]:
+    """Build the ordered variant manifest (all-pairs + canonical), deduped."""
+    variants: list[dict[str, object]] = []
+    seen: set[str] = set()
+    idx = 0
+    for row in all_pairs(DIMENSIONS):
+        vars_ = payloads(row)
+        key = json.dumps(vars_, sort_keys=True)
+        if key in seen:
+            continue
+        seen.add(key)
+        variants.append({"name": f"pair-{idx:03d}", "vars": vars_})
+        idx += 1
+    variants.append({"name": "canonical-restore", "vars": canonical()})
+    return variants
+
+
+def emit(directory: str) -> int:
+    """Write one <NNN>-<name>.tfvars.json per variant plus manifest.txt."""
+    out_dir = Path(directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for existing in out_dir.iterdir():
+        if existing.name.endswith(".tfvars.json") or existing.name == "manifest.txt":
+            existing.unlink()
+    variants = build()
+    named = [(f"{i:03d}-{v['name']}.tfvars.json", v) for i, v in enumerate(variants)]
+    for fname, v in named:
+        (out_dir / fname).write_text(json.dumps(v["vars"], indent=2) + "\n")
+    lines = [f"{i:03d} {v['name']} {fname} LIVE" for i, (fname, v) in enumerate(named)]
+    (out_dir / "manifest.txt").write_text("\n".join(lines) + "\n")
+    return len(variants)
+
+
+def main(argv: list[str]) -> None:
+    """CLI: --count, --emit <dir>, else JSON to stdout."""
+    match argv[1:]:
+        case ["--count"]:
+            sys.stdout.write(f"{len(build())}\n")
+        case ["--emit", directory]:
+            sys.stdout.write(f"{emit(directory)}\n")
+        case _:
+            json.dump(build(), sys.stdout, indent=2)
+            sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/terraform/modules/http-lb/service_policy.tf
+++ b/terraform/modules/http-lb/service_policy.tf
@@ -66,6 +66,61 @@ resource "xcsh_service_policy" "this" {
             waf_action {
               none {}
             }
+
+            # --- SPol-2 client matcher oneof (omit => server-default any_client, suppressed) ---
+            dynamic "client_selector" {
+              for_each = rules.value.client == "selector" ? [1] : []
+              content {
+                expressions = length(rules.value.client_selector) > 0 ? rules.value.client_selector : null
+              }
+            }
+            client_name = rules.value.client == "name" ? rules.value.client_name : null
+            dynamic "client_name_matcher" {
+              for_each = rules.value.client == "name_matcher" ? [1] : []
+              content {
+                exact_values = length(rules.value.client_name_exact) > 0 ? rules.value.client_name_exact : null
+                regex_values = length(rules.value.client_name_regex) > 0 ? rules.value.client_name_regex : null
+              }
+            }
+            dynamic "ip_threat_category_list" {
+              for_each = rules.value.client == "ip_threat" ? [1] : []
+              content {
+                ip_threat_categories = rules.value.ip_threat_categories
+              }
+            }
+
+            # --- SPol-2 ASN matcher oneof (omit => server-default any_asn, suppressed) ---
+            dynamic "asn_list" {
+              for_each = rules.value.asn == "list" ? [1] : []
+              content {
+                as_numbers = rules.value.asn_numbers
+              }
+            }
+
+            # --- SPol-2 IP matcher oneof (omit => server-default any_ip, suppressed) ---
+            dynamic "ip_prefix_list" {
+              for_each = rules.value.ip == "prefix_list" ? [1] : []
+              content {
+                ip_prefixes  = rules.value.ip_prefixes
+                invert_match = rules.value.ip_invert
+              }
+            }
+
+            # --- SPol-2 TLS-fingerprint matcher oneof (omit => no match constraint) ---
+            dynamic "tls_fingerprint_matcher" {
+              for_each = rules.value.tls == "matcher" ? [1] : []
+              content {
+                classes         = length(rules.value.tls_classes) > 0 ? rules.value.tls_classes : null
+                exact_values    = length(rules.value.tls_exact) > 0 ? rules.value.tls_exact : null
+                excluded_values = length(rules.value.tls_excluded) > 0 ? rules.value.tls_excluded : null
+              }
+            }
+            dynamic "ja4_tls_fingerprint" {
+              for_each = rules.value.tls == "ja4" ? [1] : []
+              content {
+                exact_values = rules.value.ja4_exact
+              }
+            }
           }
         }
       }

--- a/terraform/modules/http-lb/variables_service_policy.tf
+++ b/terraform/modules/http-lb/variables_service_policy.tf
@@ -18,6 +18,31 @@ variable "service_policies" {
     rules = optional(list(object({
       name   = string
       action = optional(string, "DENY") # DENY|ALLOW|NEXT_POLICY (provider-validated)
+      # SPol-2 client matcher oneof: any (default, omit -> server any_client) | selector |
+      # name | name_matcher | ip_threat. Concrete arms; the server echoes any_client
+      # alongside, suppressed on import.
+      client               = optional(string, "any") # any|selector|name|name_matcher|ip_threat
+      client_selector      = optional(list(string), [])
+      client_name          = optional(string)
+      client_name_exact    = optional(list(string), [])
+      client_name_regex    = optional(list(string), [])
+      ip_threat_categories = optional(list(string), [])
+      # SPol-2 ASN matcher oneof: any (default) | list (inline as_numbers). asn_matcher
+      # (bgp_asn_set ref) is SPol-2b.
+      asn         = optional(string, "any") # any|list
+      asn_numbers = optional(list(number), [])
+      # SPol-2 IP matcher oneof: any (default) | prefix_list (inline). ip_matcher
+      # (ip_prefix_set ref) is SPol-2b.
+      ip          = optional(string, "any") # any|prefix_list
+      ip_prefixes = optional(list(string), [])
+      ip_invert   = optional(bool, false)
+      # SPol-2 TLS-fingerprint matcher oneof: none (default, omit) | matcher (classes/exact/
+      # excluded) | ja4 (exact JA4 hashes).
+      tls          = optional(string, "none") # none|matcher|ja4
+      tls_classes  = optional(list(string), [])
+      tls_exact    = optional(list(string), [])
+      tls_excluded = optional(list(string), [])
+      ja4_exact    = optional(list(string), [])
     })), [])
   }))
   default = []
@@ -37,6 +62,61 @@ variable "service_policies" {
   validation {
     condition     = alltrue([for p in var.service_policies : length(coalesce(p.rules, [])) == 0 || p.rule_handling == "rule_list"])
     error_message = "service_policies[].rules is only valid when rule_handling=\"rule_list\"."
+  }
+
+  # SPol-2 matcher selectors.
+  validation {
+    condition = alltrue([for p in var.service_policies : alltrue([
+      for r in coalesce(p.rules, []) : contains(["any", "selector", "name", "name_matcher", "ip_threat"], r.client)
+    ])])
+    error_message = "each rule.client must be any, selector, name, name_matcher, or ip_threat."
+  }
+  validation {
+    condition = alltrue([for p in var.service_policies : alltrue([
+      for r in coalesce(p.rules, []) : contains(["any", "list"], r.asn)
+    ])])
+    error_message = "each rule.asn must be any or list."
+  }
+  validation {
+    condition = alltrue([for p in var.service_policies : alltrue([
+      for r in coalesce(p.rules, []) : contains(["any", "prefix_list"], r.ip)
+    ])])
+    error_message = "each rule.ip must be any or prefix_list."
+  }
+  validation {
+    condition = alltrue([for p in var.service_policies : alltrue([
+      for r in coalesce(p.rules, []) : contains(["none", "matcher", "ja4"], r.tls)
+    ])])
+    error_message = "each rule.tls must be none, matcher, or ja4."
+  }
+
+  # ip_threat_categories enum (ves.io.schema.policy IpThreatCategory) — fail fast at plan
+  # instead of a live 400.
+  validation {
+    condition = alltrue([for p in var.service_policies : alltrue([
+      for r in coalesce(p.rules, []) : alltrue([
+        for c in coalesce(r.ip_threat_categories, []) : contains([
+          "SPAM_SOURCES", "WINDOWS_EXPLOITS", "WEB_ATTACKS", "BOTNETS", "SCANNERS",
+          "REPUTATION", "PHISHING", "PROXY", "MOBILE_THREATS", "TOR_PROXY",
+          "DENIAL_OF_SERVICE", "NETWORK"
+        ], c)
+      ])
+    ])])
+    error_message = "each rule.ip_threat_categories entry must be a valid IpThreatCategory (e.g. BOTNETS, SPAM_SOURCES, TOR_PROXY)."
+  }
+
+  # tls_fingerprint_classes enum (KnownTlsFingerprintClass).
+  validation {
+    condition = alltrue([for p in var.service_policies : alltrue([
+      for r in coalesce(p.rules, []) : alltrue([
+        for c in coalesce(r.tls_classes, []) : contains([
+          "TLS_FINGERPRINT_NONE", "ANY_MALICIOUS_FINGERPRINT", "ADWARE", "ADWIND",
+          "DRIDEX", "GOOTKIT", "GOZI", "JBIFROST", "QUAKBOT", "RANSOMWARE",
+          "TROLDESH", "TOFSEE", "TORRENTLOCKER", "TRICKBOT"
+        ], c)
+      ])
+    ])])
+    error_message = "each rule.tls_classes entry must be a valid KnownTlsFingerprintClass (e.g. TRICKBOT, ANY_MALICIOUS_FINGERPRINT)."
   }
 }
 

--- a/terraform/tests/service_policy.tftest.hcl
+++ b/terraform/tests/service_policy.tftest.hcl
@@ -159,3 +159,92 @@ run "rejects_active_name_not_created" {
   }
   expect_failures = [xcsh_http_loadbalancer.this]
 }
+
+# ============================================================================
+# SPol-2: rule client/asn/ip/tls matchers
+# ============================================================================
+
+run "matcher_ip_threat_and_asn_and_ip_and_tls_render" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{
+      name          = "spol2"
+      rule_handling = "rule_list"
+      rules = [{
+        name   = "r0", action = "DENY"
+        client = "ip_threat", ip_threat_categories = ["BOTNETS"]
+        asn    = "list", asn_numbers = [64512]
+        ip     = "prefix_list", ip_prefixes = ["10.0.0.0/8"]
+        tls    = "matcher", tls_classes = ["TRICKBOT"]
+      }]
+    }]
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol2"].rule_list.rules[0].spec.ip_threat_category_list.ip_threat_categories[0] == "BOTNETS"
+    error_message = "ip_threat_category_list must render"
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol2"].rule_list.rules[0].spec.asn_list.as_numbers[0] == 64512
+    error_message = "asn_list must render"
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol2"].rule_list.rules[0].spec.ip_prefix_list.ip_prefixes[0] == "10.0.0.0/8"
+    error_message = "ip_prefix_list must render"
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol2"].rule_list.rules[0].spec.tls_fingerprint_matcher.classes[0] == "TRICKBOT"
+    error_message = "tls_fingerprint_matcher.classes must render"
+  }
+}
+
+run "matcher_client_selector_render" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{
+      name  = "spol2s", rule_handling = "rule_list"
+      rules = [{ name = "r0", action = "ALLOW", client = "selector", client_selector = ["app in (webapp)"] }]
+    }]
+  }
+  assert {
+    condition     = length(xcsh_service_policy.this["spol2s"].rule_list.rules[0].spec.client_selector.expressions) == 1
+    error_message = "client_selector.expressions must render"
+  }
+}
+
+run "matcher_rejects_bad_ip_threat_category" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{
+      name  = "x", rule_handling = "rule_list"
+      rules = [{ name = "r0", client = "ip_threat", ip_threat_categories = ["NOT_A_CATEGORY"] }]
+    }]
+  }
+  expect_failures = [var.service_policies]
+}
+
+run "matcher_rejects_bad_tls_class" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{
+      name  = "x", rule_handling = "rule_list"
+      rules = [{ name = "r0", tls = "matcher", tls_classes = ["MALWARE_X"] }]
+    }]
+  }
+  expect_failures = [var.service_policies]
+}
+
+run "matcher_rejects_bad_client_selector_arm" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{
+      name  = "x", rule_handling = "rule_list"
+      rules = [{ name = "r0", client = "cookie" }]
+    }]
+  }
+  expect_failures = [var.service_policies]
+}


### PR DESCRIPTION
Closes #75. Adds the per-rule client/asn/ip/tls matcher oneofs (inline arms) to xcsh_service_policy rule_list rules, with ip_threat_categories + tls_classes enum validations. Live-verified on f5-sales-demo v3.72.5: all arms apply -> idempotent -> import round-trip clean (AETG matcher matrix 17/17); 17 plan-tests pass. No provider change needed (existing any_* suppressions cover it). Ref-object arms (asn_matcher/ip_matcher) are SPol-2b.