### PR TITLE
feat(service-policy): SPol-4a rule action-side (waf/bot/mum arms)

### DIFF
--- a/scripts/service_policy_action_pairs.py
+++ b/scripts/service_policy_action_pairs.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Generate the service_policy action-side (SPol-4a) coverage matrix.
+
+AETG all-pairs over the four per-rule matcher oneofs, each variant a rule_list policy
+with one rule exercising the (client, asn, ip, tls) combination, LB-detached
+(service_policies_choice=omit) so the standalone policy destroys cleanly without the
+two-phase detach the attached case needs. Plus canonical restore.
+
+Matcher dimensions (inline arms; asn_matcher/ip_matcher bgp_asn_set/ip_prefix_set refs
+are SPol-2b):
+  client  any | selector | name | name_matcher | ip_threat
+  asn     any | list
+  ip      any | prefix_list
+  tls     none | matcher | ja4
+
+Deterministic (no RNG). Output: JSON to stdout, or files via --emit.
+"""
+
+import itertools
+import json
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+POLICY_NAME = "matrix-spol-a"
+
+DIMENSIONS = {
+    "waf": ["none", "skip"],
+    "bot": ["omit", "skip"],
+    "mum": ["omit", "skip"],
+}
+
+
+def _best_value(
+    values: list[str],
+    idx: int,
+    row: dict[int, str],
+    uncovered: set[tuple[int, str, int, str]],
+) -> str:
+    """Pick the value for dimension idx covering the most still-uncovered pairs."""
+    best_val, best_gain = values[0], -1
+    for val in values:
+        gain = 0
+        for pidx, pval in row.items():
+            a, b = sorted([(pidx, pval), (idx, val)])
+            if (a[0], a[1], b[0], b[1]) in uncovered:
+                gain += 1
+        if gain > best_gain:
+            best_gain, best_val = gain, val
+    return best_val
+
+
+def all_pairs(dims: dict[str, list[str]]) -> list[dict[str, str]]:
+    """Return AETG-style greedy all-pairs rows ({dim: value})."""
+    names = list(dims)
+    uncovered: set[tuple[int, str, int, str]] = set()
+    for i, j in itertools.combinations(range(len(names)), 2):
+        for vi in dims[names[i]]:
+            for vj in dims[names[j]]:
+                uncovered.add((i, vi, j, vj))
+
+    rows = []
+    while uncovered:
+        si, sv, sj, sv2 = min(uncovered)
+        row = {si: sv, sj: sv2}
+        for idx, name in enumerate(names):
+            if idx not in row:
+                row[idx] = _best_value(dims[name], idx, row, uncovered)
+        for i, j in itertools.combinations(sorted(row), 2):
+            uncovered.discard((i, row[i], j, row[j]))
+        rows.append({names[k]: v for k, v in row.items()})
+    return rows
+
+
+def rule(v: Mapping[str, object]) -> dict[str, object]:
+    """Build one rule from an action-side row."""
+    return {
+        "name": "r0",
+        "action": "DENY",
+        "waf_action_mode": v["waf"],
+        "bot_action_mode": v["bot"],
+        "mum_action_mode": v["mum"],
+    }
+
+
+def payloads(v: Mapping[str, object]) -> dict[str, object]:
+    """Expand a matcher row into real tfvars (rule_list policy, LB-detached)."""
+    return {
+        "service_policies": [
+            {"name": POLICY_NAME, "rule_handling": "rule_list", "rules": [rule(v)]}
+        ],
+        "service_policies_choice": "omit",
+    }
+
+
+def canonical() -> dict[str, object]:
+    """Live-canonical end state (no service policy; LB server default)."""
+    return {"service_policies": [], "service_policies_choice": "omit"}
+
+
+def build() -> list[dict[str, object]]:
+    """Build the ordered variant manifest (all-pairs + canonical), deduped."""
+    variants: list[dict[str, object]] = []
+    seen: set[str] = set()
+    idx = 0
+    for row in all_pairs(DIMENSIONS):
+        # F5 XC skip-processing is all-or-nothing: waf=skip requires bot=skip AND mum=skip
+        # (live-verified). Skip invalid combos the module precondition rejects.
+        if row["waf"] == "skip" and not (row["bot"] == "skip" and row["mum"] == "skip"):
+            continue
+        vars_ = payloads(row)
+        key = json.dumps(vars_, sort_keys=True)
+        if key in seen:
+            continue
+        seen.add(key)
+        variants.append({"name": f"pair-{idx:03d}", "vars": vars_})
+        idx += 1
+    variants.append({"name": "canonical-restore", "vars": canonical()})
+    return variants
+
+
+def emit(directory: str) -> int:
+    """Write one <NNN>-<name>.tfvars.json per variant plus manifest.txt."""
+    out_dir = Path(directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for existing in out_dir.iterdir():
+        if existing.name.endswith(".tfvars.json") or existing.name == "manifest.txt":
+            existing.unlink()
+    variants = build()
+    named = [(f"{i:03d}-{v['name']}.tfvars.json", v) for i, v in enumerate(variants)]
+    for fname, v in named:
+        (out_dir / fname).write_text(json.dumps(v["vars"], indent=2) + "\n")
+    lines = [f"{i:03d} {v['name']} {fname} LIVE" for i, (fname, v) in enumerate(named)]
+    (out_dir / "manifest.txt").write_text("\n".join(lines) + "\n")
+    return len(variants)
+
+
+def main(argv: list[str]) -> None:
+    """CLI: --count, --emit <dir>, else JSON to stdout."""
+    match argv[1:]:
+        case ["--count"]:
+            sys.stdout.write(f"{len(build())}\n")
+        case ["--emit", directory]:
+            sys.stdout.write(f"{emit(directory)}\n")
+        case _:
+            json.dump(build(), sys.stdout, indent=2)
+            sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/terraform/modules/http-lb/service_policy.tf
+++ b/terraform/modules/http-lb/service_policy.tf
@@ -60,11 +60,32 @@ resource "xcsh_service_policy" "this" {
           }
           spec {
             action = rules.value.action
-            # F5 XC requires an action-side block on every rule; waf_action { none {} }
-            # is the minimal "no WAF action" form (the server-default base member, which
-            # the provider suppresses on import). SPol-4 parameterizes waf/bot/mum actions.
+            # F5 XC requires waf_action on every rule (SPol-1). SPol-4a parameterizes the
+            # arm: none (no WAF action) or skip (waf_skip_processing). detection-control
+            # exclusions are SPol-4b.
             waf_action {
-              none {}
+              dynamic "none" {
+                for_each = rules.value.waf_action_mode == "none" ? [1] : []
+                content {}
+              }
+              dynamic "waf_skip_processing" {
+                for_each = rules.value.waf_action_mode == "skip" ? [1] : []
+                content {}
+              }
+            }
+            # bot_action / mum_action: omitted by default (server returns null); a concrete
+            # skip arm emits the block. SPol-4b adds any further arms.
+            dynamic "bot_action" {
+              for_each = rules.value.bot_action_mode == "skip" ? [1] : []
+              content {
+                bot_skip_processing {}
+              }
+            }
+            dynamic "mum_action" {
+              for_each = rules.value.mum_action_mode == "skip" ? [1] : []
+              content {
+                skip_processing {}
+              }
             }
 
             # --- SPol-2 client matcher oneof (omit => server-default any_client, suppressed) ---

--- a/terraform/modules/http-lb/variables_service_policy.tf
+++ b/terraform/modules/http-lb/variables_service_policy.tf
@@ -67,6 +67,13 @@ variable "service_policies" {
         exact_values = optional(list(string), [])
         regex_values = optional(list(string), [])
       })), [])
+      # SPol-4a action-side oneofs. waf_action is required on every rule (none default |
+      # skip = waf_skip_processing; app_firewall_detection_control is SPol-4b). bot_action
+      # /mum_action are omitted by default (server returns null; a concrete arm emits the
+      # block): skip = bot_skip_processing / skip_processing.
+      waf_action_mode = optional(string, "none") # none|skip
+      bot_action_mode = optional(string, "omit") # omit|skip
+      mum_action_mode = optional(string, "omit") # omit|skip
     })), [])
   }))
   default = []
@@ -164,6 +171,32 @@ variable "service_policies" {
       ))
     ])])
     error_message = "each rule.headers[]/query_params[] presence must be match, present, or absent."
+  }
+
+  # SPol-4a action-side selectors.
+  validation {
+    condition = alltrue([for p in var.service_policies : alltrue([
+      for r in coalesce(p.rules, []) : contains(["none", "skip"], r.waf_action_mode)
+    ])])
+    error_message = "each rule.waf_action_mode must be none or skip."
+  }
+  validation {
+    condition = alltrue([for p in var.service_policies : alltrue([
+      for r in coalesce(p.rules, []) : contains(["omit", "skip"], r.bot_action_mode) && contains(["omit", "skip"], r.mum_action_mode)
+    ])])
+    error_message = "each rule.bot_action_mode / mum_action_mode must be omit or skip."
+  }
+
+  # F5 XC "skip processing" is all-or-nothing: waf_action=waf_skip_processing requires
+  # bot_action and mum_action to ALSO skip (the API returns 400 otherwise — verified live:
+  # (skip,skip,skip) applies, but (skip,omit,*)/(skip,*,omit) are rejected). With
+  # waf_action=none, bot/mum are independent.
+  validation {
+    condition = alltrue([for p in var.service_policies : alltrue([
+      for r in coalesce(p.rules, []) :
+      r.waf_action_mode != "skip" || (r.bot_action_mode == "skip" && r.mum_action_mode == "skip")
+    ])])
+    error_message = "waf_action_mode=\"skip\" requires bot_action_mode=\"skip\" and mum_action_mode=\"skip\" (F5 XC skip-processing is all-or-nothing)."
   }
 }
 

--- a/terraform/tests/service_policy.tftest.hcl
+++ b/terraform/tests/service_policy.tftest.hcl
@@ -304,3 +304,64 @@ run "request_rejects_bad_header_presence" {
   }
   expect_failures = [var.service_policies]
 }
+
+# ============================================================================
+# SPol-4a: rule action-side (waf_action / bot_action / mum_action)
+# ============================================================================
+
+run "action_skip_arms_render" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{
+      name  = "spol4", rule_handling = "rule_list"
+      rules = [{ name = "r0", action = "ALLOW", waf_action_mode = "skip", bot_action_mode = "skip", mum_action_mode = "skip" }]
+    }]
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol4"].rule_list.rules[0].spec.waf_action.waf_skip_processing != null
+    error_message = "waf_action skip must render waf_skip_processing"
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol4"].rule_list.rules[0].spec.bot_action.bot_skip_processing != null
+    error_message = "bot_action skip must render bot_skip_processing"
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol4"].rule_list.rules[0].spec.mum_action.skip_processing != null
+    error_message = "mum_action skip must render skip_processing"
+  }
+}
+
+run "action_default_waf_none_no_bot_mum" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{ name = "spol4d", rule_handling = "rule_list", rules = [{ name = "r0", action = "DENY" }] }]
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol4d"].rule_list.rules[0].spec.waf_action.none != null
+    error_message = "default waf_action must be none"
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol4d"].rule_list.rules[0].spec.bot_action == null && xcsh_service_policy.this["spol4d"].rule_list.rules[0].spec.mum_action == null
+    error_message = "default bot_action/mum_action must be omitted (null)"
+  }
+}
+
+run "action_rejects_bad_waf_mode" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{ name = "x", rule_handling = "rule_list", rules = [{ name = "r0", waf_action_mode = "block" }] }]
+  }
+  expect_failures = [var.service_policies]
+}
+
+run "action_rejects_partial_skip" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{ name = "x", rule_handling = "rule_list", rules = [{ name = "r0", waf_action_mode = "skip", bot_action_mode = "omit", mum_action_mode = "skip" }] }]
+  }
+  expect_failures = [var.service_policies]
+}


### PR DESCRIPTION
Closes #79. Per-rule waf_action/bot_action/mum_action arms. Live finding: skip-processing is all-or-nothing (waf=skip ⟹ bot=skip & mum=skip; encoded as precondition). Action matrix apply→idempotent→import clean; 24 plan-tests. No provider change. detection-control/segment_policy/request_constraints = SPol-4b.