### PR TITLE
feat(service-policy): SPol-3 rule request matchers (http_method/path/domain/headers/query)

### DIFF
--- a/scripts/service_policy_request_pairs.py
+++ b/scripts/service_policy_request_pairs.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Generate the service_policy rule request-matcher (SPol-3) coverage matrix.
+
+AETG all-pairs over the request-matcher dimensions, each variant a rule_list policy with
+one rule (LB-detached, service_policies_choice=omit, so the standalone policy destroys
+cleanly). Plus canonical restore.
+
+Dimensions:
+  method  none | get | post_delete           (http_method)
+  path    none | prefix | exact | regex | suffix
+  domain  none | exact
+  header  none | match | present | absent     (headers[] item / check_present / check_not_present)
+  query   none | match                        (query_params[])
+
+Deterministic (no RNG). Output: JSON to stdout, or files via --emit.
+"""
+
+import itertools
+import json
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+POLICY_NAME = "matrix-spol-r"
+
+DIMENSIONS = {
+    "method": ["none", "get", "post_delete"],
+    "path": ["none", "prefix", "exact", "regex", "suffix"],
+    "domain": ["none", "exact"],
+    "header": ["none", "match", "present", "absent"],
+    "query": ["none", "match"],
+}
+
+
+def _best_value(
+    values: list[str],
+    idx: int,
+    row: dict[int, str],
+    uncovered: set[tuple[int, str, int, str]],
+) -> str:
+    """Pick the value for dimension idx covering the most still-uncovered pairs."""
+    best_val, best_gain = values[0], -1
+    for val in values:
+        gain = 0
+        for pidx, pval in row.items():
+            a, b = sorted([(pidx, pval), (idx, val)])
+            if (a[0], a[1], b[0], b[1]) in uncovered:
+                gain += 1
+        if gain > best_gain:
+            best_gain, best_val = gain, val
+    return best_val
+
+
+def all_pairs(dims: dict[str, list[str]]) -> list[dict[str, str]]:
+    """Return AETG-style greedy all-pairs rows ({dim: value})."""
+    names = list(dims)
+    uncovered: set[tuple[int, str, int, str]] = set()
+    for i, j in itertools.combinations(range(len(names)), 2):
+        for vi in dims[names[i]]:
+            for vj in dims[names[j]]:
+                uncovered.add((i, vi, j, vj))
+
+    rows = []
+    while uncovered:
+        si, sv, sj, sv2 = min(uncovered)
+        row = {si: sv, sj: sv2}
+        for idx, name in enumerate(names):
+            if idx not in row:
+                row[idx] = _best_value(dims[name], idx, row, uncovered)
+        for i, j in itertools.combinations(sorted(row), 2):
+            uncovered.discard((i, row[i], j, row[j]))
+        rows.append({names[k]: v for k, v in row.items()})
+    return rows
+
+
+def rule(v: Mapping[str, object]) -> dict[str, object]:
+    """Build one rule from a request-matcher row."""
+    r: dict[str, object] = {"name": "r0", "action": "DENY"}
+    if v["method"] == "get":
+        r["http_methods"] = ["GET"]
+    elif v["method"] == "post_delete":
+        r["http_methods"] = ["POST", "DELETE"]
+
+    if v["path"] == "prefix":
+        r["path_prefix"] = ["/admin"]
+    elif v["path"] == "exact":
+        r["path_exact"] = ["/health"]
+    elif v["path"] == "regex":
+        r["path_regex"] = ["/api/.*"]
+    elif v["path"] == "suffix":
+        r["path_suffix"] = [".json"]
+
+    if v["domain"] == "exact":
+        r["domain_exact"] = ["www.f5-sales-demo.com"]
+
+    if v["header"] == "match":
+        r["headers"] = [{"name": "x-test", "presence": "match", "exact_values": ["v1"]}]
+    elif v["header"] == "present":
+        r["headers"] = [{"name": "x-must", "presence": "present"}]
+    elif v["header"] == "absent":
+        r["headers"] = [{"name": "x-none", "presence": "absent"}]
+
+    if v["query"] == "match":
+        r["query_params"] = [
+            {"key": "debug", "presence": "match", "exact_values": ["1"]}
+        ]
+    return r
+
+
+def payloads(v: Mapping[str, object]) -> dict[str, object]:
+    """Expand a request-matcher row into real tfvars (rule_list policy, LB-detached)."""
+    return {
+        "service_policies": [
+            {"name": POLICY_NAME, "rule_handling": "rule_list", "rules": [rule(v)]}
+        ],
+        "service_policies_choice": "omit",
+    }
+
+
+def canonical() -> dict[str, object]:
+    """Live-canonical end state (no service policy; LB server default)."""
+    return {"service_policies": [], "service_policies_choice": "omit"}
+
+
+def build() -> list[dict[str, object]]:
+    """Build the ordered variant manifest (all-pairs + canonical), deduped."""
+    variants: list[dict[str, object]] = []
+    seen: set[str] = set()
+    idx = 0
+    for row in all_pairs(DIMENSIONS):
+        # Skip the all-"none" row: a rule with no request matcher is the SPol-2 case.
+        if all(val == "none" for val in row.values()):
+            continue
+        vars_ = payloads(row)
+        key = json.dumps(vars_, sort_keys=True)
+        if key in seen:
+            continue
+        seen.add(key)
+        variants.append({"name": f"pair-{idx:03d}", "vars": vars_})
+        idx += 1
+    variants.append({"name": "canonical-restore", "vars": canonical()})
+    return variants
+
+
+def emit(directory: str) -> int:
+    """Write one <NNN>-<name>.tfvars.json per variant plus manifest.txt."""
+    out_dir = Path(directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for existing in out_dir.iterdir():
+        if existing.name.endswith(".tfvars.json") or existing.name == "manifest.txt":
+            existing.unlink()
+    variants = build()
+    named = [(f"{i:03d}-{v['name']}.tfvars.json", v) for i, v in enumerate(variants)]
+    for fname, v in named:
+        (out_dir / fname).write_text(json.dumps(v["vars"], indent=2) + "\n")
+    lines = [f"{i:03d} {v['name']} {fname} LIVE" for i, (fname, v) in enumerate(named)]
+    (out_dir / "manifest.txt").write_text("\n".join(lines) + "\n")
+    return len(variants)
+
+
+def main(argv: list[str]) -> None:
+    """CLI: --count, --emit <dir>, else JSON to stdout."""
+    match argv[1:]:
+        case ["--count"]:
+            sys.stdout.write(f"{len(build())}\n")
+        case ["--emit", directory]:
+            sys.stdout.write(f"{emit(directory)}\n")
+        case _:
+            json.dump(build(), sys.stdout, indent=2)
+            sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/terraform/modules/http-lb/service_policy.tf
+++ b/terraform/modules/http-lb/service_policy.tf
@@ -121,6 +121,76 @@ resource "xcsh_service_policy" "this" {
                 exact_values = rules.value.ja4_exact
               }
             }
+
+            # --- SPol-3 request matchers (additive AND; omitted = no constraint) ---
+            dynamic "http_method" {
+              for_each = length(rules.value.http_methods) > 0 ? [1] : []
+              content {
+                methods        = rules.value.http_methods
+                invert_matcher = rules.value.http_methods_invert
+              }
+            }
+            dynamic "path" {
+              for_each = (length(rules.value.path_exact) + length(rules.value.path_prefix) + length(rules.value.path_regex) + length(rules.value.path_suffix)) > 0 ? [1] : []
+              content {
+                exact_values   = length(rules.value.path_exact) > 0 ? rules.value.path_exact : null
+                prefix_values  = length(rules.value.path_prefix) > 0 ? rules.value.path_prefix : null
+                regex_values   = length(rules.value.path_regex) > 0 ? rules.value.path_regex : null
+                suffix_values  = length(rules.value.path_suffix) > 0 ? rules.value.path_suffix : null
+                invert_matcher = rules.value.path_invert
+              }
+            }
+            dynamic "domain_matcher" {
+              for_each = (length(rules.value.domain_exact) + length(rules.value.domain_regex)) > 0 ? [1] : []
+              content {
+                exact_values = length(rules.value.domain_exact) > 0 ? rules.value.domain_exact : null
+                regex_values = length(rules.value.domain_regex) > 0 ? rules.value.domain_regex : null
+              }
+            }
+            dynamic "headers" {
+              for_each = rules.value.headers
+              content {
+                name           = headers.value.name
+                invert_matcher = headers.value.invert
+                dynamic "check_present" {
+                  for_each = headers.value.presence == "present" ? [1] : []
+                  content {}
+                }
+                dynamic "check_not_present" {
+                  for_each = headers.value.presence == "absent" ? [1] : []
+                  content {}
+                }
+                dynamic "item" {
+                  for_each = headers.value.presence == "match" ? [1] : []
+                  content {
+                    exact_values = length(headers.value.exact_values) > 0 ? headers.value.exact_values : null
+                    regex_values = length(headers.value.regex_values) > 0 ? headers.value.regex_values : null
+                  }
+                }
+              }
+            }
+            dynamic "query_params" {
+              for_each = rules.value.query_params
+              content {
+                key            = query_params.value.key
+                invert_matcher = query_params.value.invert
+                dynamic "check_present" {
+                  for_each = query_params.value.presence == "present" ? [1] : []
+                  content {}
+                }
+                dynamic "check_not_present" {
+                  for_each = query_params.value.presence == "absent" ? [1] : []
+                  content {}
+                }
+                dynamic "item" {
+                  for_each = query_params.value.presence == "match" ? [1] : []
+                  content {
+                    exact_values = length(query_params.value.exact_values) > 0 ? query_params.value.exact_values : null
+                    regex_values = length(query_params.value.regex_values) > 0 ? query_params.value.regex_values : null
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/terraform/modules/http-lb/variables_service_policy.tf
+++ b/terraform/modules/http-lb/variables_service_policy.tf
@@ -43,6 +43,30 @@ variable "service_policies" {
       tls_exact    = optional(list(string), [])
       tls_excluded = optional(list(string), [])
       ja4_exact    = optional(list(string), [])
+      # SPol-3 request matchers (additive AND within a rule; omitted = no constraint).
+      http_methods        = optional(list(string), []) # ANY|GET|HEAD|POST|PUT|DELETE|CONNECT|OPTIONS|TRACE|PATCH|COPY
+      http_methods_invert = optional(bool, false)
+      path_exact          = optional(list(string), []) # path oneof: parallel *_values lists
+      path_prefix         = optional(list(string), [])
+      path_regex          = optional(list(string), [])
+      path_suffix         = optional(list(string), [])
+      path_invert         = optional(bool, false)
+      domain_exact        = optional(list(string), [])
+      domain_regex        = optional(list(string), [])
+      headers = optional(list(object({
+        name         = string
+        presence     = optional(string, "match") # match|present|absent
+        invert       = optional(bool, false)
+        exact_values = optional(list(string), [])
+        regex_values = optional(list(string), [])
+      })), [])
+      query_params = optional(list(object({
+        key          = string
+        presence     = optional(string, "match") # match|present|absent
+        invert       = optional(bool, false)
+        exact_values = optional(list(string), [])
+        regex_values = optional(list(string), [])
+      })), [])
     })), [])
   }))
   default = []
@@ -117,6 +141,29 @@ variable "service_policies" {
       ])
     ])])
     error_message = "each rule.tls_classes entry must be a valid KnownTlsFingerprintClass (e.g. TRICKBOT, ANY_MALICIOUS_FINGERPRINT)."
+  }
+
+  # SPol-3 http_method enum (ves.io.schema.HttpMethod).
+  validation {
+    condition = alltrue([for p in var.service_policies : alltrue([
+      for r in coalesce(p.rules, []) : alltrue([
+        for m in coalesce(r.http_methods, []) : contains([
+          "ANY", "GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH", "COPY"
+        ], m)
+      ])
+    ])])
+    error_message = "each rule.http_methods entry must be a valid HTTP method (GET, POST, DELETE, ANY, ...)."
+  }
+
+  # SPol-3 header/query-param presence selector (match=item exact/regex, present/absent=marker).
+  validation {
+    condition = alltrue([for p in var.service_policies : alltrue([
+      for r in coalesce(p.rules, []) : alltrue(concat(
+        [for h in coalesce(r.headers, []) : contains(["match", "present", "absent"], h.presence)],
+        [for q in coalesce(r.query_params, []) : contains(["match", "present", "absent"], q.presence)]
+      ))
+    ])])
+    error_message = "each rule.headers[]/query_params[] presence must be match, present, or absent."
   }
 }
 

--- a/terraform/tests/service_policy.tftest.hcl
+++ b/terraform/tests/service_policy.tftest.hcl
@@ -248,3 +248,59 @@ run "matcher_rejects_bad_client_selector_arm" {
   }
   expect_failures = [var.service_policies]
 }
+
+# ============================================================================
+# SPol-3: rule request matchers
+# ============================================================================
+
+run "request_matchers_render" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{
+      name = "spol3", rule_handling = "rule_list"
+      rules = [{
+        name         = "r0", action = "DENY"
+        http_methods = ["POST", "DELETE"]
+        path_prefix  = ["/admin"]
+        domain_exact = ["www.f5-sales-demo.com"]
+        headers      = [{ name = "x-test", presence = "match", exact_values = ["v1"] }, { name = "x-must", presence = "present" }]
+        query_params = [{ key = "debug", presence = "match", exact_values = ["1"] }]
+      }]
+    }]
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol3"].rule_list.rules[0].spec.http_method.methods[0] == "POST"
+    error_message = "http_method must render"
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol3"].rule_list.rules[0].spec.path.prefix_values[0] == "/admin"
+    error_message = "path.prefix_values must render"
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol3"].rule_list.rules[0].spec.headers[0].item.exact_values[0] == "v1"
+    error_message = "header item exact_values must render"
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol3"].rule_list.rules[0].spec.headers[1].check_present != null
+    error_message = "header presence=present must render check_present"
+  }
+}
+
+run "request_rejects_bad_http_method" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{ name = "x", rule_handling = "rule_list", rules = [{ name = "r0", http_methods = ["FETCH"] }] }]
+  }
+  expect_failures = [var.service_policies]
+}
+
+run "request_rejects_bad_header_presence" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{ name = "x", rule_handling = "rule_list", rules = [{ name = "r0", headers = [{ name = "h", presence = "maybe" }] }] }]
+  }
+  expect_failures = [var.service_policies]
+}


### PR DESCRIPTION
Closes #77. Adds per-rule request matchers (http_method/path/domain_matcher/headers[]/query_params[]) to xcsh_service_policy rule_list rules with http_method enum + header/query presence validations. Live-verified on f5-sales-demo v3.72.5: AETG request-matcher matrix 21/21 apply->idempotent->import clean; **behavioral traffic** DENY /admin + ALLOW attached -> /admin=403, /=200 (path matcher enforces). 20 plan-tests. No provider change (declared markers round-trip). Remaining matchers (arg/cookie/jwt/body/user_identity/label/api_group/port) = SPol-3b.