### PR TITLE
CAC: client access control coverage (trusted_clients / blocked_clients / enable_ip_reputation)

### DIFF
--- a/scripts/client-access-matrix.sh
+++ b/scripts/client-access-matrix.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Client access control (CAC) live coverage-matrix harness.
+#
+# Cycles the LIVE webapp-api-protection LB through the client_access_pairs variant set and
+# verifies each variant (a) applies, (b) is idempotent (immediate plan = No changes), and
+# (c) is round-trip-import clean for the LB (state rm -> import -> plan clean). CAC is an
+# LB-nested feature, so the import target is the http_loadbalancer itself. Ends on
+# canonical-restore so the live LB is left healthy (all CAC features off). Results append to
+# reports/client-access-matrix.txt.
+#
+# The variants use RFC 5737 TEST-NET prefixes / a private ASN, so no real client traffic is
+# ever blocked and the LB stays serving throughout. An arm F5 XC rejects for entitlement is
+# recorded SKIP (word signals; a bare status number is not matched) rather than FAIL.
+# Sequential — no concurrent terraform against the shared azurerm state.
+#
+# Usage: client-access-matrix.sh [START [END]]  (inclusive 0-based index range).
+set -uo pipefail
+
+umask 077
+trap 'rm -rf /tmp/cac-variants 2>/dev/null; rm -f /tmp/cac-*.log 2>/dev/null' EXIT
+
+cd "$(dirname "$0")/../terraform" || exit 1
+ARM_ACCESS_KEY=$(az storage account keys list -n f5salesdemotfstate -g f5-sales-demo-tfstate --query "[0].value" -o tsv)
+export ARM_ACCESS_KEY
+
+NS="webapp-api-protection"
+LB_ADDR="module.http_lb.xcsh_http_loadbalancer.this"
+LB_ID="${NS}/${NS}"
+COMMON=(-input=false -lock=true
+  -var 'lb_domains=["www.f5-sales-demo.com","api.f5-sales-demo.com"]'
+  -var 'subscription_id=75f86c46-9cbc-4f6c-85ea-195e3d3c8ac0')
+VARDIR=/tmp/cac-variants
+REPORT=../reports/client-access-matrix.txt
+mkdir -p ../reports
+
+START="${1:-0}"
+END="${2:-9999}"
+GATED_RE='entitlement|not subscribed|not entitled|not enabled for|permission denied|unauthorized|AS_NOT_SUBSCRIBED|status: 401|status: 403'
+
+[ "$#" -eq 0 ] && : >"$REPORT"
+
+count=$(python3 ../scripts/client_access_pairs.py --emit "$VARDIR")
+echo "generated $count variants into $VARDIR (running [$START..$END])"
+
+round_trip() {
+  local label="$1" vf="$2"
+  terraform state rm "$LB_ADDR" >/dev/null 2>&1 || {
+    echo "FAIL $label lb-state-rm" >>"$REPORT"
+    return
+  }
+  terraform import "${COMMON[@]}" -var-file="$vf" "$LB_ADDR" "$LB_ID" >/tmp/cac-import.log 2>&1 || {
+    echo "FAIL $label lb-import ($(grep -iE 'error' /tmp/cac-import.log | head -1 | cut -c1-70))" >>"$REPORT"
+    return
+  }
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$vf" >/tmp/cac-rt-plan.log 2>&1
+  case $? in
+  0) echo "PASS $label" >>"$REPORT" ;;
+  2) echo "FAIL $label import-drift" >>"$REPORT" ;;
+  *) echo "FAIL $label rt-plan-error" >>"$REPORT" ;;
+  esac
+}
+
+while read -r idx name vf _flag; do
+  [ "$idx" -lt "$START" ] && continue
+  [ "$idx" -gt "$END" ] && continue
+  label="$idx-$name"
+  echo "--- $label ---"
+  varfile="${VARDIR}/${vf}"
+  if ! terraform apply -auto-approve "${COMMON[@]}" -var-file="$varfile" >/tmp/cac-apply.log 2>&1; then
+    if grep -qiE "$GATED_RE" /tmp/cac-apply.log; then
+      echo "SKIP $label gated-arm ($(grep -oiE "$GATED_RE" /tmp/cac-apply.log | head -1))" >>"$REPORT"
+    else
+      echo "FAIL $label apply ($(grep -iE 'error' /tmp/cac-apply.log | head -1 | cut -c1-80))" >>"$REPORT"
+    fi
+    continue
+  fi
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$varfile" >/tmp/cac-plan.log 2>&1
+  case $? in
+  0) round_trip "$label" "$varfile" ;;
+  2) echo "FAIL $label not-idempotent" >>"$REPORT" ;;
+  *) echo "FAIL $label plan-error" >>"$REPORT" ;;
+  esac
+done <"${VARDIR}/manifest.txt"
+
+echo "===== CLIENT ACCESS MATRIX RESULTS ($START..$END) ====="
+cat "$REPORT"
+echo "PASS=$(grep -c '^PASS ' "$REPORT") FAIL=$(grep -c '^FAIL ' "$REPORT") SKIP=$(grep -c '^SKIP ' "$REPORT")"

