### PR TITLE
LPC-2: header/cookie manipulation via more_option

### DIFF
--- a/scripts/header-manipulation-matrix.sh
+++ b/scripts/header-manipulation-matrix.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Header manipulation (LPC-2) live coverage-matrix harness.
+#
+# Cycles the LIVE webapp-api-protection LB through the client_access_pairs variant set and
+# verifies each variant (a) applies, (b) is idempotent (immediate plan = No changes), and
+# (c) is round-trip-import clean for the LB (state rm -> import -> plan clean). CAC is an
+# LB-nested feature, so the import target is the http_loadbalancer itself. Ends on
+# canonical-restore so the live LB is left healthy (all CAC features off). Results append to
+# reports/header-manipulation-matrix.txt.
+#
+# The variants use RFC 5737 TEST-NET prefixes / a private ASN, so no real client traffic is
+# ever blocked and the LB stays serving throughout. An arm F5 XC rejects for entitlement is
+# recorded SKIP (word signals; a bare status number is not matched) rather than FAIL.
+# Sequential — no concurrent terraform against the shared azurerm state.
+#
+# Usage: client-access-matrix.sh [START [END]]  (inclusive 0-based index range).
+set -uo pipefail
+
+umask 077
+trap 'rm -rf /tmp/lpc2-variants 2>/dev/null; rm -f /tmp/lpc2-*.log 2>/dev/null' EXIT
+
+cd "$(dirname "$0")/../terraform" || exit 1
+ARM_ACCESS_KEY=$(az storage account keys list -n f5salesdemotfstate -g f5-sales-demo-tfstate --query "[0].value" -o tsv)
+export ARM_ACCESS_KEY
+
+NS="webapp-api-protection"
+LB_ADDR="module.http_lb.xcsh_http_loadbalancer.this"
+LB_ID="${NS}/${NS}"
+COMMON=(-input=false -lock=true
+  -var 'lb_domains=["www.f5-sales-demo.com","api.f5-sales-demo.com"]'
+  -var 'subscription_id=75f86c46-9cbc-4f6c-85ea-195e3d3c8ac0')
+VARDIR=/tmp/lpc2-variants
+REPORT=../reports/header-manipulation-matrix.txt
+mkdir -p ../reports
+
+START="${1:-0}"
+END="${2:-9999}"
+GATED_RE='entitlement|not subscribed|not entitled|not enabled for|permission denied|unauthorized|AS_NOT_SUBSCRIBED|status: 401|status: 403'
+
+[ "$#" -eq 0 ] && : >"$REPORT"
+
+count=$(python3 ../scripts/header_manipulation_pairs.py --emit "$VARDIR")
+echo "generated $count variants into $VARDIR (running [$START..$END])"
+
+round_trip() {
+  local label="$1" vf="$2"
+  terraform state rm "$LB_ADDR" >/dev/null 2>&1 || {
+    echo "FAIL $label lb-state-rm" >>"$REPORT"
+    return
+  }
+  terraform import "${COMMON[@]}" -var-file="$vf" "$LB_ADDR" "$LB_ID" >/tmp/lpc2-import.log 2>&1 || {
+    echo "FAIL $label lb-import ($(grep -iE 'error' /tmp/lpc2-import.log | head -1 | cut -c1-70))" >>"$REPORT"
+    return
+  }
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$vf" >/tmp/lpc2-rt-plan.log 2>&1
+  case $? in
+  0) echo "PASS $label" >>"$REPORT" ;;
+  2) echo "FAIL $label import-drift" >>"$REPORT" ;;
+  *) echo "FAIL $label rt-plan-error" >>"$REPORT" ;;
+  esac
+}
+
+while read -r idx name vf _flag; do
+  [ "$idx" -lt "$START" ] && continue
+  [ "$idx" -gt "$END" ] && continue
+  label="$idx-$name"
+  echo "--- $label ---"
+  varfile="${VARDIR}/${vf}"
+  if ! terraform apply -auto-approve "${COMMON[@]}" -var-file="$varfile" >/tmp/lpc2-apply.log 2>&1; then
+    if grep -qiE "$GATED_RE" /tmp/lpc2-apply.log; then
+      echo "SKIP $label gated-arm ($(grep -oiE "$GATED_RE" /tmp/lpc2-apply.log | head -1))" >>"$REPORT"
+    else
+      echo "FAIL $label apply ($(grep -iE 'error' /tmp/lpc2-apply.log | head -1 | cut -c1-80))" >>"$REPORT"
+    fi
+    continue
+  fi
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$varfile" >/tmp/lpc2-plan.log 2>&1
+  case $? in
+  0) round_trip "$label" "$varfile" ;;
+  2) echo "FAIL $label not-idempotent" >>"$REPORT" ;;
+  *) echo "FAIL $label plan-error" >>"$REPORT" ;;
+  esac
+done <"${VARDIR}/manifest.txt"
+
+echo "===== CLIENT ACCESS MATRIX RESULTS ($START..$END) ====="
+cat "$REPORT"
+echo "PASS=$(grep -c '^PASS ' "$REPORT") FAIL=$(grep -c '^FAIL ' "$REPORT") SKIP=$(grep -c '^SKIP ' "$REPORT")"

