### PR TITLE
SPol-2b: service_policy rule ref matcher arms — asn_matcher + ip_matcher

### DIFF
--- a/scripts/service_policy_ref_matcher_pairs.py
+++ b/scripts/service_policy_ref_matcher_pairs.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Generate the service_policy ref matcher (SPol-2b) coverage matrix.
+
+AETG all-pairs over the two ref matcher oneof arms (asn_matcher -> bgp_asn_set,
+ip_matcher -> ip_prefix_set) plus the ip invert flag. Every non-canonical variant defines
+both ref sets (so only the rule's arm selection changes between variants — no ref-set
+create/destroy churn), LB-detached (service_policies_choice=omit). Plus canonical restore
+(removes the policy and both ref sets).
+
+Dimensions:
+  asn     none | matcher   (asn_matcher referencing bgp_asn_set "m-asn")
+  ip      none | matcher   (ip_matcher referencing ip_prefix_set "m-ip")
+  invert  false | true     (ip_matcher.invert_matcher, only meaningful with ip=matcher)
+
+The all-"none" row is skipped (that is the SPol-2 baseline, no ref arm exercised).
+
+Deterministic (no RNG). Output: JSON to stdout, or files via --emit.
+"""
+
+import itertools
+import json
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+POLICY_NAME = "matrix-spol-b"
+ASN_SET = "m-asn"
+IP_SET = "m-ip"
+
+DIMENSIONS = {
+    "asn": ["none", "matcher"],
+    "ip": ["none", "matcher"],
+    "invert": ["false", "true"],
+}
+
+
+def _best_value(
+    values: list[str],
+    idx: int,
+    row: dict[int, str],
+    uncovered: set[tuple[int, str, int, str]],
+) -> str:
+    """Pick the value for dimension idx covering the most still-uncovered pairs."""
+    best_val, best_gain = values[0], -1
+    for val in values:
+        gain = 0
+        for pidx, pval in row.items():
+            a, b = sorted([(pidx, pval), (idx, val)])
+            if (a[0], a[1], b[0], b[1]) in uncovered:
+                gain += 1
+        if gain > best_gain:
+            best_gain, best_val = gain, val
+    return best_val
+
+
+def all_pairs(dims: dict[str, list[str]]) -> list[dict[str, str]]:
+    """Return AETG-style greedy all-pairs rows ({dim: value})."""
+    names = list(dims)
+    uncovered: set[tuple[int, str, int, str]] = set()
+    for i, j in itertools.combinations(range(len(names)), 2):
+        for vi in dims[names[i]]:
+            for vj in dims[names[j]]:
+                uncovered.add((i, vi, j, vj))
+
+    rows = []
+    while uncovered:
+        si, sv, sj, sv2 = min(uncovered)
+        row = {si: sv, sj: sv2}
+        for idx, name in enumerate(names):
+            if idx not in row:
+                row[idx] = _best_value(dims[name], idx, row, uncovered)
+        for i, j in itertools.combinations(sorted(row), 2):
+            uncovered.discard((i, row[i], j, row[j]))
+        rows.append({names[k]: v for k, v in row.items()})
+    return rows
+
+
+def rule(v: Mapping[str, object]) -> dict[str, object]:
+    """Build one rule from a ref-matcher row."""
+    r: dict[str, object] = {"name": "r0", "action": "DENY"}
+    if v["asn"] == "matcher":
+        r["asn"] = "matcher"
+        r["asn_sets"] = [ASN_SET]
+    if v["ip"] == "matcher":
+        r["ip"] = "matcher"
+        r["ip_prefix_sets"] = [IP_SET]
+        r["ip_invert"] = v["invert"] == "true"
+    return r
+
+
+def payloads(v: Mapping[str, object]) -> dict[str, object]:
+    """Expand a ref-matcher row into real tfvars (both ref sets defined, LB-detached)."""
+    return {
+        "service_policy_bgp_asn_sets": [{"name": ASN_SET, "as_numbers": [64512]}],
+        "service_policy_ip_prefix_sets": [
+            {"name": IP_SET, "ipv4_prefixes": ["10.0.0.0/8"]}
+        ],
+        "service_policies": [
+            {"name": POLICY_NAME, "rule_handling": "rule_list", "rules": [rule(v)]}
+        ],
+        "service_policies_choice": "omit",
+    }
+
+
+def canonical() -> dict[str, object]:
+    """Live-canonical end state (no policy, no ref sets; LB server default)."""
+    return {
+        "service_policy_bgp_asn_sets": [],
+        "service_policy_ip_prefix_sets": [],
+        "service_policies": [],
+        "service_policies_choice": "omit",
+    }
+
+
+def build() -> list[dict[str, object]]:
+    """Build the ordered variant manifest (all-pairs + canonical), deduped."""
+    variants: list[dict[str, object]] = []
+    seen: set[str] = set()
+    idx = 0
+    for row in all_pairs(DIMENSIONS):
+        # Skip the all-none row: no ref arm exercised (that is the SPol-2 baseline).
+        if row["asn"] == "none" and row["ip"] == "none":
+            continue
+        vars_ = payloads(row)
+        key = json.dumps(vars_, sort_keys=True)
+        if key in seen:
+            continue
+        seen.add(key)
+        variants.append({"name": f"pair-{idx:03d}", "vars": vars_})
+        idx += 1
+    variants.append({"name": "canonical-restore", "vars": canonical()})
+    return variants
+
+
+def emit(directory: str) -> int:
+    """Write one <NNN>-<name>.tfvars.json per variant plus manifest.txt."""
+    out_dir = Path(directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for existing in out_dir.iterdir():
+        if existing.name.endswith(".tfvars.json") or existing.name == "manifest.txt":
+            existing.unlink()
+    variants = build()
+    named = [(f"{i:03d}-{v['name']}.tfvars.json", v) for i, v in enumerate(variants)]
+    for fname, v in named:
+        (out_dir / fname).write_text(json.dumps(v["vars"], indent=2) + "\n")
+    lines = [f"{i:03d} {v['name']} {fname} LIVE" for i, (fname, v) in enumerate(named)]
+    (out_dir / "manifest.txt").write_text("\n".join(lines) + "\n")
+    return len(variants)
+
+
+def main(argv: list[str]) -> None:
+    """CLI: --count, --emit <dir>, else JSON to stdout."""
+    match argv[1:]:
+        case ["--count"]:
+            sys.stdout.write(f"{len(build())}\n")
+        case ["--emit", directory]:
+            sys.stdout.write(f"{emit(directory)}\n")
+        case _:
+            json.dump(build(), sys.stdout, indent=2)
+            sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -160,9 +160,11 @@ module "http_lb" {
 
   # Service policies (SPol effort) passthrough. Defaults create nothing and emit no LB
   # block (server default service_policies_from_namespace, import-suppressed => 0-change).
-  service_policies        = var.service_policies
-  service_policies_choice = var.service_policies_choice
-  service_policy_active   = var.service_policy_active
+  service_policies              = var.service_policies
+  service_policies_choice       = var.service_policies_choice
+  service_policy_active         = var.service_policy_active
+  service_policy_bgp_asn_sets   = var.service_policy_bgp_asn_sets
+  service_policy_ip_prefix_sets = var.service_policy_ip_prefix_sets
 
   # API Testing (SP4) passthrough. Defaults keep it off (disable_api_testing
   # suppressed => 0-change) and create no standalone resource.

--- a/terraform/modules/http-lb/service_policy.tf
+++ b/terraform/modules/http-lb/service_policy.tf
@@ -148,20 +148,50 @@ resource "xcsh_service_policy" "this" {
               }
             }
 
-            # --- SPol-2 ASN matcher oneof (omit => server-default any_asn, suppressed) ---
+            # --- ASN matcher oneof (omit => server-default any_asn, suppressed) ---
             dynamic "asn_list" {
               for_each = rules.value.asn == "list" ? [1] : []
               content {
                 as_numbers = rules.value.asn_numbers
               }
             }
+            # SPol-2b asn_matcher: reference bgp_asn_set objects (created in service_policy_refs.tf)
+            # by name. The resource ref creates the dependency so sets exist before the policy;
+            # server-filled kind/tenant/uid are provider-computed and round-trip import-clean.
+            dynamic "asn_matcher" {
+              for_each = rules.value.asn == "matcher" ? [1] : []
+              content {
+                dynamic "asn_sets" {
+                  for_each = rules.value.asn_sets
+                  content {
+                    name      = xcsh_bgp_asn_set.this[asn_sets.value].name
+                    namespace = var.namespace
+                  }
+                }
+              }
+            }
 
-            # --- SPol-2 IP matcher oneof (omit => server-default any_ip, suppressed) ---
+            # --- IP matcher oneof (omit => server-default any_ip, suppressed) ---
             dynamic "ip_prefix_list" {
               for_each = rules.value.ip == "prefix_list" ? [1] : []
               content {
                 ip_prefixes  = rules.value.ip_prefixes
                 invert_match = rules.value.ip_invert
+              }
+            }
+            # SPol-2b ip_matcher: reference ip_prefix_set objects by name (invert_matcher reuses
+            # the rule's ip_invert knob).
+            dynamic "ip_matcher" {
+              for_each = rules.value.ip == "matcher" ? [1] : []
+              content {
+                invert_matcher = rules.value.ip_invert
+                dynamic "prefix_sets" {
+                  for_each = rules.value.ip_prefix_sets
+                  content {
+                    name      = xcsh_ip_prefix_set.this[prefix_sets.value].name
+                    namespace = var.namespace
+                  }
+                }
               }
             }
 

--- a/terraform/modules/http-lb/service_policy_refs.tf
+++ b/terraform/modules/http-lb/service_policy_refs.tf
@@ -1,0 +1,26 @@
+# Ref objects for the SPol-2b service_policy ref matcher arms (asn_matcher -> bgp_asn_set,
+# ip_matcher -> ip_prefix_set). Created here so a rule can reference a set by name via
+# asn = "matcher" / ip = "matcher". Kept as first-class module resources (for_each by name)
+# so the service_policy's ref fields resolve to real objects and round-trip import-clean
+# (the server-filled kind/tenant/uid are provider-computed — live-verified, no drift).
+resource "xcsh_bgp_asn_set" "this" {
+  for_each = { for s in var.service_policy_bgp_asn_sets : s.name => s }
+
+  name       = each.value.name
+  namespace  = var.namespace
+  as_numbers = each.value.as_numbers
+}
+
+resource "xcsh_ip_prefix_set" "this" {
+  for_each = { for s in var.service_policy_ip_prefix_sets : s.name => s }
+
+  name      = each.value.name
+  namespace = var.namespace
+
+  dynamic "ipv4_prefixes" {
+    for_each = each.value.ipv4_prefixes
+    content {
+      ipv4_prefix = ipv4_prefixes.value
+    }
+  }
+}

--- a/terraform/modules/http-lb/variables_service_policy.tf
+++ b/terraform/modules/http-lb/variables_service_policy.tf
@@ -27,15 +27,19 @@ variable "service_policies" {
       client_name_exact    = optional(list(string), [])
       client_name_regex    = optional(list(string), [])
       ip_threat_categories = optional(list(string), [])
-      # SPol-2 ASN matcher oneof: any (default) | list (inline as_numbers). asn_matcher
-      # (bgp_asn_set ref) is SPol-2b.
-      asn         = optional(string, "any") # any|list
+      # ASN matcher oneof: any (default) | list (inline as_numbers) | matcher (asn_matcher
+      # referencing bgp_asn_set objects by name, SPol-2b). asn_sets names must be defined in
+      # var.service_policy_bgp_asn_sets.
+      asn         = optional(string, "any") # any|list|matcher
       asn_numbers = optional(list(number), [])
-      # SPol-2 IP matcher oneof: any (default) | prefix_list (inline). ip_matcher
-      # (ip_prefix_set ref) is SPol-2b.
-      ip          = optional(string, "any") # any|prefix_list
-      ip_prefixes = optional(list(string), [])
-      ip_invert   = optional(bool, false)
+      asn_sets    = optional(list(string), [])
+      # IP matcher oneof: any (default) | prefix_list (inline) | matcher (ip_matcher
+      # referencing ip_prefix_set objects by name, SPol-2b). ip_prefix_sets names must be
+      # defined in var.service_policy_ip_prefix_sets.
+      ip             = optional(string, "any") # any|prefix_list|matcher
+      ip_prefixes    = optional(list(string), [])
+      ip_prefix_sets = optional(list(string), [])
+      ip_invert      = optional(bool, false)
       # SPol-2 TLS-fingerprint matcher oneof: none (default, omit) | matcher (classes/exact/
       # excluded) | ja4 (exact JA4 hashes).
       tls          = optional(string, "none") # none|matcher|ja4
@@ -150,15 +154,35 @@ variable "service_policies" {
   }
   validation {
     condition = alltrue([for p in var.service_policies : alltrue([
-      for r in coalesce(p.rules, []) : contains(["any", "list"], r.asn)
+      for r in coalesce(p.rules, []) : contains(["any", "list", "matcher"], r.asn)
     ])])
-    error_message = "each rule.asn must be any or list."
+    error_message = "each rule.asn must be any, list, or matcher."
   }
   validation {
     condition = alltrue([for p in var.service_policies : alltrue([
-      for r in coalesce(p.rules, []) : contains(["any", "prefix_list"], r.ip)
+      for r in coalesce(p.rules, []) : contains(["any", "prefix_list", "matcher"], r.ip)
     ])])
-    error_message = "each rule.ip must be any or prefix_list."
+    error_message = "each rule.ip must be any, prefix_list, or matcher."
+  }
+  # SPol-2b ref-arm integrity: a matcher arm needs >= 1 referenced set, and every referenced
+  # name must be defined in the corresponding set variable (fail fast instead of a live 404).
+  validation {
+    condition = alltrue([for p in var.service_policies : alltrue([
+      for r in coalesce(p.rules, []) :
+      r.asn != "matcher" || (length(r.asn_sets) > 0 && alltrue([
+        for n in r.asn_sets : contains([for s in var.service_policy_bgp_asn_sets : s.name], n)
+      ]))
+    ])])
+    error_message = "rule.asn=\"matcher\" requires asn_sets to name >= 1 set defined in service_policy_bgp_asn_sets."
+  }
+  validation {
+    condition = alltrue([for p in var.service_policies : alltrue([
+      for r in coalesce(p.rules, []) :
+      r.ip != "matcher" || (length(r.ip_prefix_sets) > 0 && alltrue([
+        for n in r.ip_prefix_sets : contains([for s in var.service_policy_ip_prefix_sets : s.name], n)
+      ]))
+    ])])
+    error_message = "rule.ip=\"matcher\" requires ip_prefix_sets to name >= 1 set defined in service_policy_ip_prefix_sets."
   }
   validation {
     condition = alltrue([for p in var.service_policies : alltrue([
@@ -336,6 +360,24 @@ variable "service_policies" {
     ])])
     error_message = "each rule.segment_src / segment_dst must be omit or any (segments refs are deferred)."
   }
+}
+
+variable "service_policy_bgp_asn_sets" {
+  description = "bgp_asn_set objects to create for SPol-2b asn_matcher ref arms. Referenced by name from a rule's asn_sets when asn=\"matcher\"."
+  type = list(object({
+    name       = string
+    as_numbers = list(number)
+  }))
+  default = []
+}
+
+variable "service_policy_ip_prefix_sets" {
+  description = "ip_prefix_set objects to create for SPol-2b ip_matcher ref arms. Referenced by name from a rule's ip_prefix_sets when ip=\"matcher\"."
+  type = list(object({
+    name          = string
+    ipv4_prefixes = list(string)
+  }))
+  default = []
 }
 
 variable "service_policies_choice" {

--- a/terraform/tests/service_policy.tftest.hcl
+++ b/terraform/tests/service_policy.tftest.hcl
@@ -225,6 +225,64 @@ run "matcher_rejects_bad_ip_threat_category" {
   expect_failures = [var.service_policies]
 }
 
+# --- SPol-2b: ref matcher arms (asn_matcher -> bgp_asn_set, ip_matcher -> ip_prefix_set) ---
+run "ref_matchers_render" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policy_bgp_asn_sets   = [{ name = "m-asn", as_numbers = [64512] }]
+    service_policy_ip_prefix_sets = [{ name = "m-ip", ipv4_prefixes = ["10.0.0.0/8"] }]
+    service_policies = [{
+      name  = "spol2b", rule_handling = "rule_list"
+      rules = [{ name = "r0", action = "DENY", asn = "matcher", asn_sets = ["m-asn"], ip = "matcher", ip_prefix_sets = ["m-ip"], ip_invert = true }]
+    }]
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol2b"].rule_list.rules[0].spec.asn_matcher.asn_sets[0].name == "m-asn"
+    error_message = "asn_matcher must reference the bgp_asn_set by name"
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol2b"].rule_list.rules[0].spec.ip_matcher.prefix_sets[0].name == "m-ip"
+    error_message = "ip_matcher must reference the ip_prefix_set by name"
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol2b"].rule_list.rules[0].spec.ip_matcher.invert_matcher == true
+    error_message = "ip_matcher invert_matcher must render from ip_invert"
+  }
+  assert {
+    condition     = xcsh_bgp_asn_set.this["m-asn"].as_numbers[0] == 64512
+    error_message = "bgp_asn_set ref object must be created"
+  }
+}
+
+run "ref_asn_matcher_rejects_empty_sets" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{ name = "x", rule_handling = "rule_list", rules = [{ name = "r0", asn = "matcher" }] }]
+  }
+  expect_failures = [var.service_policies]
+}
+
+run "ref_asn_matcher_rejects_undefined_set" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policy_bgp_asn_sets = [{ name = "known", as_numbers = [64512] }]
+    service_policies            = [{ name = "x", rule_handling = "rule_list", rules = [{ name = "r0", asn = "matcher", asn_sets = ["ghost"] }] }]
+  }
+  expect_failures = [var.service_policies]
+}
+
+run "ref_ip_matcher_rejects_undefined_set" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{ name = "x", rule_handling = "rule_list", rules = [{ name = "r0", ip = "matcher", ip_prefix_sets = ["ghost"] }] }]
+  }
+  expect_failures = [var.service_policies]
+}
+
 run "matcher_rejects_bad_tls_class" {
   command = plan
   module { source = "./modules/http-lb" }

--- a/terraform/variables_service_policy.tf
+++ b/terraform/variables_service_policy.tf
@@ -20,3 +20,15 @@ variable "service_policy_active" {
   type        = list(string)
   default     = []
 }
+
+variable "service_policy_bgp_asn_sets" {
+  description = "bgp_asn_set objects for SPol-2b asn_matcher ref arms (see module for shape)."
+  type        = any
+  default     = []
+}
+
+variable "service_policy_ip_prefix_sets" {
+  description = "ip_prefix_set objects for SPol-2b ip_matcher ref arms (see module for shape)."
+  type        = any
+  default     = []
+}


### PR DESCRIPTION
Closes #83.

## What
Completes the `xcsh_service_policy` rule source-matcher oneofs with the reference arms deferred from SPol-2.

- **Ref objects**: `xcsh_bgp_asn_set` / `xcsh_ip_prefix_set` created in `service_policy_refs.tf` (`for_each` by name) from new `service_policy_bgp_asn_sets` / `service_policy_ip_prefix_sets` vars (+ root passthrough).
- **Rule arms**: `asn = "matcher"` (`asn_matcher` referencing named asn sets via `asn_sets`) and `ip = "matcher"` (`ip_matcher` referencing named prefix sets via `ip_prefix_sets`; `invert_matcher` reuses the `ip_invert` knob). The rule references the resources by attribute so terraform orders set creation before the policy.
- **Ref-integrity validations**: a matcher arm needs ≥1 referenced set and every name must be defined in the corresponding set variable (fail fast at plan, not a live 404).

## No provider change
Live probing confirmed the service_policy import round-trip is clean — the server-filled `kind`/`tenant`/`uid` on each set ref are provider-computed and do not drift.

## Verification
- `terraform test` — **41 plan-tests pass** (ref render for asn+ip matchers incl. invert flow; `expect_failures` for empty matcher and undefined-set-name on both arms).
- Live AETG ref matrix on released provider **v3.72.5**: **4/4** apply → re-plan 0-change → state-rm+import+re-plan 0-change, incl. canonical restore (removes policy + both ref sets).
- Canonical repo config plans **0-change**; tenant left clean (asn/prefix sets + policies all gone).
- Local gates: `terraform fmt`, `ruff`, `codespell`, `jscpd` (9.20% < 10%) clean.

Part of the SPol exhaustive-coverage effort (SPol-1/2/3/4a/4b merged: #72 #74 #76 #78 #80 #82).

🤖 Generated with [Claude Code](https://claude.com/claude-code)