--- a/scripts/client_access_pairs.py
+++ b/scripts/client_access_pairs.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Generate the client access control (CAC) coverage matrix.
+
+AETG all-pairs over the LB client-access features, each variant applied to the LIVE LB.
+Uses RFC 5737 TEST-NET prefixes (192.0.2.0/24, 198.51.100.0/24) and a private ASN so no
+real client traffic is ever blocked — the LB stays healthy through the matrix. Plus a
+canonical-restore variant (all CAC features off).
+
+Dimensions:
+  blocked  none | ip | asn        (blocked_clients: by ip_prefix / by as_number)
+  trusted  none | ip_waf          (trusted_clients: ip_prefix + actions SKIP_PROCESSING_WAF)
+  iprep    off | on               (enable_ip_reputation with an IpThreatCategory list)
+
+All three are independent LB features (no cross-field constraint), so every combination is
+valid; only the all-off row is skipped (that is the canonical/no-CAC baseline).
+
+Deterministic (no RNG). Output: JSON to stdout, or files via --emit.
+"""
+
+import itertools
+import json
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+DIMENSIONS = {
+    "blocked": ["none", "ip", "asn"],
+    "trusted": ["none", "ip_waf"],
+    "iprep": ["off", "on"],
+}
+
+
+def _best_value(
+    values: list[str],
+    idx: int,
+    row: dict[int, str],
+    uncovered: set[tuple[int, str, int, str]],
+) -> str:
+    """Pick the value for dimension idx covering the most still-uncovered pairs."""
+    best_val, best_gain = values[0], -1
+    for val in values:
+        gain = 0
+        for pidx, pval in row.items():
+            a, b = sorted([(pidx, pval), (idx, val)])
+            if (a[0], a[1], b[0], b[1]) in uncovered:
+                gain += 1
+        if gain > best_gain:
+            best_gain, best_val = gain, val
+    return best_val
+
+
+def all_pairs(dims: dict[str, list[str]]) -> list[dict[str, str]]:
+    """Return AETG-style greedy all-pairs rows ({dim: value})."""
+    names = list(dims)
+    uncovered: set[tuple[int, str, int, str]] = set()
+    for i, j in itertools.combinations(range(len(names)), 2):
+        for vi in dims[names[i]]:
+            for vj in dims[names[j]]:
+                uncovered.add((i, vi, j, vj))
+
+    rows = []
+    while uncovered:
+        si, sv, sj, sv2 = min(uncovered)
+        row = {si: sv, sj: sv2}
+        for idx, name in enumerate(names):
+            if idx not in row:
+                row[idx] = _best_value(dims[name], idx, row, uncovered)
+        for i, j in itertools.combinations(sorted(row), 2):
+            uncovered.discard((i, row[i], j, row[j]))
+        rows.append({names[k]: v for k, v in row.items()})
+    return rows
+
+
+def payloads(v: Mapping[str, object]) -> dict[str, object]:
+    """Expand a CAC row into real tfvars (TEST-NET prefixes / private ASN, never real)."""
+    blocked: list[dict[str, object]] = []
+    if v["blocked"] == "ip":
+        blocked = [{"name": "cac-blk-ip", "ip_prefix": "192.0.2.0/24"}]
+    elif v["blocked"] == "asn":
+        blocked = [{"name": "cac-blk-asn", "as_number": 64512}]
+    trusted: list[dict[str, object]] = []
+    if v["trusted"] == "ip_waf":
+        trusted = [
+            {
+                "name": "cac-trust-ip",
+                "ip_prefix": "198.51.100.0/24",
+                "actions": ["SKIP_PROCESSING_WAF"],
+            }
+        ]
+    return {
+        "trusted_clients": trusted,
+        "blocked_clients": blocked,
+        "ip_reputation_enabled": v["iprep"] == "on",
+        "ip_reputation_categories": ["BOTNETS", "SPAM_SOURCES"]
+        if v["iprep"] == "on"
+        else [],
+    }
+
+
+def canonical() -> dict[str, object]:
+    """Live-canonical end state (all CAC features off)."""
+    return {
+        "trusted_clients": [],
+        "blocked_clients": [],
+        "ip_reputation_enabled": False,
+        "ip_reputation_categories": [],
+    }
+
+
+def build() -> list[dict[str, object]]:
+    """Build the ordered variant manifest (all-pairs + canonical), deduped."""
+    variants: list[dict[str, object]] = []
+    seen: set[str] = set()
+    idx = 0
+    for row in all_pairs(DIMENSIONS):
+        if (
+            row["blocked"] == "none"
+            and row["trusted"] == "none"
+            and row["iprep"] == "off"
+        ):
+            continue
+        vars_ = payloads(row)
+        key = json.dumps(vars_, sort_keys=True)
+        if key in seen:
+            continue
+        seen.add(key)
+        variants.append({"name": f"pair-{idx:03d}", "vars": vars_})
+        idx += 1
+    variants.append({"name": "canonical-restore", "vars": canonical()})
+    return variants
+
+
+def emit(directory: str) -> int:
+    """Write one <NNN>-<name>.tfvars.json per variant plus manifest.txt."""
+    out_dir = Path(directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for existing in out_dir.iterdir():
+        if existing.name.endswith(".tfvars.json") or existing.name == "manifest.txt":
+            existing.unlink()
+    variants = build()
+    named = [(f"{i:03d}-{v['name']}.tfvars.json", v) for i, v in enumerate(variants)]
+    for fname, v in named:
+        (out_dir / fname).write_text(json.dumps(v["vars"], indent=2) + "\n")
+    lines = [f"{i:03d} {v['name']} {fname} LIVE" for i, (fname, v) in enumerate(named)]
+    (out_dir / "manifest.txt").write_text("\n".join(lines) + "\n")
+    return len(variants)
+
+
+def main(argv: list[str]) -> None:
+    """CLI: --count, --emit <dir>, else JSON to stdout."""
+    match argv[1:]:
+        case ["--count"]:
+            sys.stdout.write(f"{len(build())}\n")
+        case ["--emit", directory]:
+            sys.stdout.write(f"{emit(directory)}\n")
+        case _:
+            json.dump(build(), sys.stdout, indent=2)
+            sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -166,6 +166,12 @@ module "http_lb" {
   service_policy_bgp_asn_sets   = var.service_policy_bgp_asn_sets
   service_policy_ip_prefix_sets = var.service_policy_ip_prefix_sets
 
+  # Client access control (CAC) passthrough.
+  trusted_clients          = var.trusted_clients
+  blocked_clients          = var.blocked_clients
+  ip_reputation_enabled    = var.ip_reputation_enabled
+  ip_reputation_categories = var.ip_reputation_categories
+
   # API Testing (SP4) passthrough. Defaults keep it off (disable_api_testing
   # suppressed => 0-change) and create no standalone resource.
   api_testing_choice              = var.api_testing_choice

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -1332,6 +1332,47 @@ resource "xcsh_http_loadbalancer" "this" {
     }
   }
 
+  # Client access control (CAC) — trusted_clients bypass the SKIP_PROCESSING_* security named
+  # in actions; blocked_clients are blocked (or have those actions applied). Each rule matches
+  # by exactly one of ip_prefix / ipv6_prefix / as_number / user_identifier. Omitted when the
+  # list is empty (0-change). actions null-when-empty (server default SKIP_PROCESSING_WAF).
+  dynamic "trusted_clients" {
+    for_each = var.trusted_clients
+    content {
+      metadata {
+        name = coalesce(trusted_clients.value.name, "cac-trusted-${trusted_clients.key}")
+      }
+      ip_prefix            = trusted_clients.value.ip_prefix
+      ipv6_prefix          = trusted_clients.value.ipv6_prefix
+      as_number            = trusted_clients.value.as_number
+      user_identifier      = trusted_clients.value.user_identifier
+      expiration_timestamp = trusted_clients.value.expiration_timestamp
+      actions              = length(trusted_clients.value.actions) > 0 ? trusted_clients.value.actions : null
+    }
+  }
+  dynamic "blocked_clients" {
+    for_each = var.blocked_clients
+    content {
+      metadata {
+        name = coalesce(blocked_clients.value.name, "cac-blocked-${blocked_clients.key}")
+      }
+      ip_prefix            = blocked_clients.value.ip_prefix
+      ipv6_prefix          = blocked_clients.value.ipv6_prefix
+      as_number            = blocked_clients.value.as_number
+      user_identifier      = blocked_clients.value.user_identifier
+      expiration_timestamp = blocked_clients.value.expiration_timestamp
+      actions              = length(blocked_clients.value.actions) > 0 ? blocked_clients.value.actions : null
+    }
+  }
+  # IP reputation — block clients whose source IP matches the given IpThreatCategory list
+  # (empty list = the server default set). Omitted entirely when disabled (0-change).
+  dynamic "enable_ip_reputation" {
+    for_each = var.ip_reputation_enabled ? [1] : []
+    content {
+      ip_threat_categories = length(var.ip_reputation_categories) > 0 ? var.ip_reputation_categories : null
+    }
+  }
+
   # API protection rules (Coverage Batch D) — allow/deny access to API endpoints
   # (api_endpoint_rules) or API groups / base paths (api_groups_rules), each scoped by
   # a PER-RULE client_matcher (full oneof) + request_matcher. Omitted when both lists

--- a/terraform/modules/http-lb/variables_client_access.tf
+++ b/terraform/modules/http-lb/variables_client_access.tf
@@ -1,0 +1,87 @@
+# Client access control (CAC effort) on the HTTP LB: trusted_clients / blocked_clients
+# (client match rules by IP prefix / IPv6 prefix / ASN / user identifier, with optional
+# SKIP_PROCESSING_* actions) and enable_ip_reputation (block clients whose source IP falls
+# in the given IpThreatCategory list). Defaults create nothing and emit no LB block (0-change).
+#
+# Validations are self-contained per variable (no cross-variable references) to stay within
+# the module's required_version >= 1.5. The SKIP_PROCESSING_* and IpThreatCategory enums are
+# inlined (matching the service_policy convention).
+
+variable "trusted_clients" {
+  description = "Trusted-client rules on the LB: matched clients bypass the security processing named in actions (SKIP_PROCESSING_*). Match by exactly one of ip_prefix / ipv6_prefix / as_number / user_identifier."
+  type = list(object({
+    name                 = optional(string)           # metadata.name (auto-generated if unset)
+    ip_prefix            = optional(string)           # IPv4 CIDR, e.g. 192.0.2.0/24
+    ipv6_prefix          = optional(string)           # IPv6 CIDR
+    as_number            = optional(number)           # BGP ASN
+    user_identifier      = optional(string)           # match by user identifier value
+    actions              = optional(list(string), []) # SKIP_PROCESSING_* (server default WAF when empty)
+    expiration_timestamp = optional(string)           # RFC3339; rule ignored after this time
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for c in var.trusted_clients :
+      length([for k in [c.ip_prefix, c.ipv6_prefix, c.as_number, c.user_identifier] : k if k != null]) == 1
+    ])
+    error_message = "each trusted_clients[] rule must set exactly one of ip_prefix, ipv6_prefix, as_number, or user_identifier."
+  }
+  validation {
+    condition = alltrue([
+      for c in var.trusted_clients : alltrue([
+        for a in c.actions : contains(["SKIP_PROCESSING_WAF", "SKIP_PROCESSING_BOT", "SKIP_PROCESSING_MUM", "SKIP_PROCESSING_IP_REPUTATION", "SKIP_PROCESSING_API_PROTECTION", "SKIP_PROCESSING_OAS_VALIDATION", "SKIP_PROCESSING_DDOS_PROTECTION", "SKIP_PROCESSING_THREAT_MESH", "SKIP_PROCESSING_MALWARE_PROTECTION"], a)
+      ])
+    ])
+    error_message = "each trusted_clients[].actions entry must be a valid SKIP_PROCESSING_* value."
+  }
+}
+
+variable "blocked_clients" {
+  description = "Blocked-client rules on the LB: matched clients are blocked (or have the named SKIP_PROCESSING_* actions applied). Match by exactly one of ip_prefix / ipv6_prefix / as_number / user_identifier."
+  type = list(object({
+    name                 = optional(string)
+    ip_prefix            = optional(string)
+    ipv6_prefix          = optional(string)
+    as_number            = optional(number)
+    user_identifier      = optional(string)
+    actions              = optional(list(string), [])
+    expiration_timestamp = optional(string)
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for c in var.blocked_clients :
+      length([for k in [c.ip_prefix, c.ipv6_prefix, c.as_number, c.user_identifier] : k if k != null]) == 1
+    ])
+    error_message = "each blocked_clients[] rule must set exactly one of ip_prefix, ipv6_prefix, as_number, or user_identifier."
+  }
+  validation {
+    condition = alltrue([
+      for c in var.blocked_clients : alltrue([
+        for a in c.actions : contains(["SKIP_PROCESSING_WAF", "SKIP_PROCESSING_BOT", "SKIP_PROCESSING_MUM", "SKIP_PROCESSING_IP_REPUTATION", "SKIP_PROCESSING_API_PROTECTION", "SKIP_PROCESSING_OAS_VALIDATION", "SKIP_PROCESSING_DDOS_PROTECTION", "SKIP_PROCESSING_THREAT_MESH", "SKIP_PROCESSING_MALWARE_PROTECTION"], a)
+      ])
+    ])
+    error_message = "each blocked_clients[].actions entry must be a valid SKIP_PROCESSING_* value."
+  }
+}
+
+variable "ip_reputation_enabled" {
+  description = "Enable IP-reputation filtering on the LB (enable_ip_reputation). When true, clients whose source IP matches ip_reputation_categories are blocked."
+  type        = bool
+  default     = false
+}
+
+variable "ip_reputation_categories" {
+  description = "IpThreatCategory values to block when ip_reputation_enabled (e.g. SPAM_SOURCES, BOTNETS, TOR_PROXY). Empty = the server default set."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for c in var.ip_reputation_categories : contains(["SPAM_SOURCES", "WINDOWS_EXPLOITS", "WEB_ATTACKS", "BOTNETS", "SCANNERS", "REPUTATION", "PHISHING", "PROXY", "MOBILE_THREATS", "TOR_PROXY", "DENIAL_OF_SERVICE", "NETWORK"], c)
+    ])
+    error_message = "each ip_reputation_categories entry must be a valid IpThreatCategory (e.g. BOTNETS, SPAM_SOURCES, TOR_PROXY)."
+  }
+}

--- a/terraform/tests/client_access.tftest.hcl
+++ b/terraform/tests/client_access.tftest.hcl
@@ -1,0 +1,108 @@
+# Plan-level tests for client access control (CAC): trusted_clients / blocked_clients
+# (match by ip_prefix/ipv6_prefix/as_number/user_identifier + SKIP_PROCESSING_* actions)
+# and enable_ip_reputation. Targets ./modules/http-lb. command = plan (no creds).
+variables {
+  namespace         = "webapp-api-protection"
+  lb_domains        = ["www.f5-sales-demo.com"]
+  origin_ip         = "203.0.113.10"
+  origin_port       = 80
+  health_check_path = "/health"
+  labels            = {}
+  csd_enabled       = false
+  mud_enabled       = false
+}
+
+run "blocked_client_ip_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    blocked_clients = [{ ip_prefix = "192.0.2.10/32" }]
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.blocked_clients[0].ip_prefix == "192.0.2.10/32"
+    error_message = "blocked_clients ip_prefix must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.blocked_clients[0].metadata.name == "cac-blocked-0"
+    error_message = "blocked_clients metadata name must auto-generate"
+  }
+}
+
+run "trusted_client_asn_with_actions_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    trusted_clients = [{ as_number = 64512, actions = ["SKIP_PROCESSING_WAF", "SKIP_PROCESSING_BOT"] }]
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.trusted_clients[0].as_number == 64512
+    error_message = "trusted_clients as_number must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.trusted_clients[0].actions[0] == "SKIP_PROCESSING_WAF"
+    error_message = "trusted_clients actions must render"
+  }
+}
+
+run "ip_reputation_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    ip_reputation_enabled    = true
+    ip_reputation_categories = ["BOTNETS", "TOR_PROXY"]
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.enable_ip_reputation.ip_threat_categories[0] == "BOTNETS"
+    error_message = "enable_ip_reputation categories must render"
+  }
+}
+
+run "cac_omitted_by_default" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  assert {
+    condition     = try(length(xcsh_http_loadbalancer.this.blocked_clients), 0) == 0 && try(length(xcsh_http_loadbalancer.this.trusted_clients), 0) == 0
+    error_message = "CAC client lists must be empty by default"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.enable_ip_reputation == null
+    error_message = "enable_ip_reputation must be omitted (null) by default"
+  }
+}
+
+run "rejects_no_match_key" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    blocked_clients = [{ actions = ["SKIP_PROCESSING_WAF"] }]
+  }
+  expect_failures = [var.blocked_clients]
+}
+
+run "rejects_multi_match_key" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    blocked_clients = [{ ip_prefix = "192.0.2.0/24", as_number = 64512 }]
+  }
+  expect_failures = [var.blocked_clients]
+}
+
+run "rejects_bad_action" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    trusted_clients = [{ ip_prefix = "192.0.2.0/24", actions = ["SKIP_EVERYTHING"] }]
+  }
+  expect_failures = [var.trusted_clients]
+}
+
+run "rejects_bad_ip_threat_category" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    ip_reputation_enabled    = true
+    ip_reputation_categories = ["NOT_A_CATEGORY"]
+  }
+  expect_failures = [var.ip_reputation_categories]
+}

--- a/terraform/variables_client_access.tf
+++ b/terraform/variables_client_access.tf
@@ -1,0 +1,28 @@
+# Root-level client access control (CAC) passthrough to modules/http-lb. The full typed
+# objects + validations live once in the module (modules/http-lb/variables_client_access.tf),
+# so object vars use type = any; the scalar knobs mirror the module defaults. Defaults create
+# nothing and emit no LB block (0-change).
+
+variable "trusted_clients" {
+  description = "Trusted-client rules on the LB (see module for the object shape)."
+  type        = any
+  default     = []
+}
+
+variable "blocked_clients" {
+  description = "Blocked-client rules on the LB (see module for the object shape)."
+  type        = any
+  default     = []
+}
+
+variable "ip_reputation_enabled" {
+  description = "Enable IP-reputation filtering on the LB."
+  type        = bool
+  default     = false
+}
+
+variable "ip_reputation_categories" {
+  description = "IpThreatCategory values to block when ip_reputation_enabled."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
Closes #95.

## What
Exhaustive coverage of the HTTP LB client access control features:
- **`trusted_clients` / `blocked_clients`** — match a client by exactly one of `ip_prefix` / `ipv6_prefix` / `as_number` / `user_identifier`; `actions[]` (SKIP_PROCESSING_WAF|BOT|MUM|IP_REPUTATION|API_PROTECTION|OAS_VALIDATION|DDOS_PROTECTION|THREAT_MESH|MALWARE_PROTECTION); auto-gen `metadata.name`; `expiration_timestamp`.
- **`enable_ip_reputation`** — `ip_threat_categories[]` (IpThreatCategory enum).
- Self-contained per-variable validations (req_version >= 1.5); root passthrough. Generator `scripts/client_access_pairs.py` (TEST-NET prefixes / private ASN, never blocks real traffic) + runner `scripts/client-access-matrix.sh`.

Includes the merged whole-LB import fix (#94, drop stale `endpoint_subsets {}`), without which the whole-LB import round-trip could not reach 0-change.

## Verification (live, f5-sales-demo)
- `terraform test` — **8 plan-tests pass** (render per feature + reject no-match / multi-match / bad action / bad IpThreatCategory).
- Live AETG matrix **7/7**: apply → re-plan 0-change → state-rm + import LB → re-plan **0-change**, incl. canonical restore.
- **Behavioral**: `blocked_clients` for the tester IP → `GET /` = **403** + `action=block` **"L7 Policy Violation"** event in `app_security/events`; removed → access restored **200**.
- Local gates: `terraform fmt`, `ruff`, `shellcheck`, `jscpd` (9.00% < 10%), `codespell` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)