--- a/scripts/header_manipulation_pairs.py
+++ b/scripts/header_manipulation_pairs.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Generate the header/cookie manipulation (LPC-2) coverage matrix.
+
+AETG all-pairs over more_option request/response header add+remove and cookie remove, each
+variant applied to the LIVE LB. Plus canonical-restore (more_option off).
+
+Dimensions:
+  req      none | add | remove     (request_headers_to_add / _to_remove)
+  resp     none | add | remove     (response_headers_to_add / _to_remove)
+  cookies  none | remove           (request/response_cookies_to_remove)
+
+Deterministic (no RNG). Output: JSON to stdout, or files via --emit.
+"""
+
+import itertools
+import json
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+DIMENSIONS = {
+    "req": ["none", "add", "remove"],
+    "resp": ["none", "add", "remove"],
+    "cookies": ["none", "remove"],
+}
+
+
+def _best_value(
+    values: list[str],
+    idx: int,
+    row: dict[int, str],
+    uncovered: set[tuple[int, str, int, str]],
+) -> str:
+    """Pick the value for dimension idx covering the most still-uncovered pairs."""
+    best_val, best_gain = values[0], -1
+    for val in values:
+        gain = 0
+        for pidx, pval in row.items():
+            a, b = sorted([(pidx, pval), (idx, val)])
+            if (a[0], a[1], b[0], b[1]) in uncovered:
+                gain += 1
+        if gain > best_gain:
+            best_gain, best_val = gain, val
+    return best_val
+
+
+def all_pairs(dims: dict[str, list[str]]) -> list[dict[str, str]]:
+    """Return AETG-style greedy all-pairs rows ({dim: value})."""
+    names = list(dims)
+    uncovered: set[tuple[int, str, int, str]] = set()
+    for i, j in itertools.combinations(range(len(names)), 2):
+        for vi in dims[names[i]]:
+            for vj in dims[names[j]]:
+                uncovered.add((i, vi, j, vj))
+
+    rows = []
+    while uncovered:
+        si, sv, sj, sv2 = min(uncovered)
+        row = {si: sv, sj: sv2}
+        for idx, name in enumerate(names):
+            if idx not in row:
+                row[idx] = _best_value(dims[name], idx, row, uncovered)
+        for i, j in itertools.combinations(sorted(row), 2):
+            uncovered.discard((i, row[i], j, row[j]))
+        rows.append({names[k]: v for k, v in row.items()})
+    return rows
+
+
+def payloads(v: Mapping[str, object]) -> dict[str, object]:
+    """Expand an LPC-2 row into real tfvars."""
+    out: dict[str, object] = {
+        "request_headers_to_add": [],
+        "request_headers_to_remove": [],
+        "response_headers_to_add": [],
+        "response_headers_to_remove": [],
+        "request_cookies_to_remove": [],
+        "response_cookies_to_remove": [],
+    }
+    if v["req"] == "add":
+        out["request_headers_to_add"] = [
+            {"name": "x-env", "value": "prod", "append": True}
+        ]
+    elif v["req"] == "remove":
+        out["request_headers_to_remove"] = ["x-internal"]
+    if v["resp"] == "add":
+        out["response_headers_to_add"] = [{"name": "x-frame-options", "value": "DENY"}]
+    elif v["resp"] == "remove":
+        out["response_headers_to_remove"] = ["server"]
+    if v["cookies"] == "remove":
+        out["request_cookies_to_remove"] = ["tracking"]
+        out["response_cookies_to_remove"] = ["debug"]
+    return out
+
+
+def canonical() -> dict[str, object]:
+    """Live-canonical end state (more_option off)."""
+    return {
+        "request_headers_to_add": [],
+        "request_headers_to_remove": [],
+        "response_headers_to_add": [],
+        "response_headers_to_remove": [],
+        "request_cookies_to_remove": [],
+        "response_cookies_to_remove": [],
+    }
+
+
+def build() -> list[dict[str, object]]:
+    """Build the ordered variant manifest (all-pairs + canonical), deduped."""
+    variants: list[dict[str, object]] = []
+    seen: set[str] = set()
+    idx = 0
+    for row in all_pairs(DIMENSIONS):
+        if row["req"] == "none" and row["resp"] == "none" and row["cookies"] == "none":
+            continue
+        vars_ = payloads(row)
+        key = json.dumps(vars_, sort_keys=True)
+        if key in seen:
+            continue
+        seen.add(key)
+        variants.append({"name": f"pair-{idx:03d}", "vars": vars_})
+        idx += 1
+    variants.append({"name": "canonical-restore", "vars": canonical()})
+    return variants
+
+
+def emit(directory: str) -> int:
+    """Write one <NNN>-<name>.tfvars.json per variant plus manifest.txt."""
+    out_dir = Path(directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for existing in out_dir.iterdir():
+        if existing.name.endswith(".tfvars.json") or existing.name == "manifest.txt":
+            existing.unlink()
+    variants = build()
+    named = [(f"{i:03d}-{v['name']}.tfvars.json", v) for i, v in enumerate(variants)]
+    for fname, v in named:
+        (out_dir / fname).write_text(json.dumps(v["vars"], indent=2) + "\n")
+    lines = [f"{i:03d} {v['name']} {fname} LIVE" for i, (fname, v) in enumerate(named)]
+    (out_dir / "manifest.txt").write_text("\n".join(lines) + "\n")
+    return len(variants)
+
+
+def main(argv: list[str]) -> None:
+    """CLI: --count, --emit <dir>, else JSON to stdout."""
+    match argv[1:]:
+        case ["--count"]:
+            sys.stdout.write(f"{len(build())}\n")
+        case ["--emit", directory]:
+            sys.stdout.write(f"{emit(directory)}\n")
+        case _:
+            json.dump(build(), sys.stdout, indent=2)
+            sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -179,12 +179,13 @@ module "http_lb" {
   protected_cookies   = var.protected_cookies
 
   # Header/cookie manipulation (LPC-2) passthrough.
-  request_headers_to_add     = var.request_headers_to_add
-  request_headers_to_remove  = var.request_headers_to_remove
-  response_headers_to_add    = var.response_headers_to_add
-  response_headers_to_remove = var.response_headers_to_remove
-  request_cookies_to_remove  = var.request_cookies_to_remove
-  response_cookies_to_remove = var.response_cookies_to_remove
+  request_headers_to_add      = var.request_headers_to_add
+  request_headers_to_remove   = var.request_headers_to_remove
+  response_headers_to_add     = var.response_headers_to_add
+  response_headers_to_remove  = var.response_headers_to_remove
+  request_cookies_to_remove   = var.request_cookies_to_remove
+  response_cookies_to_remove  = var.response_cookies_to_remove
+  disable_default_error_pages = var.disable_default_error_pages
 
   # API Testing (SP4) passthrough. Defaults keep it off (disable_api_testing
   # suppressed => 0-change) and create no standalone resource.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -178,6 +178,14 @@ module "http_lb" {
   csrf_custom_domains = var.csrf_custom_domains
   protected_cookies   = var.protected_cookies
 
+  # Header/cookie manipulation (LPC-2) passthrough.
+  request_headers_to_add     = var.request_headers_to_add
+  request_headers_to_remove  = var.request_headers_to_remove
+  response_headers_to_add    = var.response_headers_to_add
+  response_headers_to_remove = var.response_headers_to_remove
+  request_cookies_to_remove  = var.request_cookies_to_remove
+  response_cookies_to_remove = var.response_cookies_to_remove
+
   # API Testing (SP4) passthrough. Defaults keep it off (disable_api_testing
   # suppressed => 0-change) and create no standalone resource.
   api_testing_choice              = var.api_testing_choice

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -1460,6 +1460,34 @@ resource "xcsh_http_loadbalancer" "this" {
     }
   }
 
+  # Header/cookie manipulation (LPC-2) via more_option. Emitted only when a header/cookie
+  # list is set (0-change otherwise); *_to_remove lists null-when-empty.
+  dynamic "more_option" {
+    for_each = (length(var.request_headers_to_add) + length(var.request_headers_to_remove) + length(var.response_headers_to_add) + length(var.response_headers_to_remove) + length(var.request_cookies_to_remove) + length(var.response_cookies_to_remove)) > 0 ? [1] : []
+    content {
+      dynamic "request_headers_to_add" {
+        for_each = var.request_headers_to_add
+        content {
+          name   = request_headers_to_add.value.name
+          value  = request_headers_to_add.value.value
+          append = request_headers_to_add.value.append
+        }
+      }
+      request_headers_to_remove = length(var.request_headers_to_remove) > 0 ? var.request_headers_to_remove : null
+      dynamic "response_headers_to_add" {
+        for_each = var.response_headers_to_add
+        content {
+          name   = response_headers_to_add.value.name
+          value  = response_headers_to_add.value.value
+          append = response_headers_to_add.value.append
+        }
+      }
+      response_headers_to_remove = length(var.response_headers_to_remove) > 0 ? var.response_headers_to_remove : null
+      request_cookies_to_remove  = length(var.request_cookies_to_remove) > 0 ? var.request_cookies_to_remove : null
+      response_cookies_to_remove = length(var.response_cookies_to_remove) > 0 ? var.response_cookies_to_remove : null
+    }
+  }
+
   # API protection rules (Coverage Batch D) — allow/deny access to API endpoints
   # (api_endpoint_rules) or API groups / base paths (api_groups_rules), each scoped by
   # a PER-RULE client_matcher (full oneof) + request_matcher. Omitted when both lists

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -1463,7 +1463,7 @@ resource "xcsh_http_loadbalancer" "this" {
   # Header/cookie manipulation (LPC-2) via more_option. Emitted only when a header/cookie
   # list is set (0-change otherwise); *_to_remove lists null-when-empty.
   dynamic "more_option" {
-    for_each = (length(var.request_headers_to_add) + length(var.request_headers_to_remove) + length(var.response_headers_to_add) + length(var.response_headers_to_remove) + length(var.request_cookies_to_remove) + length(var.response_cookies_to_remove)) > 0 ? [1] : []
+    for_each = (length(var.request_headers_to_add) + length(var.request_headers_to_remove) + length(var.response_headers_to_add) + length(var.response_headers_to_remove) + length(var.request_cookies_to_remove) + length(var.response_cookies_to_remove)) > 0 || var.disable_default_error_pages ? [1] : []
     content {
       dynamic "request_headers_to_add" {
         for_each = var.request_headers_to_add
@@ -1482,9 +1482,10 @@ resource "xcsh_http_loadbalancer" "this" {
           append = response_headers_to_add.value.append
         }
       }
-      response_headers_to_remove = length(var.response_headers_to_remove) > 0 ? var.response_headers_to_remove : null
-      request_cookies_to_remove  = length(var.request_cookies_to_remove) > 0 ? var.request_cookies_to_remove : null
-      response_cookies_to_remove = length(var.response_cookies_to_remove) > 0 ? var.response_cookies_to_remove : null
+      response_headers_to_remove  = length(var.response_headers_to_remove) > 0 ? var.response_headers_to_remove : null
+      request_cookies_to_remove   = length(var.request_cookies_to_remove) > 0 ? var.request_cookies_to_remove : null
+      response_cookies_to_remove  = length(var.response_cookies_to_remove) > 0 ? var.response_cookies_to_remove : null
+      disable_default_error_pages = var.disable_default_error_pages
     }
   }
 

--- a/terraform/modules/http-lb/variables_header_manipulation.tf
+++ b/terraform/modules/http-lb/variables_header_manipulation.tf
@@ -45,3 +45,9 @@ variable "response_cookies_to_remove" {
   type        = list(string)
   default     = []
 }
+
+variable "disable_default_error_pages" {
+  description = "Disable the LB's default error pages (more_option.disable_default_error_pages). Emitted inside more_option (server default false); set true to disable."
+  type        = bool
+  default     = false
+}

--- a/terraform/modules/http-lb/variables_header_manipulation.tf
+++ b/terraform/modules/http-lb/variables_header_manipulation.tf
@@ -1,0 +1,47 @@
+# Header/cookie manipulation (LPC-2) via the LB top-level more_option block: add/remove
+# request and response headers (and cookies). secret_value (blindfold-sealed header value)
+# is deferred. Defaults create nothing and emit no more_option block (0-change).
+
+variable "request_headers_to_add" {
+  description = "Request headers to add/append toward the origin (more_option.request_headers_to_add)."
+  type = list(object({
+    name   = string
+    value  = string
+    append = optional(bool, false)
+  }))
+  default = []
+}
+
+variable "request_headers_to_remove" {
+  description = "Request header names to remove toward the origin."
+  type        = list(string)
+  default     = []
+}
+
+variable "response_headers_to_add" {
+  description = "Response headers to add/append toward the client (more_option.response_headers_to_add)."
+  type = list(object({
+    name   = string
+    value  = string
+    append = optional(bool, false)
+  }))
+  default = []
+}
+
+variable "response_headers_to_remove" {
+  description = "Response header names to remove toward the client."
+  type        = list(string)
+  default     = []
+}
+
+variable "request_cookies_to_remove" {
+  description = "Request cookie names to remove toward the origin (more_option.request_cookies_to_remove)."
+  type        = list(string)
+  default     = []
+}
+
+variable "response_cookies_to_remove" {
+  description = "Response cookie names to remove toward the client (more_option.response_cookies_to_remove)."
+  type        = list(string)
+  default     = []
+}

--- a/terraform/modules/http-lb/versions.tf
+++ b/terraform/modules/http-lb/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     xcsh = {
       source  = "f5-sales-demo/xcsh"
-      version = ">= 3.72.5"
+      version = ">= 3.72.6"
     }
   }
 }

--- a/terraform/tests/header_manipulation.tftest.hcl
+++ b/terraform/tests/header_manipulation.tftest.hcl
@@ -1,0 +1,61 @@
+# Plan-level tests for header/cookie manipulation (LPC-2): more_option request/response
+# headers add/remove + cookies remove. Targets ./modules/http-lb. command = plan (no creds).
+variables {
+  namespace         = "webapp-api-protection"
+  lb_domains        = ["www.f5-sales-demo.com"]
+  origin_ip         = "203.0.113.10"
+  origin_port       = 80
+  health_check_path = "/health"
+  labels            = {}
+  csd_enabled       = false
+  mud_enabled       = false
+}
+
+run "headers_add_remove_render" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    request_headers_to_add     = [{ name = "x-env", value = "prod", append = true }]
+    response_headers_to_add    = [{ name = "x-frame-options", value = "DENY" }]
+    request_headers_to_remove  = ["x-internal"]
+    response_headers_to_remove = ["server"]
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.more_option.request_headers_to_add[0].name == "x-env"
+    error_message = "request_headers_to_add must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.more_option.request_headers_to_add[0].append == true
+    error_message = "request_headers_to_add append must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.more_option.response_headers_to_add[0].value == "DENY"
+    error_message = "response_headers_to_add must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.more_option.response_headers_to_remove[0] == "server"
+    error_message = "response_headers_to_remove must render"
+  }
+}
+
+run "cookies_remove_render" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    request_cookies_to_remove  = ["tracking"]
+    response_cookies_to_remove = ["debug"]
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.more_option.request_cookies_to_remove[0] == "tracking"
+    error_message = "request_cookies_to_remove must render"
+  }
+}
+
+run "more_option_omitted_by_default" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.more_option == null
+    error_message = "more_option must be omitted (null) by default"
+  }
+}

--- a/terraform/tests/header_manipulation.tftest.hcl
+++ b/terraform/tests/header_manipulation.tftest.hcl
@@ -59,3 +59,13 @@ run "more_option_omitted_by_default" {
     error_message = "more_option must be omitted (null) by default"
   }
 }
+
+run "disable_default_error_pages_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { disable_default_error_pages = true }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.more_option.disable_default_error_pages == true
+    error_message = "disable_default_error_pages must render inside more_option"
+  }
+}

--- a/terraform/variables_header_manipulation.tf
+++ b/terraform/variables_header_manipulation.tf
@@ -1,0 +1,33 @@
+# Root passthrough for header/cookie manipulation (LPC-2) to modules/http-lb. Object lists
+# use type = any (shape lives in the module). Defaults = 0-change.
+
+variable "request_headers_to_add" {
+  description = "Request headers to add (see module for shape)."
+  type        = any
+  default     = []
+}
+variable "request_headers_to_remove" {
+  description = "Request header names to remove."
+  type        = list(string)
+  default     = []
+}
+variable "response_headers_to_add" {
+  description = "Response headers to add (see module for shape)."
+  type        = any
+  default     = []
+}
+variable "response_headers_to_remove" {
+  description = "Response header names to remove."
+  type        = list(string)
+  default     = []
+}
+variable "request_cookies_to_remove" {
+  description = "Request cookie names to remove."
+  type        = list(string)
+  default     = []
+}
+variable "response_cookies_to_remove" {
+  description = "Response cookie names to remove."
+  type        = list(string)
+  default     = []
+}

--- a/terraform/variables_header_manipulation.tf
+++ b/terraform/variables_header_manipulation.tf
@@ -31,3 +31,9 @@ variable "response_cookies_to_remove" {
   type        = list(string)
   default     = []
 }
+
+variable "disable_default_error_pages" {
+  description = "Disable the LB's default error pages (more_option)."
+  type        = bool
+  default     = false
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -46,7 +46,10 @@ terraform {
       # request_constraints bases) on import. Live GET proved only any_server/any_client/
       # any_asn/any_ip are echoed-on-omit; v3.72.5 suppresses just those, so a rule_list
       # rule (which must declare waf_action { none {} }) round-trip-imports clean.
-      version = ">= 3.72.5"
+      # >= 3.72.6: LPC-2 more_option import suppressions (provider #1125) — custom_errors /
+      # no_request_limit_per_connection empty markers, so a more_option header config
+      # round-trip-imports clean.
+      version = ">= 3.72.6"
     }
     # Azure providers: this plan also deploys its OWN Azure origin server and
     # traffic generator (modules/origin-server, modules/traffic-generator), which


### PR DESCRIPTION
Closes #99. Slice 2 of #70.

## What
LB `more_option` header/cookie manipulation — request/response `headers_to_add[]{name,value,append}` + `headers_to_remove[]`, request/response `cookies_to_remove[]`, and `disable_default_error_pages`. Requires provider **v3.72.6** (#1125) which seeds the `more_option` `custom_errors` / `no_request_limit_per_connection` import suppressions.

## Verification (live, f5-sales-demo)
- `terraform test` — **4 plan-tests pass**.
- Live AETG matrix **9/9** on v3.72.6: apply → re-plan 0-change → import LB → re-plan **0-change** + canonical restore.
- **Behavioral**: applied `response_headers_to_add` → `x-frame-options: DENY` present in the LB response; restored.
- Local gates: fmt / ruff / shellcheck / jscpd (8.66%) / codespell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)