### PR TITLE
LPC-1: app-layer protection — cors_policy / csrf_policy / protected_cookies

### DIFF
--- a/scripts/app-protection-matrix.sh
+++ b/scripts/app-protection-matrix.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# App-layer protection (LPC-1) live coverage-matrix harness.
+#
+# Cycles the LIVE webapp-api-protection LB through the client_access_pairs variant set and
+# verifies each variant (a) applies, (b) is idempotent (immediate plan = No changes), and
+# (c) is round-trip-import clean for the LB (state rm -> import -> plan clean). CAC is an
+# LB-nested feature, so the import target is the http_loadbalancer itself. Ends on
+# canonical-restore so the live LB is left healthy (all CAC features off). Results append to
+# reports/app-protection-matrix.txt.
+#
+# The variants use RFC 5737 TEST-NET prefixes / a private ASN, so no real client traffic is
+# ever blocked and the LB stays serving throughout. An arm F5 XC rejects for entitlement is
+# recorded SKIP (word signals; a bare status number is not matched) rather than FAIL.
+# Sequential — no concurrent terraform against the shared azurerm state.
+#
+# Usage: client-access-matrix.sh [START [END]]  (inclusive 0-based index range).
+set -uo pipefail
+
+umask 077
+trap 'rm -rf /tmp/lpc1-variants 2>/dev/null; rm -f /tmp/lpc1-*.log 2>/dev/null' EXIT
+
+cd "$(dirname "$0")/../terraform" || exit 1
+ARM_ACCESS_KEY=$(az storage account keys list -n f5salesdemotfstate -g f5-sales-demo-tfstate --query "[0].value" -o tsv)
+export ARM_ACCESS_KEY
+
+NS="webapp-api-protection"
+LB_ADDR="module.http_lb.xcsh_http_loadbalancer.this"
+LB_ID="${NS}/${NS}"
+COMMON=(-input=false -lock=true
+  -var 'lb_domains=["www.f5-sales-demo.com","api.f5-sales-demo.com"]'
+  -var 'subscription_id=75f86c46-9cbc-4f6c-85ea-195e3d3c8ac0')
+VARDIR=/tmp/lpc1-variants
+REPORT=../reports/app-protection-matrix.txt
+mkdir -p ../reports
+
+START="${1:-0}"
+END="${2:-9999}"
+GATED_RE='entitlement|not subscribed|not entitled|not enabled for|permission denied|unauthorized|AS_NOT_SUBSCRIBED|status: 401|status: 403'
+
+[ "$#" -eq 0 ] && : >"$REPORT"
+
+count=$(python3 ../scripts/app_protection_pairs.py --emit "$VARDIR")
+echo "generated $count variants into $VARDIR (running [$START..$END])"
+
+round_trip() {
+  local label="$1" vf="$2"
+  terraform state rm "$LB_ADDR" >/dev/null 2>&1 || {
+    echo "FAIL $label lb-state-rm" >>"$REPORT"
+    return
+  }
+  terraform import "${COMMON[@]}" -var-file="$vf" "$LB_ADDR" "$LB_ID" >/tmp/lpc1-import.log 2>&1 || {
+    echo "FAIL $label lb-import ($(grep -iE 'error' /tmp/lpc1-import.log | head -1 | cut -c1-70))" >>"$REPORT"
+    return
+  }
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$vf" >/tmp/lpc1-rt-plan.log 2>&1
+  case $? in
+  0) echo "PASS $label" >>"$REPORT" ;;
+  2) echo "FAIL $label import-drift" >>"$REPORT" ;;
+  *) echo "FAIL $label rt-plan-error" >>"$REPORT" ;;
+  esac
+}
+
+while read -r idx name vf _flag; do
+  [ "$idx" -lt "$START" ] && continue
+  [ "$idx" -gt "$END" ] && continue
+  label="$idx-$name"
+  echo "--- $label ---"
+  varfile="${VARDIR}/${vf}"
+  if ! terraform apply -auto-approve "${COMMON[@]}" -var-file="$varfile" >/tmp/lpc1-apply.log 2>&1; then
+    if grep -qiE "$GATED_RE" /tmp/lpc1-apply.log; then
+      echo "SKIP $label gated-arm ($(grep -oiE "$GATED_RE" /tmp/lpc1-apply.log | head -1))" >>"$REPORT"
+    else
+      echo "FAIL $label apply ($(grep -iE 'error' /tmp/lpc1-apply.log | head -1 | cut -c1-80))" >>"$REPORT"
+    fi
+    continue
+  fi
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$varfile" >/tmp/lpc1-plan.log 2>&1
+  case $? in
+  0) round_trip "$label" "$varfile" ;;
+  2) echo "FAIL $label not-idempotent" >>"$REPORT" ;;
+  *) echo "FAIL $label plan-error" >>"$REPORT" ;;
+  esac
+done <"${VARDIR}/manifest.txt"
+
+echo "===== CLIENT ACCESS MATRIX RESULTS ($START..$END) ====="
+cat "$REPORT"
+echo "PASS=$(grep -c '^PASS ' "$REPORT") FAIL=$(grep -c '^FAIL ' "$REPORT") SKIP=$(grep -c '^SKIP ' "$REPORT")"

