### PR TITLE
fix(http-lb): drop stale endpoint_subsets {} workaround (breaks whole-LB import)

### DIFF
--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -426,12 +426,11 @@ resource "xcsh_http_loadbalancer" "this" {
     }
     weight   = 1
     priority = 1
-    # F5 XC always normalizes an empty endpoint_subsets object into the API
-    # response for each default_route_pools entry (verified via live API), so we
-    # declare it to keep apply/plan/import consistent. This is correct config,
-    # not a workaround. (Provider-side handling of server-default empty oneof
-    # members on import is tracked in terraform-provider-xcsh#1003.)
-    endpoint_subsets {}
+    # endpoint_subsets is a server-default empty marker the API always echoes; the
+    # provider suppresses it on import (#1103) and only preserves it on read when it
+    # was in prior state, so the module OMITS it — declaring it {} instead forces a
+    # spurious "+ endpoint_subsets {}" on every import round-trip (and cascades into
+    # computed tenant re-planning on the pool/WAF refs).
   }
 
   advertise_on_public_default_vip {}


### PR DESCRIPTION
Closes #93.

The `endpoint_subsets {}` declaration in `default_route_pools` was a pre-#1103 workaround. The provider #1103 fix now suppresses that server-default empty marker on import, so declaring it forces `+ endpoint_subsets {}` on every whole-LB import round-trip — cascading into `tenant -> (known after apply)` on the pool/WAF/MUD refs. Removing it lets the provider suppression own the marker.

**Verified live:** apply -> idempotent 0-change; state-rm -> import LB -> plan **0-change** (whole-LB import round-trip clean, both symptoms gone). Clean-break, pre-release.

Unblocks the whole-LB import gate for CAC (#68) and all future LB-nested coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)