### PR TITLE
SPol-4b: service_policy action-side — detection-control, segment_policy, request_constraints (+ fix SPol-4a coupling)

### DIFF
--- a/scripts/service_policy_action_pairs.py
+++ b/scripts/service_policy_action_pairs.py
@@ -1,17 +1,23 @@
 #!/usr/bin/env python3
-"""Generate the service_policy action-side (SPol-4a) coverage matrix.
+"""Generate the service_policy action-side + constraints (SPol-4a/4b) coverage matrix.
 
-AETG all-pairs over the four per-rule matcher oneofs, each variant a rule_list policy
-with one rule exercising the (client, asn, ip, tls) combination, LB-detached
-(service_policies_choice=omit) so the standalone policy destroys cleanly without the
-two-phase detach the attached case needs. Plus canonical restore.
+AETG all-pairs over the per-rule action-side oneofs and constraint blocks, each variant a
+rule_list policy with one rule, LB-detached (service_policies_choice=omit) so the standalone
+policy destroys cleanly without the two-phase detach the attached case needs. Plus canonical
+restore.
 
-Matcher dimensions (inline arms; asn_matcher/ip_matcher bgp_asn_set/ip_prefix_set refs
-are SPol-2b):
-  client  any | selector | name | name_matcher | ip_threat
-  asn     any | list
-  ip      any | prefix_list
-  tls     none | matcher | ja4
+Dimensions:
+  waf  none | skip | detection_control   (waf_action arm)
+  bot  omit | skip                        (bot_action)
+  mum  omit | skip                        (mum_action)
+  seg  omit | any | intra                 (segment_policy markers; segments refs deferred)
+  rc   off | on                           (request_constraints, exceeds + none markers)
+
+The rule action is derived from waf: a configured WAF action (skip/detection_control) is
+rejected by F5 XC on a DENY rule ("WAF Action cannot be configured for a rule with action
+DENY" — live-verified), so waf!=none => action ALLOW, else DENY. bot/mum are independent of
+waf and of each other (the SPol-4a all-or-nothing rule was a misdiagnosis of that DENY
+rejection). All generated combinations are therefore valid; no combos are filtered.
 
 Deterministic (no RNG). Output: JSON to stdout, or files via --emit.
 """
@@ -25,9 +31,11 @@ from pathlib import Path
 POLICY_NAME = "matrix-spol-a"
 
 DIMENSIONS = {
-    "waf": ["none", "skip"],
+    "waf": ["none", "skip", "detection_control"],
     "bot": ["omit", "skip"],
     "mum": ["omit", "skip"],
+    "seg": ["omit", "any", "intra"],
+    "rc": ["off", "on"],
 }
 
 
@@ -73,14 +81,40 @@ def all_pairs(dims: dict[str, list[str]]) -> list[dict[str, str]]:
 
 
 def rule(v: Mapping[str, object]) -> dict[str, object]:
-    """Build one rule from an action-side row."""
-    return {
+    """Build one rule from an action-side + constraints row."""
+    waf = v["waf"]
+    # A configured WAF action requires a non-DENY rule (F5 XC constraint).
+    r: dict[str, object] = {
         "name": "r0",
-        "action": "DENY",
-        "waf_action_mode": v["waf"],
-        "bot_action_mode": v["bot"],
-        "mum_action_mode": v["mum"],
+        "action": "DENY" if waf == "none" else "ALLOW",
+        "waf_action_mode": waf,
     }
+    if waf == "detection_control":
+        # Exercise all four exclusion list types: attack-type (default CONTEXT_ANY), violation
+        # (CONTEXT_HEADER), signature (CONTEXT_URL + id), and bot-name.
+        r["waf_exclude_attack_type_contexts"] = [
+            {"exclude_attack_type": "ATTACK_TYPE_SQL_INJECTION"}
+        ]
+        r["waf_exclude_violation_contexts"] = [
+            {"context": "CONTEXT_HEADER", "exclude_violation": "VIOL_JSON_MALFORMED"}
+        ]
+        r["waf_exclude_signature_contexts"] = [
+            {"context": "CONTEXT_URL", "signature_id": 200000001}
+        ]
+        r["waf_exclude_bot_names"] = ["curl"]
+    if v["bot"] == "skip":
+        r["bot_action_mode"] = "skip"
+    if v["mum"] == "skip":
+        r["mum_action_mode"] = "skip"
+    if v["seg"] == "any":
+        r["segment_src"] = "any"
+        r["segment_dst"] = "any"
+    elif v["seg"] == "intra":
+        r["segment_intra"] = True
+    if v["rc"] == "on":
+        r["request_constraints_enabled"] = True
+        r["max_url_size"] = 2048
+    return r
 
 
 def payloads(v: Mapping[str, object]) -> dict[str, object]:
@@ -104,10 +138,8 @@ def build() -> list[dict[str, object]]:
     seen: set[str] = set()
     idx = 0
     for row in all_pairs(DIMENSIONS):
-        # F5 XC skip-processing is all-or-nothing: waf=skip requires bot=skip AND mum=skip
-        # (live-verified). Skip invalid combos the module precondition rejects.
-        if row["waf"] == "skip" and not (row["bot"] == "skip" and row["mum"] == "skip"):
-            continue
+        # All combinations are valid (action is derived from waf to satisfy the DENY
+        # coupling; bot/mum/seg/rc are independent) — nothing to filter.
         vars_ = payloads(row)
         key = json.dumps(vars_, sort_keys=True)
         if key in seen:

--- a/terraform/modules/http-lb/service_policy.tf
+++ b/terraform/modules/http-lb/service_policy.tf
@@ -60,9 +60,12 @@ resource "xcsh_service_policy" "this" {
           }
           spec {
             action = rules.value.action
-            # F5 XC requires waf_action on every rule (SPol-1). SPol-4a parameterizes the
-            # arm: none (no WAF action) or skip (waf_skip_processing). detection-control
-            # exclusions are SPol-4b.
+            # F5 XC requires waf_action on every rule (SPol-1). Arm: none (no WAF action) |
+            # skip (waf_skip_processing) | detection_control (app_firewall_detection_control
+            # exclusions, SPol-4b). skip/detection_control require action != DENY (enforced in
+            # variables_service_policy.tf). context is always emitted (server keeps the enum,
+            # default CONTEXT_ANY); context_name is emitted null-when-empty because the provider
+            # reads the server's empty string back as null (an explicit "" would drift on import).
             waf_action {
               dynamic "none" {
                 for_each = rules.value.waf_action_mode == "none" ? [1] : []
@@ -71,6 +74,41 @@ resource "xcsh_service_policy" "this" {
               dynamic "waf_skip_processing" {
                 for_each = rules.value.waf_action_mode == "skip" ? [1] : []
                 content {}
+              }
+              dynamic "app_firewall_detection_control" {
+                for_each = rules.value.waf_action_mode == "detection_control" ? [1] : []
+                content {
+                  dynamic "exclude_attack_type_contexts" {
+                    for_each = rules.value.waf_exclude_attack_type_contexts
+                    content {
+                      context             = exclude_attack_type_contexts.value.context
+                      context_name        = exclude_attack_type_contexts.value.context_name != "" ? exclude_attack_type_contexts.value.context_name : null
+                      exclude_attack_type = exclude_attack_type_contexts.value.exclude_attack_type
+                    }
+                  }
+                  dynamic "exclude_violation_contexts" {
+                    for_each = rules.value.waf_exclude_violation_contexts
+                    content {
+                      context           = exclude_violation_contexts.value.context
+                      context_name      = exclude_violation_contexts.value.context_name != "" ? exclude_violation_contexts.value.context_name : null
+                      exclude_violation = exclude_violation_contexts.value.exclude_violation
+                    }
+                  }
+                  dynamic "exclude_signature_contexts" {
+                    for_each = rules.value.waf_exclude_signature_contexts
+                    content {
+                      context      = exclude_signature_contexts.value.context
+                      context_name = exclude_signature_contexts.value.context_name != "" ? exclude_signature_contexts.value.context_name : null
+                      signature_id = exclude_signature_contexts.value.signature_id
+                    }
+                  }
+                  dynamic "exclude_bot_name_contexts" {
+                    for_each = rules.value.waf_exclude_bot_names
+                    content {
+                      bot_name = exclude_bot_name_contexts.value
+                    }
+                  }
+                }
               }
             }
             # bot_action / mum_action: omitted by default (server returns null); a concrete
@@ -209,6 +247,101 @@ resource "xcsh_service_policy" "this" {
                     exact_values = length(query_params.value.exact_values) > 0 ? query_params.value.exact_values : null
                     regex_values = length(query_params.value.regex_values) > 0 ? query_params.value.regex_values : null
                   }
+                }
+              }
+            }
+
+            # --- SPol-4b segment_policy (source/destination markers; segments refs deferred).
+            # Emitted only when a marker is selected; read-back is exact (no provider change). ---
+            dynamic "segment_policy" {
+              for_each = (rules.value.segment_src != "omit" || rules.value.segment_dst != "omit" || rules.value.segment_intra) ? [1] : []
+              content {
+                dynamic "src_any" {
+                  for_each = rules.value.segment_src == "any" ? [1] : []
+                  content {}
+                }
+                dynamic "dst_any" {
+                  for_each = rules.value.segment_dst == "any" ? [1] : []
+                  content {}
+                }
+                dynamic "intra_segment" {
+                  for_each = rules.value.segment_intra ? [1] : []
+                  content {}
+                }
+              }
+            }
+
+            # --- SPol-4b request_constraints. When enabled, every dimension is emitted as a
+            # oneof: a set max_* value => max_*_exceeds, an unset one => max_*_none marker. The
+            # server echoes the none marker for each unset dimension, so emitting all 13 keeps
+            # the plan import-clean. ---
+            dynamic "request_constraints" {
+              for_each = rules.value.request_constraints_enabled ? [1] : []
+              content {
+                max_cookie_count_exceeds = rules.value.max_cookie_count
+                dynamic "max_cookie_count_none" {
+                  for_each = rules.value.max_cookie_count == null ? [1] : []
+                  content {}
+                }
+                max_cookie_key_size_exceeds = rules.value.max_cookie_key_size
+                dynamic "max_cookie_key_size_none" {
+                  for_each = rules.value.max_cookie_key_size == null ? [1] : []
+                  content {}
+                }
+                max_cookie_value_size_exceeds = rules.value.max_cookie_value_size
+                dynamic "max_cookie_value_size_none" {
+                  for_each = rules.value.max_cookie_value_size == null ? [1] : []
+                  content {}
+                }
+                max_header_count_exceeds = rules.value.max_header_count
+                dynamic "max_header_count_none" {
+                  for_each = rules.value.max_header_count == null ? [1] : []
+                  content {}
+                }
+                max_header_key_size_exceeds = rules.value.max_header_key_size
+                dynamic "max_header_key_size_none" {
+                  for_each = rules.value.max_header_key_size == null ? [1] : []
+                  content {}
+                }
+                max_header_value_size_exceeds = rules.value.max_header_value_size
+                dynamic "max_header_value_size_none" {
+                  for_each = rules.value.max_header_value_size == null ? [1] : []
+                  content {}
+                }
+                max_parameter_count_exceeds = rules.value.max_parameter_count
+                dynamic "max_parameter_count_none" {
+                  for_each = rules.value.max_parameter_count == null ? [1] : []
+                  content {}
+                }
+                max_parameter_name_size_exceeds = rules.value.max_parameter_name_size
+                dynamic "max_parameter_name_size_none" {
+                  for_each = rules.value.max_parameter_name_size == null ? [1] : []
+                  content {}
+                }
+                max_parameter_value_size_exceeds = rules.value.max_parameter_value_size
+                dynamic "max_parameter_value_size_none" {
+                  for_each = rules.value.max_parameter_value_size == null ? [1] : []
+                  content {}
+                }
+                max_query_size_exceeds = rules.value.max_query_size
+                dynamic "max_query_size_none" {
+                  for_each = rules.value.max_query_size == null ? [1] : []
+                  content {}
+                }
+                max_request_line_size_exceeds = rules.value.max_request_line_size
+                dynamic "max_request_line_size_none" {
+                  for_each = rules.value.max_request_line_size == null ? [1] : []
+                  content {}
+                }
+                max_request_size_exceeds = rules.value.max_request_size
+                dynamic "max_request_size_none" {
+                  for_each = rules.value.max_request_size == null ? [1] : []
+                  content {}
+                }
+                max_url_size_exceeds = rules.value.max_url_size
+                dynamic "max_url_size_none" {
+                  for_each = rules.value.max_url_size == null ? [1] : []
+                  content {}
                 }
               }
             }

--- a/terraform/modules/http-lb/variables_service_policy.tf
+++ b/terraform/modules/http-lb/variables_service_policy.tf
@@ -67,13 +67,59 @@ variable "service_policies" {
         exact_values = optional(list(string), [])
         regex_values = optional(list(string), [])
       })), [])
-      # SPol-4a action-side oneofs. waf_action is required on every rule (none default |
-      # skip = waf_skip_processing; app_firewall_detection_control is SPol-4b). bot_action
-      # /mum_action are omitted by default (server returns null; a concrete arm emits the
-      # block): skip = bot_skip_processing / skip_processing.
-      waf_action_mode = optional(string, "none") # none|skip
+      # Action-side waf_action oneof (required on every rule): none default | skip =
+      # waf_skip_processing | detection_control = app_firewall_detection_control. skip and
+      # detection_control require action != DENY (F5 XC: "WAF Action cannot be configured for
+      # a rule with action DENY" — live-verified). bot_action/mum_action are omitted by
+      # default (server returns null; a concrete skip arm emits the block) and are INDEPENDENT
+      # of waf_action and each other (the SPol-4a all-or-nothing precondition was a
+      # misdiagnosis of the DENY rejection — corrected here).
+      waf_action_mode = optional(string, "none") # none|skip|detection_control
       bot_action_mode = optional(string, "omit") # omit|skip
       mum_action_mode = optional(string, "omit") # omit|skip
+      # SPol-4b detection_control (waf_action_mode="detection_control") exclusion lists. Each
+      # entry excludes a signature/violation/attack-type/bot-name from triggering. context
+      # defaults CONTEXT_ANY and context_name "" (server-filled) — emitted explicitly to stay
+      # import-clean. Requires >= 1 exclusion when the mode is selected.
+      waf_exclude_attack_type_contexts = optional(list(object({
+        context             = optional(string, "CONTEXT_ANY")
+        context_name        = optional(string, "")
+        exclude_attack_type = string
+      })), [])
+      waf_exclude_violation_contexts = optional(list(object({
+        context           = optional(string, "CONTEXT_ANY")
+        context_name      = optional(string, "")
+        exclude_violation = string
+      })), [])
+      waf_exclude_signature_contexts = optional(list(object({
+        context      = optional(string, "CONTEXT_ANY")
+        context_name = optional(string, "")
+        signature_id = number # 0 or 200000001-299999999
+      })), [])
+      waf_exclude_bot_names = optional(list(string), [])
+      # SPol-4b segment_policy source/destination markers (src_segments/dst_segments Segment
+      # refs deferred to a later ref slice). Any combination is accepted; the block is emitted
+      # only when a marker is selected. Read-back is exact (no provider change).
+      segment_src   = optional(string, "omit") # omit|any
+      segment_dst   = optional(string, "omit") # omit|any
+      segment_intra = optional(bool, false)
+      # SPol-4b request_constraints: when enabled, ALL 13 dimensions are emitted (a set max_*
+      # value => max_*_exceeds, an unset one => max_*_none marker). The server echoes the none
+      # marker for every unset dimension, so emitting all 13 keeps the plan import-clean.
+      request_constraints_enabled = optional(bool, false)
+      max_cookie_count            = optional(number)
+      max_cookie_key_size         = optional(number)
+      max_cookie_value_size       = optional(number)
+      max_header_count            = optional(number)
+      max_header_key_size         = optional(number)
+      max_header_value_size       = optional(number)
+      max_parameter_count         = optional(number)
+      max_parameter_name_size     = optional(number)
+      max_parameter_value_size    = optional(number)
+      max_query_size              = optional(number)
+      max_request_line_size       = optional(number)
+      max_request_size            = optional(number)
+      max_url_size                = optional(number)
     })), [])
   }))
   default = []
@@ -173,12 +219,12 @@ variable "service_policies" {
     error_message = "each rule.headers[]/query_params[] presence must be match, present, or absent."
   }
 
-  # SPol-4a action-side selectors.
+  # Action-side selectors.
   validation {
     condition = alltrue([for p in var.service_policies : alltrue([
-      for r in coalesce(p.rules, []) : contains(["none", "skip"], r.waf_action_mode)
+      for r in coalesce(p.rules, []) : contains(["none", "skip", "detection_control"], r.waf_action_mode)
     ])])
-    error_message = "each rule.waf_action_mode must be none or skip."
+    error_message = "each rule.waf_action_mode must be none, skip, or detection_control."
   }
   validation {
     condition = alltrue([for p in var.service_policies : alltrue([
@@ -187,16 +233,108 @@ variable "service_policies" {
     error_message = "each rule.bot_action_mode / mum_action_mode must be omit or skip."
   }
 
-  # F5 XC "skip processing" is all-or-nothing: waf_action=waf_skip_processing requires
-  # bot_action and mum_action to ALSO skip (the API returns 400 otherwise — verified live:
-  # (skip,skip,skip) applies, but (skip,omit,*)/(skip,*,omit) are rejected). With
-  # waf_action=none, bot/mum are independent.
+  # F5 XC: a configured WAF action (waf_skip_processing or app_firewall_detection_control)
+  # cannot be attached to a DENY rule — "WAF Action cannot be configured for a rule with
+  # action DENY" (live-verified). waf_action_mode=none is unconstrained; bot_action and
+  # mum_action are independent of waf_action and of each other.
   validation {
     condition = alltrue([for p in var.service_policies : alltrue([
       for r in coalesce(p.rules, []) :
-      r.waf_action_mode != "skip" || (r.bot_action_mode == "skip" && r.mum_action_mode == "skip")
+      r.waf_action_mode == "none" || r.action != "DENY"
     ])])
-    error_message = "waf_action_mode=\"skip\" requires bot_action_mode=\"skip\" and mum_action_mode=\"skip\" (F5 XC skip-processing is all-or-nothing)."
+    error_message = "rule.waf_action_mode \"skip\"/\"detection_control\" requires action != DENY (F5 XC rejects a WAF action on a DENY rule)."
+  }
+
+  # SPol-4b detection_control needs at least one exclusion when selected (an empty block is
+  # meaningless), and the exclusion lists are only valid under that mode.
+  validation {
+    condition = alltrue([for p in var.service_policies : alltrue([
+      for r in coalesce(p.rules, []) :
+      r.waf_action_mode != "detection_control" || (
+        length(r.waf_exclude_attack_type_contexts) + length(r.waf_exclude_violation_contexts) +
+        length(r.waf_exclude_signature_contexts) + length(r.waf_exclude_bot_names) > 0
+      )
+    ])])
+    error_message = "rule.waf_action_mode=\"detection_control\" requires at least one waf_exclude_* entry."
+  }
+  validation {
+    condition = alltrue([for p in var.service_policies : alltrue([
+      for r in coalesce(p.rules, []) :
+      r.waf_action_mode == "detection_control" || (
+        length(r.waf_exclude_attack_type_contexts) + length(r.waf_exclude_violation_contexts) +
+        length(r.waf_exclude_signature_contexts) + length(r.waf_exclude_bot_names) == 0
+      )
+    ])])
+    error_message = "rule.waf_exclude_* is only valid when waf_action_mode=\"detection_control\"."
+  }
+
+  # SPol-4b detection_control enum validations (fail fast at plan instead of a live 400).
+  validation {
+    condition = alltrue([for p in var.service_policies : alltrue([
+      for r in coalesce(p.rules, []) : alltrue([
+        for c in concat(r.waf_exclude_attack_type_contexts, r.waf_exclude_violation_contexts, r.waf_exclude_signature_contexts) :
+        contains([
+          "CONTEXT_ANY", "CONTEXT_BODY", "CONTEXT_REQUEST", "CONTEXT_RESPONSE", "CONTEXT_PARAMETER",
+          "CONTEXT_HEADER", "CONTEXT_COOKIE", "CONTEXT_URL", "CONTEXT_URI"
+        ], c.context)
+      ])
+    ])])
+    error_message = "each waf_exclude_*.context must be a valid WAF exclusion context (CONTEXT_ANY, CONTEXT_HEADER, CONTEXT_URL, ...)."
+  }
+  validation {
+    condition = alltrue([for p in var.service_policies : alltrue([
+      for r in coalesce(p.rules, []) : alltrue([
+        for c in r.waf_exclude_attack_type_contexts : contains([
+          "ATTACK_TYPE_NONE", "ATTACK_TYPE_NON_BROWSER_CLIENT", "ATTACK_TYPE_OTHER_APPLICATION_ATTACKS",
+          "ATTACK_TYPE_TROJAN_BACKDOOR_SPYWARE", "ATTACK_TYPE_DETECTION_EVASION", "ATTACK_TYPE_VULNERABILITY_SCAN",
+          "ATTACK_TYPE_ABUSE_OF_FUNCTIONALITY", "ATTACK_TYPE_AUTHENTICATION_AUTHORIZATION_ATTACKS",
+          "ATTACK_TYPE_BUFFER_OVERFLOW", "ATTACK_TYPE_PREDICTABLE_RESOURCE_LOCATION", "ATTACK_TYPE_INFORMATION_LEAKAGE",
+          "ATTACK_TYPE_DIRECTORY_INDEXING", "ATTACK_TYPE_PATH_TRAVERSAL", "ATTACK_TYPE_XPATH_INJECTION",
+          "ATTACK_TYPE_LDAP_INJECTION", "ATTACK_TYPE_SERVER_SIDE_CODE_INJECTION", "ATTACK_TYPE_COMMAND_EXECUTION",
+          "ATTACK_TYPE_SQL_INJECTION", "ATTACK_TYPE_CROSS_SITE_SCRIPTING", "ATTACK_TYPE_DENIAL_OF_SERVICE",
+          "ATTACK_TYPE_HTTP_PARSER_ATTACK", "ATTACK_TYPE_SESSION_HIJACKING", "ATTACK_TYPE_HTTP_RESPONSE_SPLITTING",
+          "ATTACK_TYPE_FORCEFUL_BROWSING", "ATTACK_TYPE_REMOTE_FILE_INCLUDE", "ATTACK_TYPE_MALICIOUS_FILE_UPLOAD",
+          "ATTACK_TYPE_GRAPHQL_PARSER_ATTACK"
+        ], c.exclude_attack_type)
+      ])
+    ])])
+    error_message = "each waf_exclude_attack_type_contexts[].exclude_attack_type must be a valid ATTACK_TYPE_* value."
+  }
+  validation {
+    condition = alltrue([for p in var.service_policies : alltrue([
+      for r in coalesce(p.rules, []) : alltrue([
+        for c in r.waf_exclude_violation_contexts : contains([
+          "VIOL_NONE", "VIOL_FILETYPE", "VIOL_METHOD", "VIOL_MANDATORY_HEADER", "VIOL_HTTP_RESPONSE_STATUS",
+          "VIOL_REQUEST_MAX_LENGTH", "VIOL_FILE_UPLOAD", "VIOL_FILE_UPLOAD_IN_BODY", "VIOL_XML_MALFORMED",
+          "VIOL_JSON_MALFORMED", "VIOL_ASM_COOKIE_MODIFIED", "VIOL_HTTP_PROTOCOL_MULTIPLE_HOST_HEADERS",
+          "VIOL_HTTP_PROTOCOL_BAD_HOST_HEADER_VALUE", "VIOL_HTTP_PROTOCOL_UNPARSABLE_REQUEST_CONTENT",
+          "VIOL_HTTP_PROTOCOL_NULL_IN_REQUEST", "VIOL_HTTP_PROTOCOL_BAD_HTTP_VERSION",
+          "VIOL_HTTP_PROTOCOL_SEVERAL_CONTENT_LENGTH_HEADERS", "VIOL_EVASION_DIRECTORY_TRAVERSALS",
+          "VIOL_MALFORMED_REQUEST", "VIOL_EVASION_MULTIPLE_DECODING", "VIOL_DATA_GUARD",
+          "VIOL_EVASION_APACHE_WHITESPACE", "VIOL_COOKIE_MODIFIED", "VIOL_EVASION_IIS_UNICODE_CODEPOINTS",
+          "VIOL_EVASION_IIS_BACKSLASHES", "VIOL_EVASION_PERCENT_U_DECODING", "VIOL_EVASION_BARE_BYTE_DECODING",
+          "VIOL_EVASION_BAD_UNESCAPE", "VIOL_HTTP_PROTOCOL_BODY_IN_GET_OR_HEAD_REQUEST", "VIOL_ENCODING",
+          "VIOL_COOKIE_MALFORMED", "VIOL_GRAPHQL_FORMAT", "VIOL_GRAPHQL_MALFORMED", "VIOL_GRAPHQL_INTROSPECTION_QUERY"
+        ], c.exclude_violation)
+      ])
+    ])])
+    error_message = "each waf_exclude_violation_contexts[].exclude_violation must be a valid VIOL_* value."
+  }
+  validation {
+    condition = alltrue([for p in var.service_policies : alltrue([
+      for r in coalesce(p.rules, []) : alltrue([
+        for c in r.waf_exclude_signature_contexts : c.signature_id == 0 || (c.signature_id >= 200000001 && c.signature_id <= 299999999)
+      ])
+    ])])
+    error_message = "each waf_exclude_signature_contexts[].signature_id must be 0 or in 200000001-299999999."
+  }
+
+  # SPol-4b segment_policy source/destination marker selectors.
+  validation {
+    condition = alltrue([for p in var.service_policies : alltrue([
+      for r in coalesce(p.rules, []) : contains(["omit", "any"], r.segment_src) && contains(["omit", "any"], r.segment_dst)
+    ])])
+    error_message = "each rule.segment_src / segment_dst must be omit or any (segments refs are deferred)."
   }
 }
 

--- a/terraform/tests/service_policy.tftest.hcl
+++ b/terraform/tests/service_policy.tftest.hcl
@@ -332,6 +332,27 @@ run "action_skip_arms_render" {
   }
 }
 
+# waf skip with bot/mum OMITTED under ALLOW is valid (bot/mum are independent of waf —
+# the SPol-4a all-or-nothing precondition was a misdiagnosis of the DENY rejection).
+run "action_skip_omit_bot_mum_render" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{
+      name  = "spol4i", rule_handling = "rule_list"
+      rules = [{ name = "r0", action = "ALLOW", waf_action_mode = "skip" }]
+    }]
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol4i"].rule_list.rules[0].spec.waf_action.waf_skip_processing != null
+    error_message = "waf skip with omitted bot/mum must render"
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol4i"].rule_list.rules[0].spec.bot_action == null && xcsh_service_policy.this["spol4i"].rule_list.rules[0].spec.mum_action == null
+    error_message = "omitted bot/mum must stay null alongside waf skip"
+  }
+}
+
 run "action_default_waf_none_no_bot_mum" {
   command = plan
   module { source = "./modules/http-lb" }
@@ -357,11 +378,169 @@ run "action_rejects_bad_waf_mode" {
   expect_failures = [var.service_policies]
 }
 
-run "action_rejects_partial_skip" {
+# A configured WAF action (skip or detection_control) on a DENY rule is rejected by F5 XC.
+run "action_rejects_waf_on_deny" {
   command = plan
   module { source = "./modules/http-lb" }
   variables {
-    service_policies = [{ name = "x", rule_handling = "rule_list", rules = [{ name = "r0", waf_action_mode = "skip", bot_action_mode = "omit", mum_action_mode = "skip" }] }]
+    service_policies = [{ name = "x", rule_handling = "rule_list", rules = [{ name = "r0", action = "DENY", waf_action_mode = "skip" }] }]
+  }
+  expect_failures = [var.service_policies]
+}
+
+# --- SPol-4b: detection_control renders all four exclusion lists ---
+run "detection_control_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{
+      name          = "spol4b-dc"
+      rule_handling = "rule_list"
+      rules = [{
+        name                             = "r0", action = "ALLOW", waf_action_mode = "detection_control"
+        waf_exclude_attack_type_contexts = [{ context = "CONTEXT_ANY", exclude_attack_type = "ATTACK_TYPE_SQL_INJECTION" }]
+        waf_exclude_violation_contexts   = [{ context = "CONTEXT_HEADER", context_name = "x-h", exclude_violation = "VIOL_JSON_MALFORMED" }]
+        waf_exclude_signature_contexts   = [{ context = "CONTEXT_URL", signature_id = 200000001 }]
+        waf_exclude_bot_names            = ["curl"]
+      }]
+    }]
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol4b-dc"].rule_list.rules[0].spec.waf_action.app_firewall_detection_control.exclude_attack_type_contexts[0].exclude_attack_type == "ATTACK_TYPE_SQL_INJECTION"
+    error_message = "detection_control attack-type exclusion must render"
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol4b-dc"].rule_list.rules[0].spec.waf_action.app_firewall_detection_control.exclude_bot_name_contexts[0].bot_name == "curl"
+    error_message = "detection_control bot-name exclusion must render"
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol4b-dc"].rule_list.rules[0].spec.waf_action.app_firewall_detection_control.exclude_signature_contexts[0].signature_id == 200000001
+    error_message = "detection_control signature exclusion must render"
+  }
+}
+
+# --- SPol-4b: segment_policy markers render ---
+run "segment_policy_markers_render" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{
+      name          = "spol4b-seg"
+      rule_handling = "rule_list"
+      rules         = [{ name = "r0", action = "DENY", segment_src = "any", segment_dst = "any" }]
+    }]
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol4b-seg"].rule_list.rules[0].spec.segment_policy.src_any != null && xcsh_service_policy.this["spol4b-seg"].rule_list.rules[0].spec.segment_policy.dst_any != null
+    error_message = "segment_policy src_any/dst_any markers must render"
+  }
+}
+
+run "segment_policy_omitted_by_default" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{ name = "spol4b-nseg", rule_handling = "rule_list", rules = [{ name = "r0", action = "DENY" }] }]
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol4b-nseg"].rule_list.rules[0].spec.segment_policy == null
+    error_message = "segment_policy must be omitted (null) when no marker selected"
+  }
+}
+
+# --- SPol-4b: request_constraints emits exceeds where set + none markers elsewhere ---
+run "request_constraints_render" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{
+      name          = "spol4b-rc"
+      rule_handling = "rule_list"
+      rules         = [{ name = "r0", action = "DENY", request_constraints_enabled = true, max_url_size = 2048 }]
+    }]
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol4b-rc"].rule_list.rules[0].spec.request_constraints.max_url_size_exceeds == 2048
+    error_message = "request_constraints set dimension must render max_*_exceeds"
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol4b-rc"].rule_list.rules[0].spec.request_constraints.max_cookie_count_none != null
+    error_message = "request_constraints unset dimension must render max_*_none marker"
+  }
+}
+
+run "request_constraints_omitted_by_default" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{ name = "spol4b-nrc", rule_handling = "rule_list", rules = [{ name = "r0", action = "DENY" }] }]
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol4b-nrc"].rule_list.rules[0].spec.request_constraints == null
+    error_message = "request_constraints must be omitted (null) when not enabled"
+  }
+}
+
+# --- SPol-4b validation rejections ---
+run "detection_control_rejects_deny" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{ name = "x", rule_handling = "rule_list", rules = [{ name = "r0", action = "DENY", waf_action_mode = "detection_control", waf_exclude_bot_names = ["curl"] }] }]
+  }
+  expect_failures = [var.service_policies]
+}
+
+run "detection_control_rejects_empty" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{ name = "x", rule_handling = "rule_list", rules = [{ name = "r0", action = "ALLOW", waf_action_mode = "detection_control" }] }]
+  }
+  expect_failures = [var.service_policies]
+}
+
+run "detection_control_rejects_exclusions_without_mode" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{ name = "x", rule_handling = "rule_list", rules = [{ name = "r0", action = "DENY", waf_exclude_bot_names = ["curl"] }] }]
+  }
+  expect_failures = [var.service_policies]
+}
+
+run "detection_control_rejects_bad_context" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{ name = "x", rule_handling = "rule_list", rules = [{ name = "r0", action = "ALLOW", waf_action_mode = "detection_control", waf_exclude_violation_contexts = [{ context = "CONTEXT_BOGUS", exclude_violation = "VIOL_NONE" }] }] }]
+  }
+  expect_failures = [var.service_policies]
+}
+
+run "detection_control_rejects_bad_attack_type" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{ name = "x", rule_handling = "rule_list", rules = [{ name = "r0", action = "ALLOW", waf_action_mode = "detection_control", waf_exclude_attack_type_contexts = [{ exclude_attack_type = "ATTACK_TYPE_BOGUS" }] }] }]
+  }
+  expect_failures = [var.service_policies]
+}
+
+run "detection_control_rejects_bad_signature_id" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{ name = "x", rule_handling = "rule_list", rules = [{ name = "r0", action = "ALLOW", waf_action_mode = "detection_control", waf_exclude_signature_contexts = [{ signature_id = 42 }] }] }]
+  }
+  expect_failures = [var.service_policies]
+}
+
+run "segment_policy_rejects_bad_src" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{ name = "x", rule_handling = "rule_list", rules = [{ name = "r0", action = "DENY", segment_src = "segments" }] }]
   }
   expect_failures = [var.service_policies]
 }


### PR DESCRIPTION
Closes #81.

## What
Extends `xcsh_service_policy` rule coverage (SPol effort) with three action-side/constraint areas, and root-cause-fixes the SPol-4a WAF/action coupling.

### Added
- **waf_action `detection_control`** (`app_firewall_detection_control`): 4 exclusion lists — attack-type / violation / signature contexts + bot names — with CONTEXT_*/ATTACK_TYPE_*/VIOL_* enum validations and signature_id range (0 or 200000001-299999999).
- **segment_policy** markers `src_any` / `dst_any` / `intra_segment` (Segment refs `*_segments` deferred, like SPol-2b).
- **request_constraints**: 13 dimensions, each a `max_*_exceeds` | `max_*_none` oneof; all 13 emitted when enabled to match the server-echoed none markers.

### Fixed (SPol-4a coupling)
Live probing proved the shipped precondition wrong. A *configured* WAF action (`waf_skip_processing` **or** `app_firewall_detection_control`) is rejected on a **DENY** rule — *"WAF Action cannot be configured for a rule with action DENY"*. The prior `waf=skip ⟹ bot=skip AND mum=skip` all-or-nothing rule was a **misdiagnosis** of that DENY rejection: under a valid ALLOW action, every bot/mum combination applies cleanly (bot/mum are independent). Replaced with the DENY coupling; regenerated `service_policy_action_pairs.py` to derive a valid non-DENY action for skip/detection_control (it previously generated API-rejected `skip`+`DENY` variants).

### Import-cleanliness
`context_name` is emitted null-when-empty because the provider reads the server's empty string back as `null` — an explicit `""` drifts on import. No provider change is required (segment markers + request-constraint none markers + declared members all round-trip).

## Verification
- `terraform test` — **37 plan-tests pass** (positive renders per arm + `expect_failures` for every validation/precondition, incl. skip/detection_control+DENY, empty detection_control, exclusions-without-mode, bad enums, bad signature_id).
- Live AETG action+constraints matrix on released provider **v3.72.5**: **11/11** apply → re-plan 0-change (idempotent) → state-rm+import+re-plan 0-change (import-clean), incl. canonical restore.
- Canonical repo config plans **0-change**; tenant left clean (only `ves-io-*` built-ins remain).
- Local gates: `terraform fmt`, `ruff`, `codespell`, `jscpd` (9.34% < 10%) clean.

Part of the SPol exhaustive-coverage effort (SPol-1/2/3/4a merged: #72 #74 #76 #78 #80).

🤖 Generated with [Claude Code](https://claude.com/claude-code)