--- a/scripts/app_protection_pairs.py
+++ b/scripts/app_protection_pairs.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Generate the app-layer protection (LPC-1) coverage matrix.
+
+AETG all-pairs over cors_policy / csrf_policy / protected_cookies, each variant applied to
+the LIVE LB. Plus canonical-restore (all off).
+
+Dimensions:
+  cors     none | on                                (cors_policy access-control-* headers)
+  csrf     omit | all_domains | custom | disabled   (csrf_policy oneof)
+  cookies  none | one                               (a protected_cookies entry)
+
+All independent; only the all-off row is skipped (canonical baseline).
+Deterministic (no RNG). Output: JSON to stdout, or files via --emit.
+"""
+
+import itertools
+import json
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+DIMENSIONS = {
+    "cors": ["none", "on"],
+    "csrf": ["omit", "all_domains", "custom", "disabled"],
+    "cookies": ["none", "one"],
+}
+
+
+def _best_value(
+    values: list[str],
+    idx: int,
+    row: dict[int, str],
+    uncovered: set[tuple[int, str, int, str]],
+) -> str:
+    """Pick the value for dimension idx covering the most still-uncovered pairs."""
+    best_val, best_gain = values[0], -1
+    for val in values:
+        gain = 0
+        for pidx, pval in row.items():
+            a, b = sorted([(pidx, pval), (idx, val)])
+            if (a[0], a[1], b[0], b[1]) in uncovered:
+                gain += 1
+        if gain > best_gain:
+            best_gain, best_val = gain, val
+    return best_val
+
+
+def all_pairs(dims: dict[str, list[str]]) -> list[dict[str, str]]:
+    """Return AETG-style greedy all-pairs rows ({dim: value})."""
+    names = list(dims)
+    uncovered: set[tuple[int, str, int, str]] = set()
+    for i, j in itertools.combinations(range(len(names)), 2):
+        for vi in dims[names[i]]:
+            for vj in dims[names[j]]:
+                uncovered.add((i, vi, j, vj))
+
+    rows = []
+    while uncovered:
+        si, sv, sj, sv2 = min(uncovered)
+        row = {si: sv, sj: sv2}
+        for idx, name in enumerate(names):
+            if idx not in row:
+                row[idx] = _best_value(dims[name], idx, row, uncovered)
+        for i, j in itertools.combinations(sorted(row), 2):
+            uncovered.discard((i, row[i], j, row[j]))
+        rows.append({names[k]: v for k, v in row.items()})
+    return rows
+
+
+def payloads(v: Mapping[str, object]) -> dict[str, object]:
+    """Expand an LPC-1 row into real tfvars."""
+    cors = None
+    if v["cors"] == "on":
+        cors = {
+            "allow_origin": ["https://app.example.com"],
+            "allow_methods": "GET, POST",
+            "allow_credentials": True,
+            "maximum_age": 600,
+        }
+    cookies: list[dict[str, object]] = []
+    if v["cookies"] == "one":
+        cookies = [
+            {
+                "name": "SESSION",
+                "httponly": "add",
+                "secure": "add",
+                "samesite": "strict",
+                "tampering": "enable",
+                "max_age_value": 3600,
+            }
+        ]
+    return {
+        "cors_policy": cors,
+        "csrf_policy_mode": v["csrf"],
+        "csrf_custom_domains": ["trusted.example.com"] if v["csrf"] == "custom" else [],
+        "protected_cookies": cookies,
+    }
+
+
+def canonical() -> dict[str, object]:
+    """Live-canonical end state (all LPC-1 features off)."""
+    return {
+        "cors_policy": None,
+        "csrf_policy_mode": "omit",
+        "csrf_custom_domains": [],
+        "protected_cookies": [],
+    }
+
+
+def build() -> list[dict[str, object]]:
+    """Build the ordered variant manifest (all-pairs + canonical), deduped."""
+    variants: list[dict[str, object]] = []
+    seen: set[str] = set()
+    idx = 0
+    for row in all_pairs(DIMENSIONS):
+        if row["cors"] == "none" and row["csrf"] == "omit" and row["cookies"] == "none":
+            continue
+        vars_ = payloads(row)
+        key = json.dumps(vars_, sort_keys=True)
+        if key in seen:
+            continue
+        seen.add(key)
+        variants.append({"name": f"pair-{idx:03d}", "vars": vars_})
+        idx += 1
+    variants.append({"name": "canonical-restore", "vars": canonical()})
+    return variants
+
+
+def emit(directory: str) -> int:
+    """Write one <NNN>-<name>.tfvars.json per variant plus manifest.txt."""
+    out_dir = Path(directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for existing in out_dir.iterdir():
+        if existing.name.endswith(".tfvars.json") or existing.name == "manifest.txt":
+            existing.unlink()
+    variants = build()
+    named = [(f"{i:03d}-{v['name']}.tfvars.json", v) for i, v in enumerate(variants)]
+    for fname, v in named:
+        (out_dir / fname).write_text(json.dumps(v["vars"], indent=2) + "\n")
+    lines = [f"{i:03d} {v['name']} {fname} LIVE" for i, (fname, v) in enumerate(named)]
+    (out_dir / "manifest.txt").write_text("\n".join(lines) + "\n")
+    return len(variants)
+
+
+def main(argv: list[str]) -> None:
+    """CLI: --count, --emit <dir>, else JSON to stdout."""
+    match argv[1:]:
+        case ["--count"]:
+            sys.stdout.write(f"{len(build())}\n")
+        case ["--emit", directory]:
+            sys.stdout.write(f"{emit(directory)}\n")
+        case _:
+            json.dump(build(), sys.stdout, indent=2)
+            sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -172,6 +172,12 @@ module "http_lb" {
   ip_reputation_enabled    = var.ip_reputation_enabled
   ip_reputation_categories = var.ip_reputation_categories
 
+  # App-layer protection (LPC-1) passthrough.
+  cors_policy         = var.cors_policy
+  csrf_policy_mode    = var.csrf_policy_mode
+  csrf_custom_domains = var.csrf_custom_domains
+  protected_cookies   = var.protected_cookies
+
   # API Testing (SP4) passthrough. Defaults keep it off (disable_api_testing
   # suppressed => 0-change) and create no standalone resource.
   api_testing_choice              = var.api_testing_choice

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -1372,6 +1372,94 @@ resource "xcsh_http_loadbalancer" "this" {
     }
   }
 
+  # App-layer response/cookie protection (LPC-1). cors_policy: access-control-* headers.
+  # csrf_policy: oneof all_load_balancer_domains | custom_domain_list | disabled.
+  # protected_cookies[]: per-cookie httponly/secure/samesite/tampering handling. Each omitted
+  # when unset (0-change). Empty lists emitted null-when-empty.
+  dynamic "cors_policy" {
+    for_each = var.cors_policy != null ? [1] : []
+    content {
+      allow_origin       = length(var.cors_policy.allow_origin) > 0 ? var.cors_policy.allow_origin : null
+      allow_origin_regex = length(var.cors_policy.allow_origin_regex) > 0 ? var.cors_policy.allow_origin_regex : null
+      allow_methods      = var.cors_policy.allow_methods
+      allow_headers      = var.cors_policy.allow_headers
+      expose_headers     = var.cors_policy.expose_headers
+      maximum_age        = var.cors_policy.maximum_age
+      allow_credentials  = var.cors_policy.allow_credentials
+      disabled           = var.cors_policy.disabled
+    }
+  }
+  dynamic "csrf_policy" {
+    for_each = var.csrf_policy_mode != "omit" ? [1] : []
+    content {
+      dynamic "all_load_balancer_domains" {
+        for_each = var.csrf_policy_mode == "all_domains" ? [1] : []
+        content {}
+      }
+      dynamic "custom_domain_list" {
+        for_each = var.csrf_policy_mode == "custom" ? [1] : []
+        content {
+          domains = length(var.csrf_custom_domains) > 0 ? var.csrf_custom_domains : null
+        }
+      }
+      dynamic "disabled" {
+        for_each = var.csrf_policy_mode == "disabled" ? [1] : []
+        content {}
+      }
+    }
+  }
+  dynamic "protected_cookies" {
+    for_each = var.protected_cookies
+    content {
+      name          = protected_cookies.value.name
+      max_age_value = protected_cookies.value.max_age_value
+      dynamic "add_httponly" {
+        for_each = protected_cookies.value.httponly == "add" ? [1] : []
+        content {}
+      }
+      dynamic "ignore_httponly" {
+        for_each = protected_cookies.value.httponly == "ignore" ? [1] : []
+        content {}
+      }
+      dynamic "add_secure" {
+        for_each = protected_cookies.value.secure == "add" ? [1] : []
+        content {}
+      }
+      dynamic "ignore_secure" {
+        for_each = protected_cookies.value.secure == "ignore" ? [1] : []
+        content {}
+      }
+      dynamic "samesite_lax" {
+        for_each = protected_cookies.value.samesite == "lax" ? [1] : []
+        content {}
+      }
+      dynamic "samesite_none" {
+        for_each = protected_cookies.value.samesite == "none" ? [1] : []
+        content {}
+      }
+      dynamic "samesite_strict" {
+        for_each = protected_cookies.value.samesite == "strict" ? [1] : []
+        content {}
+      }
+      dynamic "ignore_samesite" {
+        for_each = protected_cookies.value.samesite == "ignore" ? [1] : []
+        content {}
+      }
+      dynamic "enable_tampering_protection" {
+        for_each = protected_cookies.value.tampering == "enable" ? [1] : []
+        content {}
+      }
+      dynamic "disable_tampering_protection" {
+        for_each = protected_cookies.value.tampering == "disable" ? [1] : []
+        content {}
+      }
+      dynamic "ignore_max_age" {
+        for_each = protected_cookies.value.ignore_max_age ? [1] : []
+        content {}
+      }
+    }
+  }
+
   # API protection rules (Coverage Batch D) — allow/deny access to API endpoints
   # (api_endpoint_rules) or API groups / base paths (api_groups_rules), each scoped by
   # a PER-RULE client_matcher (full oneof) + request_matcher. Omitted when both lists

--- a/terraform/modules/http-lb/variables_app_protection.tf
+++ b/terraform/modules/http-lb/variables_app_protection.tf
@@ -1,0 +1,69 @@
+# App-layer response/cookie protection (LPC-1) on the HTTP LB: cors_policy, csrf_policy,
+# and protected_cookies. All top-level LB features (apply to the default-route LB — no
+# custom routes needed). Defaults create nothing and emit no LB block (0-change).
+
+variable "cors_policy" {
+  description = "CORS policy on the LB. Set to configure access-control-* response headers; null omits the block."
+  type = object({
+    allow_origin       = optional(list(string), [])
+    allow_origin_regex = optional(list(string), [])
+    allow_methods      = optional(string) # access-control-allow-methods content
+    allow_headers      = optional(string)
+    expose_headers     = optional(string)
+    maximum_age        = optional(number) # access-control-max-age seconds
+    allow_credentials  = optional(bool, false)
+    disabled           = optional(bool, false)
+  })
+  default = null
+}
+
+variable "csrf_policy_mode" {
+  description = "CSRF policy oneof: omit (no block) | all_domains (all_load_balancer_domains) | custom (custom_domain_list) | disabled."
+  type        = string
+  default     = "omit"
+
+  validation {
+    condition     = contains(["omit", "all_domains", "custom", "disabled"], var.csrf_policy_mode)
+    error_message = "csrf_policy_mode must be omit, all_domains, custom, or disabled."
+  }
+}
+
+variable "csrf_custom_domains" {
+  description = "Allowed source domains when csrf_policy_mode=\"custom\" (custom_domain_list.domains)."
+  type        = list(string)
+  default     = []
+}
+
+variable "protected_cookies" {
+  description = "Per-cookie protection rules on the LB. Each names a cookie and selects attribute handling (httponly/secure/samesite/tampering) via single-knob selectors."
+  type = list(object({
+    name           = string
+    max_age_value  = optional(number)
+    httponly       = optional(string, "omit") # omit|add|ignore
+    secure         = optional(string, "omit") # omit|add|ignore
+    samesite       = optional(string, "omit") # omit|lax|none|strict|ignore
+    tampering      = optional(string, "omit") # omit|enable|disable
+    ignore_max_age = optional(bool, false)
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for c in var.protected_cookies :
+      contains(["omit", "add", "ignore"], c.httponly) && contains(["omit", "add", "ignore"], c.secure)
+    ])
+    error_message = "each protected_cookies[].httponly / secure must be omit, add, or ignore."
+  }
+  validation {
+    condition = alltrue([
+      for c in var.protected_cookies : contains(["omit", "lax", "none", "strict", "ignore"], c.samesite)
+    ])
+    error_message = "each protected_cookies[].samesite must be omit, lax, none, strict, or ignore."
+  }
+  validation {
+    condition = alltrue([
+      for c in var.protected_cookies : contains(["omit", "enable", "disable"], c.tampering)
+    ])
+    error_message = "each protected_cookies[].tampering must be omit, enable, or disable."
+  }
+}

--- a/terraform/tests/app_protection.tftest.hcl
+++ b/terraform/tests/app_protection.tftest.hcl
@@ -1,0 +1,102 @@
+# Plan-level tests for app-layer protection (LPC-1): cors_policy, csrf_policy,
+# protected_cookies. Targets ./modules/http-lb. command = plan (no creds).
+variables {
+  namespace         = "webapp-api-protection"
+  lb_domains        = ["www.f5-sales-demo.com"]
+  origin_ip         = "203.0.113.10"
+  origin_port       = 80
+  health_check_path = "/health"
+  labels            = {}
+  csd_enabled       = false
+  mud_enabled       = false
+}
+
+run "cors_policy_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    cors_policy = {
+      allow_origin      = ["https://app.example.com"]
+      allow_methods     = "GET, POST"
+      allow_credentials = true
+      maximum_age       = 600
+    }
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.cors_policy.allow_origin[0] == "https://app.example.com"
+    error_message = "cors_policy allow_origin must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.cors_policy.allow_credentials == true
+    error_message = "cors_policy allow_credentials must render"
+  }
+}
+
+run "csrf_all_domains_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { csrf_policy_mode = "all_domains" }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.csrf_policy.all_load_balancer_domains != null
+    error_message = "csrf all_domains marker must render"
+  }
+}
+
+run "csrf_custom_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    csrf_policy_mode    = "custom"
+    csrf_custom_domains = ["trusted.example.com"]
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.csrf_policy.custom_domain_list.domains[0] == "trusted.example.com"
+    error_message = "csrf custom_domain_list must render"
+  }
+}
+
+run "protected_cookies_render" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    protected_cookies = [{ name = "SESSION", httponly = "add", secure = "add", samesite = "strict", tampering = "enable", max_age_value = 3600 }]
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.protected_cookies[0].name == "SESSION"
+    error_message = "protected_cookies name must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.protected_cookies[0].add_httponly != null && xcsh_http_loadbalancer.this.protected_cookies[0].samesite_strict != null && xcsh_http_loadbalancer.this.protected_cookies[0].enable_tampering_protection != null
+    error_message = "protected_cookies attribute markers must render"
+  }
+}
+
+run "app_protection_omitted_by_default" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.cors_policy == null && xcsh_http_loadbalancer.this.csrf_policy == null && try(length(xcsh_http_loadbalancer.this.protected_cookies), 0) == 0
+    error_message = "cors/csrf/protected_cookies must be omitted by default"
+  }
+}
+
+run "rejects_bad_csrf_mode" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { csrf_policy_mode = "maybe" }
+  expect_failures = [var.csrf_policy_mode]
+}
+
+run "rejects_bad_cookie_samesite" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { protected_cookies = [{ name = "X", samesite = "sometimes" }] }
+  expect_failures = [var.protected_cookies]
+}
+
+run "rejects_bad_cookie_httponly" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { protected_cookies = [{ name = "X", httponly = "maybe" }] }
+  expect_failures = [var.protected_cookies]
+}

--- a/terraform/variables_app_protection.tf
+++ b/terraform/variables_app_protection.tf
@@ -1,0 +1,26 @@
+# Root passthrough for app-layer protection (LPC-1) to modules/http-lb. Typed objects use
+# type = any (full shape + validation live in the module). Defaults = 0-change.
+
+variable "cors_policy" {
+  description = "CORS policy on the LB (see module for the object shape)."
+  type        = any
+  default     = null
+}
+
+variable "csrf_policy_mode" {
+  description = "CSRF policy oneof: omit | all_domains | custom | disabled."
+  type        = string
+  default     = "omit"
+}
+
+variable "csrf_custom_domains" {
+  description = "Allowed source domains when csrf_policy_mode=custom."
+  type        = list(string)
+  default     = []
+}
+
+variable "protected_cookies" {
+  description = "Per-cookie protection rules on the LB (see module for the object shape)."
+  type        = any
+  default     = []
+}


### PR DESCRIPTION
Closes #97. Slice 1 of the LB-protection coverage effort (#70).

## What
Top-level HTTP LB app-layer protection:
- **cors_policy** — allow_origin(_regex), allow_methods/headers, expose_headers, maximum_age, allow_credentials, disabled.
- **csrf_policy** oneof — omit | all_domains | custom (domains) | disabled.
- **protected_cookies[]** — per-cookie httponly/secure/samesite/tampering single-knob selectors + max_age.

## Verification (live, f5-sales-demo)
- `terraform test` — **8 plan-tests pass** (renders + reject bad csrf mode / cookie samesite / cookie httponly).
- Live AETG matrix **8/8**: apply → re-plan 0-change → import LB → re-plan **0-change** + canonical restore (whole-LB import clean since #94).
- **Behavioral**: applied cors_policy → `access-control-allow-origin: https://app.example.com` response header live; restored.
- Local gates: fmt / ruff / shellcheck / jscpd (8.80%) / codespell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)