### PR TITLE
SPol-3b: service_policy remaining rule matchers (arg/cookie/jwt/body/user_identity/label/port/api_group)

### DIFF
--- a/scripts/service_policy_matcher2_pairs.py
+++ b/scripts/service_policy_matcher2_pairs.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Generate the service_policy remaining-matcher (SPol-3b) coverage matrix.
+
+AETG all-pairs over the SPol-3b rule matchers, each variant a rule_list policy with one
+rule combining the selected matchers (all additive AND), LB-detached
+(service_policies_choice=omit). Plus canonical restore.
+
+Dimensions:
+  arg     none | item | present   (arg_matchers: item exact+transformers, or present marker)
+  cookie  none | absent           (cookie_matchers check_not_present)
+  jwt     none | item             (jwt_claims item exact)
+  body    none | regex            (body_matcher regex)
+  ident   none | exact            (user_identity_matcher exact)
+  label   none | keys             (label_matcher keys)
+  port    none | ports            (port_matcher ports + invert)
+  apigrp  none | match            (api_group_matcher match)
+
+All matchers are independent (live-verified — no cross-field constraint), so every
+combination is valid; only the all-"none" row is skipped (that is the SPol-3 baseline).
+
+Deterministic (no RNG). Output: JSON to stdout, or files via --emit.
+"""
+
+import itertools
+import json
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+POLICY_NAME = "matrix-spol-c"
+
+DIMENSIONS = {
+    "arg": ["none", "item", "present"],
+    "cookie": ["none", "absent"],
+    "jwt": ["none", "item"],
+    "body": ["none", "regex"],
+    "ident": ["none", "exact"],
+    "label": ["none", "keys"],
+    "port": ["none", "ports"],
+    "apigrp": ["none", "match"],
+}
+
+
+def _best_value(
+    values: list[str],
+    idx: int,
+    row: dict[int, str],
+    uncovered: set[tuple[int, str, int, str]],
+) -> str:
+    """Pick the value for dimension idx covering the most still-uncovered pairs."""
+    best_val, best_gain = values[0], -1
+    for val in values:
+        gain = 0
+        for pidx, pval in row.items():
+            a, b = sorted([(pidx, pval), (idx, val)])
+            if (a[0], a[1], b[0], b[1]) in uncovered:
+                gain += 1
+        if gain > best_gain:
+            best_gain, best_val = gain, val
+    return best_val
+
+
+def all_pairs(dims: dict[str, list[str]]) -> list[dict[str, str]]:
+    """Return AETG-style greedy all-pairs rows ({dim: value})."""
+    names = list(dims)
+    uncovered: set[tuple[int, str, int, str]] = set()
+    for i, j in itertools.combinations(range(len(names)), 2):
+        for vi in dims[names[i]]:
+            for vj in dims[names[j]]:
+                uncovered.add((i, vi, j, vj))
+
+    rows = []
+    while uncovered:
+        si, sv, sj, sv2 = min(uncovered)
+        row = {si: sv, sj: sv2}
+        for idx, name in enumerate(names):
+            if idx not in row:
+                row[idx] = _best_value(dims[name], idx, row, uncovered)
+        for i, j in itertools.combinations(sorted(row), 2):
+            uncovered.discard((i, row[i], j, row[j]))
+        rows.append({names[k]: v for k, v in row.items()})
+    return rows
+
+
+def rule(v: Mapping[str, object]) -> dict[str, object]:
+    """Build one rule from a matcher row."""
+    r: dict[str, object] = {"name": "r0", "action": "DENY"}
+    if v["arg"] == "item":
+        r["arg_matchers"] = [
+            {
+                "name": "q",
+                "presence": "match",
+                "exact_values": ["1"],
+                "transformers": ["LOWER_CASE"],
+            }
+        ]
+    elif v["arg"] == "present":
+        r["arg_matchers"] = [{"name": "q", "presence": "present"}]
+    if v["cookie"] == "absent":
+        r["cookie_matchers"] = [{"name": "sid", "presence": "absent"}]
+    if v["jwt"] == "item":
+        r["jwt_claims"] = [
+            {"name": "sub", "presence": "match", "exact_values": ["admin"]}
+        ]
+    if v["body"] == "regex":
+        r["body_regex"] = [".*evil.*"]
+    if v["ident"] == "exact":
+        r["user_identity_exact"] = ["u1"]
+    if v["label"] == "keys":
+        r["label_keys"] = ["env"]
+    if v["port"] == "ports":
+        r["port_ports"] = ["443"]
+        r["port_invert"] = True
+    if v["apigrp"] == "match":
+        r["api_groups"] = ["grp1"]
+    return r
+
+
+def payloads(v: Mapping[str, object]) -> dict[str, object]:
+    """Expand a matcher row into real tfvars (rule_list policy, LB-detached)."""
+    return {
+        "service_policies": [
+            {"name": POLICY_NAME, "rule_handling": "rule_list", "rules": [rule(v)]}
+        ],
+        "service_policies_choice": "omit",
+    }
+
+
+def canonical() -> dict[str, object]:
+    """Live-canonical end state (no service policy; LB server default)."""
+    return {"service_policies": [], "service_policies_choice": "omit"}
+
+
+def build() -> list[dict[str, object]]:
+    """Build the ordered variant manifest (all-pairs + canonical), deduped."""
+    variants: list[dict[str, object]] = []
+    seen: set[str] = set()
+    idx = 0
+    for row in all_pairs(DIMENSIONS):
+        if all(val == "none" for val in row.values()):
+            continue
+        vars_ = payloads(row)
+        key = json.dumps(vars_, sort_keys=True)
+        if key in seen:
+            continue
+        seen.add(key)
+        variants.append({"name": f"pair-{idx:03d}", "vars": vars_})
+        idx += 1
+    variants.append({"name": "canonical-restore", "vars": canonical()})
+    return variants
+
+
+def emit(directory: str) -> int:
+    """Write one <NNN>-<name>.tfvars.json per variant plus manifest.txt."""
+    out_dir = Path(directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for existing in out_dir.iterdir():
+        if existing.name.endswith(".tfvars.json") or existing.name == "manifest.txt":
+            existing.unlink()
+    variants = build()
+    named = [(f"{i:03d}-{v['name']}.tfvars.json", v) for i, v in enumerate(variants)]
+    for fname, v in named:
+        (out_dir / fname).write_text(json.dumps(v["vars"], indent=2) + "\n")
+    lines = [f"{i:03d} {v['name']} {fname} LIVE" for i, (fname, v) in enumerate(named)]
+    (out_dir / "manifest.txt").write_text("\n".join(lines) + "\n")
+    return len(variants)
+
+
+def main(argv: list[str]) -> None:
+    """CLI: --count, --emit <dir>, else JSON to stdout."""
+    match argv[1:]:
+        case ["--count"]:
+            sys.stdout.write(f"{len(build())}\n")
+        case ["--emit", directory]:
+            sys.stdout.write(f"{emit(directory)}\n")
+        case _:
+            json.dump(build(), sys.stdout, indent=2)
+            sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/terraform/modules/http-lb/service_policy.tf
+++ b/terraform/modules/http-lb/service_policy.tf
@@ -281,6 +281,116 @@ resource "xcsh_service_policy" "this" {
               }
             }
 
+            # --- SPol-3b list matchers: arg_matchers / cookie_matchers / jwt_claims (same
+            # present/absent/item shape as headers, keyed by name, item adds transformers).
+            # invert_matcher always emitted; item lists null-when-empty. ---
+            dynamic "arg_matchers" {
+              for_each = rules.value.arg_matchers
+              content {
+                name           = arg_matchers.value.name
+                invert_matcher = arg_matchers.value.invert
+                dynamic "check_present" {
+                  for_each = arg_matchers.value.presence == "present" ? [1] : []
+                  content {}
+                }
+                dynamic "check_not_present" {
+                  for_each = arg_matchers.value.presence == "absent" ? [1] : []
+                  content {}
+                }
+                dynamic "item" {
+                  for_each = arg_matchers.value.presence == "match" ? [1] : []
+                  content {
+                    exact_values = length(arg_matchers.value.exact_values) > 0 ? arg_matchers.value.exact_values : null
+                    regex_values = length(arg_matchers.value.regex_values) > 0 ? arg_matchers.value.regex_values : null
+                    transformers = length(arg_matchers.value.transformers) > 0 ? arg_matchers.value.transformers : null
+                  }
+                }
+              }
+            }
+            dynamic "cookie_matchers" {
+              for_each = rules.value.cookie_matchers
+              content {
+                name           = cookie_matchers.value.name
+                invert_matcher = cookie_matchers.value.invert
+                dynamic "check_present" {
+                  for_each = cookie_matchers.value.presence == "present" ? [1] : []
+                  content {}
+                }
+                dynamic "check_not_present" {
+                  for_each = cookie_matchers.value.presence == "absent" ? [1] : []
+                  content {}
+                }
+                dynamic "item" {
+                  for_each = cookie_matchers.value.presence == "match" ? [1] : []
+                  content {
+                    exact_values = length(cookie_matchers.value.exact_values) > 0 ? cookie_matchers.value.exact_values : null
+                    regex_values = length(cookie_matchers.value.regex_values) > 0 ? cookie_matchers.value.regex_values : null
+                    transformers = length(cookie_matchers.value.transformers) > 0 ? cookie_matchers.value.transformers : null
+                  }
+                }
+              }
+            }
+            dynamic "jwt_claims" {
+              for_each = rules.value.jwt_claims
+              content {
+                name           = jwt_claims.value.name
+                invert_matcher = jwt_claims.value.invert
+                dynamic "check_present" {
+                  for_each = jwt_claims.value.presence == "present" ? [1] : []
+                  content {}
+                }
+                dynamic "check_not_present" {
+                  for_each = jwt_claims.value.presence == "absent" ? [1] : []
+                  content {}
+                }
+                dynamic "item" {
+                  for_each = jwt_claims.value.presence == "match" ? [1] : []
+                  content {
+                    exact_values = length(jwt_claims.value.exact_values) > 0 ? jwt_claims.value.exact_values : null
+                    regex_values = length(jwt_claims.value.regex_values) > 0 ? jwt_claims.value.regex_values : null
+                    transformers = length(jwt_claims.value.transformers) > 0 ? jwt_claims.value.transformers : null
+                  }
+                }
+              }
+            }
+
+            # --- SPol-3b single-value matchers (block omitted when its lists are empty) ---
+            dynamic "body_matcher" {
+              for_each = (length(rules.value.body_exact) + length(rules.value.body_regex) + length(rules.value.body_transformers)) > 0 ? [1] : []
+              content {
+                exact_values = length(rules.value.body_exact) > 0 ? rules.value.body_exact : null
+                regex_values = length(rules.value.body_regex) > 0 ? rules.value.body_regex : null
+                transformers = length(rules.value.body_transformers) > 0 ? rules.value.body_transformers : null
+              }
+            }
+            dynamic "user_identity_matcher" {
+              for_each = (length(rules.value.user_identity_exact) + length(rules.value.user_identity_regex)) > 0 ? [1] : []
+              content {
+                exact_values = length(rules.value.user_identity_exact) > 0 ? rules.value.user_identity_exact : null
+                regex_values = length(rules.value.user_identity_regex) > 0 ? rules.value.user_identity_regex : null
+              }
+            }
+            dynamic "label_matcher" {
+              for_each = length(rules.value.label_keys) > 0 ? [1] : []
+              content {
+                keys = rules.value.label_keys
+              }
+            }
+            dynamic "port_matcher" {
+              for_each = length(rules.value.port_ports) > 0 ? [1] : []
+              content {
+                invert_matcher = rules.value.port_invert
+                ports          = rules.value.port_ports
+              }
+            }
+            dynamic "api_group_matcher" {
+              for_each = length(rules.value.api_groups) > 0 ? [1] : []
+              content {
+                invert_matcher = rules.value.api_group_invert
+                match          = rules.value.api_groups
+              }
+            }
+
             # --- SPol-4b segment_policy (source/destination markers; segments refs deferred).
             # Emitted only when a marker is selected; read-back is exact (no provider change). ---
             dynamic "segment_policy" {

--- a/terraform/modules/http-lb/variables_service_policy.tf
+++ b/terraform/modules/http-lb/variables_service_policy.tf
@@ -71,6 +71,46 @@ variable "service_policies" {
         exact_values = optional(list(string), [])
         regex_values = optional(list(string), [])
       })), [])
+      # SPol-3b list matchers arg_matchers / cookie_matchers / jwt_claims: same present/absent/
+      # item(exact/regex/transformers) shape as headers/query_params, keyed by name. invert is
+      # always emitted (server echoes false). transformers is a WAF transform enum.
+      arg_matchers = optional(list(object({
+        name         = string
+        presence     = optional(string, "match") # match|present|absent
+        invert       = optional(bool, false)
+        exact_values = optional(list(string), [])
+        regex_values = optional(list(string), [])
+        transformers = optional(list(string), [])
+      })), [])
+      cookie_matchers = optional(list(object({
+        name         = string
+        presence     = optional(string, "match") # match|present|absent
+        invert       = optional(bool, false)
+        exact_values = optional(list(string), [])
+        regex_values = optional(list(string), [])
+        transformers = optional(list(string), [])
+      })), [])
+      jwt_claims = optional(list(object({
+        name         = string
+        presence     = optional(string, "match") # match|present|absent
+        invert       = optional(bool, false)
+        exact_values = optional(list(string), [])
+        regex_values = optional(list(string), [])
+        transformers = optional(list(string), [])
+      })), [])
+      # SPol-3b single-value matchers (emitted null-when-empty; block omitted when unset).
+      body_exact          = optional(list(string), [])
+      body_regex          = optional(list(string), [])
+      body_transformers   = optional(list(string), [])
+      user_identity_exact = optional(list(string), [])
+      user_identity_regex = optional(list(string), [])
+      label_keys          = optional(list(string), []) # label_matcher.keys
+      # SPol-3b port_matcher (invert always emitted) and api_group_matcher (match = api group
+      # names, free-form). Blocks omitted when their list is empty.
+      port_ports       = optional(list(string), [])
+      port_invert      = optional(bool, false)
+      api_groups       = optional(list(string), [])
+      api_group_invert = optional(bool, false)
       # Action-side waf_action oneof (required on every rule): none default | skip =
       # waf_skip_processing | detection_control = app_firewall_detection_control. skip and
       # detection_control require action != DENY (F5 XC: "WAF Action cannot be configured for
@@ -241,6 +281,32 @@ variable "service_policies" {
       ))
     ])])
     error_message = "each rule.headers[]/query_params[] presence must be match, present, or absent."
+  }
+
+  # SPol-3b list-matcher presence selector (arg_matchers/cookie_matchers/jwt_claims).
+  validation {
+    condition = alltrue([for p in var.service_policies : alltrue([
+      for r in coalesce(p.rules, []) : alltrue([
+        for m in concat(r.arg_matchers, r.cookie_matchers, r.jwt_claims) : contains(["match", "present", "absent"], m.presence)
+      ])
+    ])])
+    error_message = "each rule.arg_matchers[]/cookie_matchers[]/jwt_claims[] presence must be match, present, or absent."
+  }
+
+  # SPol-3b transformers enum (ves.io.schema.policy Transformer) on the item/body matchers.
+  validation {
+    condition = alltrue([for p in var.service_policies : alltrue([
+      for r in coalesce(p.rules, []) : alltrue([
+        for t in concat(
+          flatten([for m in concat(r.arg_matchers, r.cookie_matchers, r.jwt_claims) : m.transformers]),
+          r.body_transformers
+          ) : contains([
+            "LOWER_CASE", "UPPER_CASE", "BASE64_DECODE", "NORMALIZE_PATH", "REMOVE_WHITESPACE",
+            "URL_DECODE", "TRIM_LEFT", "TRIM_RIGHT", "TRIM"
+        ], t)
+      ])
+    ])])
+    error_message = "each transformers entry must be a valid WAF transformer (LOWER_CASE, URL_DECODE, TRIM, ...)."
   }
 
   # Action-side selectors.

--- a/terraform/tests/service_policy.tftest.hcl
+++ b/terraform/tests/service_policy.tftest.hcl
@@ -283,6 +283,108 @@ run "ref_ip_matcher_rejects_undefined_set" {
   expect_failures = [var.service_policies]
 }
 
+# ============================================================================
+# SPol-3b: remaining rule matchers
+# ============================================================================
+
+run "spol3b_list_matchers_render" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{
+      name          = "spol3b-l"
+      rule_handling = "rule_list"
+      rules = [{
+        name            = "r0", action = "DENY"
+        arg_matchers    = [{ name = "q", presence = "match", exact_values = ["1"], transformers = ["LOWER_CASE"] }]
+        cookie_matchers = [{ name = "sid", presence = "present" }]
+        jwt_claims      = [{ name = "sub", presence = "match", exact_values = ["admin"] }]
+      }]
+    }]
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol3b-l"].rule_list.rules[0].spec.arg_matchers[0].item.transformers[0] == "LOWER_CASE"
+    error_message = "arg_matchers item transformers must render"
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol3b-l"].rule_list.rules[0].spec.cookie_matchers[0].check_present != null
+    error_message = "cookie_matchers present marker must render"
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol3b-l"].rule_list.rules[0].spec.jwt_claims[0].item.exact_values[0] == "admin"
+    error_message = "jwt_claims item must render"
+  }
+}
+
+run "spol3b_single_matchers_render" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{
+      name          = "spol3b-s"
+      rule_handling = "rule_list"
+      rules = [{
+        name                = "r0", action = "DENY"
+        body_regex          = [".*evil.*"]
+        user_identity_exact = ["u1"]
+        label_keys          = ["env"]
+        port_ports          = ["443"]
+        api_groups          = ["grp1"]
+      }]
+    }]
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol3b-s"].rule_list.rules[0].spec.body_matcher.regex_values[0] == ".*evil.*"
+    error_message = "body_matcher must render"
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol3b-s"].rule_list.rules[0].spec.user_identity_matcher.exact_values[0] == "u1"
+    error_message = "user_identity_matcher must render"
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol3b-s"].rule_list.rules[0].spec.label_matcher.keys[0] == "env"
+    error_message = "label_matcher must render"
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol3b-s"].rule_list.rules[0].spec.port_matcher.ports[0] == "443"
+    error_message = "port_matcher must render"
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol3b-s"].rule_list.rules[0].spec.api_group_matcher.match[0] == "grp1"
+    error_message = "api_group_matcher must render"
+  }
+}
+
+run "spol3b_matchers_omitted_by_default" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{ name = "spol3b-n", rule_handling = "rule_list", rules = [{ name = "r0", action = "DENY" }] }]
+  }
+  assert {
+    condition     = xcsh_service_policy.this["spol3b-n"].rule_list.rules[0].spec.port_matcher == null && xcsh_service_policy.this["spol3b-n"].rule_list.rules[0].spec.body_matcher == null
+    error_message = "SPol-3b matchers must be omitted (null) when unset"
+  }
+}
+
+run "spol3b_rejects_bad_transformer" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{ name = "x", rule_handling = "rule_list", rules = [{ name = "r0", arg_matchers = [{ name = "q", exact_values = ["1"], transformers = ["ROT13"] }] }] }]
+  }
+  expect_failures = [var.service_policies]
+}
+
+run "spol3b_rejects_bad_presence" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    service_policies = [{ name = "x", rule_handling = "rule_list", rules = [{ name = "r0", cookie_matchers = [{ name = "sid", presence = "maybe" }] }] }]
+  }
+  expect_failures = [var.service_policies]
+}
+
 run "matcher_rejects_bad_tls_class" {
   command = plan
   module { source = "./modules/http-lb" }


### PR DESCRIPTION
Closes #85.

## What
Completes `xcsh_service_policy` rule matcher coverage with the eight matchers deferred from SPol-3.

- **List matchers** `arg_matchers` / `cookie_matchers` / `jwt_claims`: present/absent/item(exact/regex/transformers) shape (mirrors headers/query_params), keyed by name; `invert_matcher` always emitted; item value lists null-when-empty.
- **Single matchers** `body_matcher`, `user_identity_matcher`, `label_matcher` (keys), `port_matcher` (ports + invert), `api_group_matcher` (free-form `match` + invert).
- **Validations**: presence enum for the list matchers; `transformers` WAF-transform enum.

## No provider change
Live-verified: all eight matchers are independent (additive AND); `port_matcher` (flagged non-empty server-default) omit→null and round-trips clean when set; `invert_matcher` echoed false → always emitted; item `[]` → null-when-empty (SPol-3 pattern). `api_group_matcher.match` is free-form (no ref dependency).

## Verification
- `terraform test` — **46 plan-tests pass** (list + single renders, null-when-unset, `expect_failures` for bad transformer + bad presence).
- Live AETG matcher matrix on released provider **v3.72.5**: **10/10** apply → re-plan 0-change → state-rm+import+re-plan 0-change, incl. canonical restore.
- Canonical repo config plans **0-change**; tenant left clean.
- Local gates: `terraform fmt`, `ruff`, `codespell`, `jscpd` (9.21% < 10%) clean.

Part of the SPol exhaustive-coverage effort (SPol-1/2/2b/3/4a/4b merged: #72 #74 #76 #78 #80 #82 #84).

🤖 Generated with [Claude Code](https://claude.com/claude-code)