### PR TITLE
LPC-3: JWT validation (inline JWKS) + GraphQL inspection rules

### DIFF
--- a/scripts/jwt-graphql-matrix.sh
+++ b/scripts/jwt-graphql-matrix.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# JWT validation + GraphQL inspection (LPC-3) live coverage-matrix harness.
+#
+# Cycles the LIVE webapp-api-protection LB through the jwt_graphql_pairs variant set and
+# verifies each variant (a) applies, (b) is idempotent (immediate plan = No changes), and
+# (c) is round-trip-import clean for the LB (state rm -> import -> plan clean). Both features
+# are LB-nested, so the import target is the http_loadbalancer itself. Ends on
+# canonical-restore so the live LB is left healthy (jwt + graphql off). Results append to
+# reports/jwt-graphql-matrix.txt.
+#
+# The JWKS is a public RSA key and the graphql rules only add inspection limits, so no real
+# client traffic is ever blocked and the LB stays serving throughout. An arm F5 XC rejects for
+# entitlement is recorded SKIP (word signals; a bare status number is not matched) rather than
+# FAIL. Sequential — no concurrent terraform against the shared azurerm state.
+#
+# Usage: jwt-graphql-matrix.sh [START [END]]  (inclusive 0-based index range).
+set -uo pipefail
+
+umask 077
+trap 'rm -rf /tmp/lpc3-variants 2>/dev/null; rm -f /tmp/lpc3-*.log 2>/dev/null' EXIT
+
+cd "$(dirname "$0")/../terraform" || exit 1
+ARM_ACCESS_KEY=$(az storage account keys list -n f5salesdemotfstate -g f5-sales-demo-tfstate --query "[0].value" -o tsv)
+export ARM_ACCESS_KEY
+
+NS="webapp-api-protection"
+LB_ADDR="module.http_lb.xcsh_http_loadbalancer.this"
+LB_ID="${NS}/${NS}"
+COMMON=(-input=false -lock=true
+  -var 'lb_domains=["www.f5-sales-demo.com","api.f5-sales-demo.com"]'
+  -var 'subscription_id=75f86c46-9cbc-4f6c-85ea-195e3d3c8ac0')
+VARDIR=/tmp/lpc3-variants
+REPORT=../reports/jwt-graphql-matrix.txt
+mkdir -p ../reports
+
+START="${1:-0}"
+END="${2:-9999}"
+GATED_RE='entitlement|not subscribed|not entitled|not enabled for|permission denied|unauthorized|AS_NOT_SUBSCRIBED|status: 401|status: 403'
+
+[ "$#" -eq 0 ] && : >"$REPORT"
+
+count=$(python3 ../scripts/jwt_graphql_pairs.py --emit "$VARDIR")
+echo "generated $count variants into $VARDIR (running [$START..$END])"
+
+round_trip() {
+  local label="$1" vf="$2" flag="$3"
+  terraform state rm "$LB_ADDR" >/dev/null 2>&1 || {
+    echo "FAIL $label lb-state-rm" >>"$REPORT"
+    return
+  }
+  terraform import "${COMMON[@]}" -var-file="$vf" "$LB_ADDR" "$LB_ID" >/tmp/lpc3-import.log 2>&1 || {
+    echo "FAIL $label lb-import ($(grep -iE 'error' /tmp/lpc3-import.log | head -1 | cut -c1-70))" >>"$REPORT"
+    return
+  }
+  if [ "$flag" = "SECRET" ]; then
+    # jwt_validation.jwks_config.cleartext is a write-only secret the API masks as "Redacted",
+    # so import always re-applies it. PASS if that secret is the ONLY meaningful LB drift
+    # (any other changed leaf is a real import bug); classified from the plan JSON.
+    terraform plan -out=/tmp/lpc3-rt.tfplan "${COMMON[@]}" -var-file="$vf" >/tmp/lpc3-rt-plan.log 2>&1 || {
+      echo "FAIL $label rt-plan-error" >>"$REPORT"
+      return
+    }
+    terraform show -json /tmp/lpc3-rt.tfplan >/tmp/lpc3-rt.json 2>/dev/null
+    if python3 ../scripts/lpc3_import_check.py /tmp/lpc3-rt.json >/tmp/lpc3-classify.log 2>&1; then
+      echo "PASS $label (secret re-apply expected)" >>"$REPORT"
+    else
+      echo "FAIL $label import-drift ($(grep -v 'unexpected' /tmp/lpc3-classify.log | head -1 | tr -s ' '))" >>"$REPORT"
+    fi
+    return
+  fi
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$vf" >/tmp/lpc3-rt-plan.log 2>&1
+  case $? in
+  0) echo "PASS $label" >>"$REPORT" ;;
+  2) echo "FAIL $label import-drift" >>"$REPORT" ;;
+  *) echo "FAIL $label rt-plan-error" >>"$REPORT" ;;
+  esac
+}
+
+while read -r idx name vf flag; do
+  [ "$idx" -lt "$START" ] && continue
+  [ "$idx" -gt "$END" ] && continue
+  label="$idx-$name"
+  echo "--- $label ---"
+  varfile="${VARDIR}/${vf}"
+  if ! terraform apply -auto-approve "${COMMON[@]}" -var-file="$varfile" >/tmp/lpc3-apply.log 2>&1; then
+    if grep -qiE "$GATED_RE" /tmp/lpc3-apply.log; then
+      echo "SKIP $label gated-arm ($(grep -oiE "$GATED_RE" /tmp/lpc3-apply.log | head -1))" >>"$REPORT"
+    else
+      echo "FAIL $label apply ($(grep -iE 'error' /tmp/lpc3-apply.log | head -1 | cut -c1-80))" >>"$REPORT"
+    fi
+    continue
+  fi
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$varfile" >/tmp/lpc3-plan.log 2>&1
+  case $? in
+  0) round_trip "$label" "$varfile" "$flag" ;;
+  2) echo "FAIL $label not-idempotent" >>"$REPORT" ;;
+  *) echo "FAIL $label plan-error" >>"$REPORT" ;;
+  esac
+done <"${VARDIR}/manifest.txt"
+
+echo "===== JWT + GRAPHQL MATRIX RESULTS ($START..$END) ====="
+cat "$REPORT"
+echo "PASS=$(grep -c '^PASS ' "$REPORT") FAIL=$(grep -c '^FAIL ' "$REPORT") SKIP=$(grep -c '^SKIP ' "$REPORT")"

--- a/scripts/jwt_graphql_pairs.py
+++ b/scripts/jwt_graphql_pairs.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Generate the JWT validation + GraphQL inspection (LPC-3) coverage matrix.
+
+AETG all-pairs over the jwt_validation arms and the graphql_rules arms, each variant applied
+to the LIVE LB. Plus canonical-restore (both off).
+
+Dimensions:
+  jwt  none | block_all | report_paths
+       none         -> no jwt_validation
+       block_all    -> action=block, target=all_endpoint, issuer+audiences+validate_period
+       report_paths -> action=report, target=base_paths, mandatory_claims, issuer_disable
+  gql  none | any_post | exact_get
+       none      -> no graphql_rules
+       any_post  -> domain=any, method=post, introspection=disable, depth/length limits
+       exact_get -> domain=exact, method=get, introspection=enable, batched-queries limit
+
+The JWKS is a readable JSON document (RFC 7517); the module base64-encodes it for the API
+(F5 XC validates the "cleartext" field as base64). Embedded key below is a public RSA JWKS.
+
+Deterministic (no RNG). Output: JSON to stdout, or files via --emit.
+"""
+
+import itertools
+import json
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+# A valid public RSA JWKS (RFC 7517). Public key material only — safe to embed.
+JWKS = json.dumps(
+    {
+        "keys": [
+            {
+                "kty": "RSA",
+                "use": "sig",
+                "kid": "webapp-test-1",
+                "alg": "RS256",
+                "n": (
+                    "oXkqKtCbRs88qF3SyyWysA5vXHXsdPheDF0pbJz_AG3FGbDriytdB8UR"
+                    "ONeNyhfO_ad3kucemewL4b0EQfopAR5LEPOIWmnmjhTnQB7a3YP1C-HQ"
+                    "yrWoQ_xNI9mXuhwcns65Ry-gZc2FFvGGdwJykDBPzDG4AVXNdAwzffWg"
+                    "FYXf903vKewC-mHsHuZuZkmEHOg3RXIgtY0dSpIFwH_QYyQl1HCZCWtN"
+                    "bp4yWZy0Pi8yAt-zcfze516-XxywCJiJ61KLCE0RwyIzZ1PpZlyCK0TQ"
+                    "tRF94N-A0b1Ws4IOfQ-QOanBWS5bC-Q7N7SaoUHEDmUJlnQS7hJZWOKV"
+                    "fn8jPQ"
+                ),
+                "e": "AQAB",
+            }
+        ]
+    }
+)
+
+DIMENSIONS = {
+    "jwt": ["none", "block_all", "report_paths"],
+    "gql": ["none", "any_post", "exact_get"],
+}
+
+
+def _best_value(
+    values: list[str],
+    idx: int,
+    row: dict[int, str],
+    uncovered: set[tuple[int, str, int, str]],
+) -> str:
+    """Pick the value for dimension idx covering the most still-uncovered pairs."""
+    best_val, best_gain = values[0], -1
+    for val in values:
+        gain = 0
+        for pidx, pval in row.items():
+            a, b = sorted([(pidx, pval), (idx, val)])
+            if (a[0], a[1], b[0], b[1]) in uncovered:
+                gain += 1
+        if gain > best_gain:
+            best_gain, best_val = gain, val
+    return best_val
+
+
+def all_pairs(dims: dict[str, list[str]]) -> list[dict[str, str]]:
+    """Return AETG-style greedy all-pairs rows ({dim: value})."""
+    names = list(dims)
+    uncovered: set[tuple[int, str, int, str]] = set()
+    for i, j in itertools.combinations(range(len(names)), 2):
+        for vi in dims[names[i]]:
+            for vj in dims[names[j]]:
+                uncovered.add((i, vi, j, vj))
+
+    rows = []
+    while uncovered:
+        si, sv, sj, sv2 = min(uncovered)
+        row = {si: sv, sj: sv2}
+        for idx, name in enumerate(names):
+            if idx not in row:
+                row[idx] = _best_value(dims[name], idx, row, uncovered)
+        for i, j in itertools.combinations(sorted(row), 2):
+            uncovered.discard((i, row[i], j, row[j]))
+        rows.append({names[k]: v for k, v in row.items()})
+    return rows
+
+
+def _jwt(kind: str) -> object:
+    """Expand a jwt dimension value into the jwt_validation object (or None)."""
+    if kind == "block_all":
+        return {
+            "jwks_cleartext": JWKS,
+            "action": "block",
+            "target": "all_endpoint",
+            "issuer": "https://issuer.example.com",
+            "audiences": ["api://webapp"],
+            "validate_period": True,
+        }
+    if kind == "report_paths":
+        # issuer omitted -> issuer_disable derived; audiences omitted -> audience_disable derived.
+        return {
+            "jwks_cleartext": JWKS,
+            "action": "report",
+            "target": "base_paths",
+            "base_paths": ["/api"],
+            "mandatory_claims": ["sub", "iat"],
+            "validate_period": False,
+        }
+    return None
+
+
+def _gql(kind: str) -> list[dict[str, object]]:
+    """Expand a gql dimension value into the graphql_rules list."""
+    if kind == "any_post":
+        return [
+            {
+                "name": "gql-any",
+                "exact_path": "/graphql",
+                "domain": "any",
+                "method": "post",
+                "max_depth": 10,
+                "max_total_length": 4096,
+                "introspection": "disable",
+            }
+        ]
+    if kind == "exact_get":
+        return [
+            {
+                "name": "gql-exact",
+                "exact_path": "/graphql",
+                "domain": "exact",
+                "domain_value": "api.f5-sales-demo.com",
+                "method": "get",
+                "max_batched_queries": 5,
+                "introspection": "enable",
+            }
+        ]
+    return []
+
+
+def payloads(v: Mapping[str, object]) -> dict[str, object]:
+    """Expand an LPC-3 row into real tfvars."""
+    return {"jwt_validation": _jwt(str(v["jwt"])), "graphql_rules": _gql(str(v["gql"]))}
+
+
+def canonical() -> dict[str, object]:
+    """Live-canonical end state (jwt off, graphql off)."""
+    return {"jwt_validation": None, "graphql_rules": []}
+
+
+def build() -> list[dict[str, object]]:
+    """Build the ordered variant manifest (all-pairs + canonical), deduped."""
+    variants: list[dict[str, object]] = []
+    seen: set[str] = set()
+    idx = 0
+    for row in all_pairs(DIMENSIONS):
+        if row["jwt"] == "none" and row["gql"] == "none":
+            continue
+        vars_ = payloads(row)
+        key = json.dumps(vars_, sort_keys=True)
+        if key in seen:
+            continue
+        seen.add(key)
+        variants.append({"name": f"pair-{idx:03d}", "vars": vars_})
+        idx += 1
+    variants.append({"name": "canonical-restore", "vars": canonical()})
+    return variants
+
+
+def emit(directory: str) -> int:
+    """Write one <NNN>-<name>.tfvars.json per variant plus manifest.txt."""
+    out_dir = Path(directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for existing in out_dir.iterdir():
+        if existing.name.endswith(".tfvars.json") or existing.name == "manifest.txt":
+            existing.unlink()
+    variants = build()
+    named = [(f"{i:03d}-{v['name']}.tfvars.json", v) for i, v in enumerate(variants)]
+    for fname, v in named:
+        (out_dir / fname).write_text(json.dumps(v["vars"], indent=2) + "\n")
+    # jwt-bearing variants carry a write-only secret (jwks_config.cleartext) the API masks as
+    # "Redacted"; their whole-LB import re-applies it (expected). Flag SECRET so the runner
+    # classifies the round-trip via lpc3_import_check.py instead of demanding a 0-change plan.
+    def flag(variant: dict[str, object]) -> str:
+        vars_ = variant["vars"]
+        return "SECRET" if isinstance(vars_, dict) and vars_.get("jwt_validation") else "LIVE"
+
+    lines = [f"{i:03d} {v['name']} {fname} {flag(v)}" for i, (fname, v) in enumerate(named)]
+    (out_dir / "manifest.txt").write_text("\n".join(lines) + "\n")
+    return len(variants)
+
+
+def main(argv: list[str]) -> None:
+    """CLI: --count, --emit <dir>, else JSON to stdout."""
+    match argv[1:]:
+        case ["--count"]:
+            sys.stdout.write(f"{len(build())}\n")
+        case ["--emit", directory]:
+            sys.stdout.write(f"{emit(directory)}\n")
+        case _:
+            json.dump(build(), sys.stdout, indent=2)
+            sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/scripts/jwt_graphql_pairs.py
+++ b/scripts/jwt_graphql_pairs.py
@@ -190,14 +190,21 @@ def emit(directory: str) -> int:
     named = [(f"{i:03d}-{v['name']}.tfvars.json", v) for i, v in enumerate(variants)]
     for fname, v in named:
         (out_dir / fname).write_text(json.dumps(v["vars"], indent=2) + "\n")
+
     # jwt-bearing variants carry a write-only secret (jwks_config.cleartext) the API masks as
     # "Redacted"; their whole-LB import re-applies it (expected). Flag SECRET so the runner
     # classifies the round-trip via lpc3_import_check.py instead of demanding a 0-change plan.
     def flag(variant: dict[str, object]) -> str:
         vars_ = variant["vars"]
-        return "SECRET" if isinstance(vars_, dict) and vars_.get("jwt_validation") else "LIVE"
+        return (
+            "SECRET"
+            if isinstance(vars_, dict) and vars_.get("jwt_validation")
+            else "LIVE"
+        )
 
-    lines = [f"{i:03d} {v['name']} {fname} {flag(v)}" for i, (fname, v) in enumerate(named)]
+    lines = [
+        f"{i:03d} {v['name']} {fname} {flag(v)}" for i, (fname, v) in enumerate(named)
+    ]
     (out_dir / "manifest.txt").write_text("\n".join(lines) + "\n")
     return len(variants)
 

--- a/scripts/lpc3_import_check.py
+++ b/scripts/lpc3_import_check.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Classify a whole-LB import round-trip plan for LPC-3 SECRET variants.
+
+jwt_validation.jwks_config.cleartext is a write-only secret: the F5 XC API masks it as
+"Redacted" on read, so after `state rm` + `import` the next plan always re-applies the real
+value (a 1-change that cannot be avoided — same class as other clear secrets). That single
+re-apply is EXPECTED; any OTHER meaningful (known-value) drift on the LB is a real import bug.
+
+This reads `terraform show -json <planfile>` and prints the meaningful config-driven changes
+on module.http_lb.xcsh_http_loadbalancer.this, excluding:
+  - the allowed jwks_config.cleartext secret re-apply, and
+  - computed values the plan marks unknown (after_unknown — e.g. ref tenant recompute).
+
+Exit 0 if nothing unexpected changed (import round-trip clean modulo the secret); exit 1 and
+list the offending paths otherwise.
+
+Usage: lpc3_import_check.py <plan.json>
+"""
+
+import json
+import sys
+from pathlib import Path
+
+LB_ADDR = "module.http_lb.xcsh_http_loadbalancer.this"
+EXPECTED_ARGC = 2
+
+
+def flatten(obj: object, prefix: str = "") -> dict[str, object]:
+    """Flatten nested dict/list into dotted paths -> scalar leaves.
+
+    An empty dict/list emits a presence sentinel at its own path so that empty-marker oneof
+    arms (e.g. action.block {}, target.all_endpoint {}) are detectable — otherwise flipping
+    between two empty-marker arms would produce no leaves and hide a real import drift.
+    """
+    out: dict[str, object] = {}
+    if isinstance(obj, dict):
+        if not obj and prefix:
+            out[prefix] = "<empty>"
+        for k, v in obj.items():
+            out.update(flatten(v, f"{prefix}.{k}" if prefix else k))
+    elif isinstance(obj, list):
+        if not obj and prefix:
+            out[prefix] = "<empty>"
+        for i, v in enumerate(obj):
+            out.update(flatten(v, f"{prefix}[{i}]"))
+    else:
+        out[prefix] = obj
+    return out
+
+
+def unknown_paths(obj: object, prefix: str = "") -> set[str]:
+    """Collect dotted paths the plan marks unknown (True leaves in after_unknown)."""
+    paths: set[str] = set()
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            paths |= unknown_paths(v, f"{prefix}.{k}" if prefix else k)
+    elif isinstance(obj, list):
+        for i, v in enumerate(obj):
+            paths |= unknown_paths(v, f"{prefix}[{i}]")
+    elif obj is True:
+        paths.add(prefix)
+    return paths
+
+
+def meaningful_changes(change: dict[str, object]) -> list[str]:
+    """Return LB leaf paths that changed to a KNOWN value (excludes computed-unknown)."""
+    before = flatten(change.get("before") or {})
+    after = flatten(change.get("after") or {})
+    unknown = unknown_paths(change.get("after_unknown") or {})
+    changed = [
+        path
+        for path, aval in after.items()
+        if path not in unknown and before.get(path) != aval
+    ]
+    # deletions (present before, absent after and not unknown)
+    changed.extend(p for p in before if p not in after and p not in unknown)
+    return changed
+
+
+def is_allowed(path: str) -> bool:
+    """The one expected write-only-secret re-apply."""
+    return path.endswith("jwks_config.cleartext") or "jwks_config.cleartext" in path
+
+
+def main(argv: list[str]) -> int:
+    """Parse the plan JSON and report unexpected LB drift."""
+    if len(argv) != EXPECTED_ARGC:
+        sys.stderr.write("usage: lpc3_import_check.py <plan.json>\n")
+        return 2
+    plan = json.loads(Path(argv[1]).read_text())
+    rc = next(
+        (r for r in plan.get("resource_changes", []) if r.get("address") == LB_ADDR),
+        None,
+    )
+    if rc is None:
+        sys.stderr.write(f"LB resource_change {LB_ADDR} not found in plan\n")
+        return 1
+    unexpected = [p for p in meaningful_changes(rc["change"]) if not is_allowed(p)]
+    if unexpected:
+        sys.stderr.write("unexpected import drift on LB:\n")
+        for p in sorted(unexpected):
+            sys.stderr.write(f"  {p}\n")
+        return 1
+    sys.stdout.write("import clean modulo jwks_config.cleartext secret\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -187,6 +187,10 @@ module "http_lb" {
   response_cookies_to_remove  = var.response_cookies_to_remove
   disable_default_error_pages = var.disable_default_error_pages
 
+  # GraphQL inspection (LPC-3) passthrough.
+  graphql_rules  = var.graphql_rules
+  jwt_validation = var.jwt_validation
+
   # API Testing (SP4) passthrough. Defaults keep it off (disable_api_testing
   # suppressed => 0-change) and create no standalone resource.
   api_testing_choice              = var.api_testing_choice

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -1489,6 +1489,125 @@ resource "xcsh_http_loadbalancer" "this" {
     }
   }
 
+  # JWT validation (LPC-3) — inline JWKS (jwks_config.cleartext); action block/report;
+  # target all_endpoint|api_groups|base_paths; reserved/mandatory claims. Omitted when null.
+  dynamic "jwt_validation" {
+    for_each = var.jwt_validation != null ? [1] : []
+    content {
+      jwks_config {
+        # F5 XC quirk: the API field is named "cleartext" but the server validates it as
+        # base64-decoded JWKS ("failed to decode base64 cleartext JWKS" 500 otherwise). The
+        # variable takes a readable JWKS JSON document; encode it here for the API.
+        cleartext = base64encode(var.jwt_validation.jwks_cleartext)
+      }
+      action {
+        dynamic "block" {
+          for_each = var.jwt_validation.action == "block" ? [1] : []
+          content {}
+        }
+        dynamic "report" {
+          for_each = var.jwt_validation.action == "report" ? [1] : []
+          content {}
+        }
+      }
+      token_location {
+        bearer_token {}
+      }
+      target {
+        dynamic "all_endpoint" {
+          for_each = var.jwt_validation.target == "all_endpoint" ? [1] : []
+          content {}
+        }
+        dynamic "api_groups" {
+          for_each = var.jwt_validation.target == "api_groups" ? [1] : []
+          content {
+            api_groups = var.jwt_validation.api_groups
+          }
+        }
+        dynamic "base_paths" {
+          for_each = var.jwt_validation.target == "base_paths" ? [1] : []
+          content {
+            base_paths = var.jwt_validation.base_paths
+          }
+        }
+      }
+      dynamic "mandatory_claims" {
+        for_each = length(var.jwt_validation.mandatory_claims) > 0 ? [1] : []
+        content {
+          claim_names = var.jwt_validation.mandatory_claims
+        }
+      }
+      reserved_claims {
+        # Each oneof is required: derive the disable arm from value presence so no choice is
+        # ever left nil (the API rejects a nil oneof with required_oneof).
+        issuer = (var.jwt_validation.issuer != null && var.jwt_validation.issuer != "") ? var.jwt_validation.issuer : null
+        dynamic "issuer_disable" {
+          for_each = (var.jwt_validation.issuer == null || var.jwt_validation.issuer == "") ? [1] : []
+          content {}
+        }
+        dynamic "audience" {
+          for_each = length(var.jwt_validation.audiences) > 0 ? [1] : []
+          content {
+            audiences = var.jwt_validation.audiences
+          }
+        }
+        dynamic "audience_disable" {
+          for_each = length(var.jwt_validation.audiences) == 0 ? [1] : []
+          content {}
+        }
+        dynamic "validate_period_enable" {
+          for_each = var.jwt_validation.validate_period ? [1] : []
+          content {}
+        }
+        dynamic "validate_period_disable" {
+          for_each = var.jwt_validation.validate_period ? [] : [1]
+          content {}
+        }
+      }
+    }
+  }
+
+  # GraphQL inspection (LPC-3) — per-rule path/domain/method + query limits + introspection.
+  # Omitted when no rule; graphql_settings emitted per rule (int limits null-when-unset).
+  dynamic "graphql_rules" {
+    for_each = var.graphql_rules
+    content {
+      metadata {
+        name = graphql_rules.value.name
+      }
+      exact_path = graphql_rules.value.exact_path
+      dynamic "any_domain" {
+        for_each = graphql_rules.value.domain == "any" ? [1] : []
+        content {}
+      }
+      exact_value  = graphql_rules.value.domain == "exact" ? graphql_rules.value.domain_value : null
+      suffix_value = graphql_rules.value.domain == "suffix" ? graphql_rules.value.domain_value : null
+      dynamic "method_get" {
+        for_each = graphql_rules.value.method == "get" ? [1] : []
+        content {}
+      }
+      dynamic "method_post" {
+        for_each = graphql_rules.value.method == "post" ? [1] : []
+        content {}
+      }
+      graphql_settings {
+        max_batched_queries = graphql_rules.value.max_batched_queries
+        max_depth           = graphql_rules.value.max_depth
+        max_total_length    = graphql_rules.value.max_total_length
+        max_value_length    = graphql_rules.value.max_value_length
+        policy_name         = graphql_rules.value.policy_name
+        dynamic "enable_introspection" {
+          for_each = graphql_rules.value.introspection == "enable" ? [1] : []
+          content {}
+        }
+        dynamic "disable_introspection" {
+          for_each = graphql_rules.value.introspection == "disable" ? [1] : []
+          content {}
+        }
+      }
+    }
+  }
+
   # API protection rules (Coverage Batch D) — allow/deny access to API endpoints
   # (api_endpoint_rules) or API groups / base paths (api_groups_rules), each scoped by
   # a PER-RULE client_matcher (full oneof) + request_matcher. Omitted when both lists

--- a/terraform/modules/http-lb/variables_graphql.tf
+++ b/terraform/modules/http-lb/variables_graphql.tf
@@ -1,0 +1,38 @@
+# GraphQL inspection (LPC-3) via the LB top-level graphql_rules[]. Each rule targets a
+# GraphQL endpoint (path + domain + method) and applies limits + introspection control.
+# Default creates nothing (0-change).
+
+variable "graphql_rules" {
+  description = "GraphQL inspection rules on the LB. Each matches a path/domain/method and sets query limits + introspection."
+  type = list(object({
+    name                = string                   # metadata.name
+    exact_path          = optional(string)         # the GraphQL endpoint path, e.g. /graphql
+    domain              = optional(string, "any")  # any|exact|suffix
+    domain_value        = optional(string)         # value for domain=exact|suffix
+    method              = optional(string, "post") # get|post
+    max_batched_queries = optional(number)
+    max_depth           = optional(number)
+    max_total_length    = optional(number)
+    max_value_length    = optional(number)
+    policy_name         = optional(string)
+    introspection       = optional(string, "omit") # omit|enable|disable
+  }))
+  default = []
+
+  validation {
+    condition     = alltrue([for r in var.graphql_rules : contains(["any", "exact", "suffix"], r.domain)])
+    error_message = "each graphql_rules[].domain must be any, exact, or suffix."
+  }
+  validation {
+    condition     = alltrue([for r in var.graphql_rules : contains(["get", "post"], r.method)])
+    error_message = "each graphql_rules[].method must be get or post."
+  }
+  validation {
+    condition     = alltrue([for r in var.graphql_rules : contains(["omit", "enable", "disable"], r.introspection)])
+    error_message = "each graphql_rules[].introspection must be omit, enable, or disable."
+  }
+  validation {
+    condition     = alltrue([for r in var.graphql_rules : r.domain == "any" || (r.domain_value != null && r.domain_value != "")])
+    error_message = "graphql_rules[].domain_value is required when domain is exact or suffix."
+  }
+}

--- a/terraform/modules/http-lb/variables_jwt.tf
+++ b/terraform/modules/http-lb/variables_jwt.tf
@@ -1,0 +1,47 @@
+# JWT validation (LPC-3) on the LB top-level jwt_validation block. Uses the inline JWKS arm
+# (jwks_config.cleartext); the authorization_server ref arm is deferred to a later ref slice.
+# Default (null) omits the block (0-change).
+#
+# jwks_cleartext takes a readable JWKS JSON document (RFC 7517). The F5 XC API field is named
+# "cleartext" but the server validates it as base64 (a bare JSON 500s with "failed to decode
+# base64 cleartext JWKS"); the module base64-encodes it, so callers pass plain JSON.
+
+variable "jwt_validation" {
+  description = "JWT validation on the LB (inline JWKS). null omits the block."
+  type = object({
+    jwks_cleartext   = string                           # a readable JWKS JSON document (module base64-encodes for the API)
+    action           = optional(string, "block")        # block|report
+    target           = optional(string, "all_endpoint") # all_endpoint|api_groups|base_paths
+    api_groups       = optional(list(string), [])       # target=api_groups
+    base_paths       = optional(list(string), [])       # target=base_paths
+    mandatory_claims = optional(list(string), [])       # mandatory_claims.claim_names
+    # reserved_claims has three required oneofs; the arm is derived from value presence so a
+    # choice is never left empty (the API rejects a nil oneof). issuer set -> validate it, else
+    # issuer_disable; audiences non-empty -> validate them, else audience_disable.
+    issuer          = optional(string)           # reserved_claims.issuer (absent -> issuer_disable)
+    audiences       = optional(list(string), []) # reserved_claims.audience (empty -> audience_disable)
+    validate_period = optional(bool, true)       # validate_period_enable (true) vs _disable (false)
+  })
+  default = null
+
+  validation {
+    condition     = var.jwt_validation == null || can(jsondecode(var.jwt_validation.jwks_cleartext))
+    error_message = "jwt_validation.jwks_cleartext must be a JWKS JSON document (RFC 7517); the module base64-encodes it."
+  }
+  validation {
+    condition     = var.jwt_validation == null || contains(["block", "report"], var.jwt_validation.action)
+    error_message = "jwt_validation.action must be block or report."
+  }
+  validation {
+    condition     = var.jwt_validation == null || contains(["all_endpoint", "api_groups", "base_paths"], var.jwt_validation.target)
+    error_message = "jwt_validation.target must be all_endpoint, api_groups, or base_paths."
+  }
+  validation {
+    condition     = var.jwt_validation == null || var.jwt_validation.target != "api_groups" || length(var.jwt_validation.api_groups) > 0
+    error_message = "jwt_validation.api_groups is required when target=api_groups."
+  }
+  validation {
+    condition     = var.jwt_validation == null || var.jwt_validation.target != "base_paths" || length(var.jwt_validation.base_paths) > 0
+    error_message = "jwt_validation.base_paths is required when target=base_paths."
+  }
+}

--- a/terraform/tests/jwt_graphql.tftest.hcl
+++ b/terraform/tests/jwt_graphql.tftest.hcl
@@ -1,0 +1,166 @@
+# Plan-level tests for LPC-3: jwt_validation (inline JWKS) + graphql_rules[]. Targets
+# ./modules/http-lb. command = plan (no creds). The JWKS is a readable JSON document; the
+# module base64-encodes it for the API (F5 XC "cleartext" field is validated as base64).
+variables {
+  namespace         = "webapp-api-protection"
+  lb_domains        = ["www.f5-sales-demo.com"]
+  origin_ip         = "203.0.113.10"
+  origin_port       = 80
+  health_check_path = "/health"
+  labels            = {}
+  csd_enabled       = false
+  mud_enabled       = false
+}
+
+run "graphql_rule_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    graphql_rules = [{
+      name          = "gql"
+      exact_path    = "/graphql"
+      domain        = "any"
+      method        = "post"
+      max_depth     = 10
+      introspection = "disable"
+    }]
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.graphql_rules[0].metadata.name == "gql"
+    error_message = "graphql_rules metadata.name must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.graphql_rules[0].exact_path == "/graphql"
+    error_message = "graphql_rules exact_path must render"
+  }
+}
+
+run "graphql_exact_domain_requires_value" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    graphql_rules = [{ name = "g", domain = "exact", method = "post" }]
+  }
+  expect_failures = [var.graphql_rules]
+}
+
+run "graphql_bad_method_rejected" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    graphql_rules = [{ name = "g", method = "delete" }]
+  }
+  expect_failures = [var.graphql_rules]
+}
+
+run "graphql_bad_introspection_rejected" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    graphql_rules = [{ name = "g", introspection = "maybe" }]
+  }
+  expect_failures = [var.graphql_rules]
+}
+
+run "graphql_empty_by_default" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  assert {
+    condition     = length(xcsh_http_loadbalancer.this.graphql_rules) == 0
+    error_message = "graphql_rules must be empty by default"
+  }
+}
+
+run "jwt_block_renders_base64_jwks" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    jwt_validation = {
+      jwks_cleartext = "{\"keys\":[]}"
+      action         = "block"
+      target         = "all_endpoint"
+      issuer         = "https://issuer.example.com"
+      audiences      = ["api://webapp"]
+    }
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.jwt_validation.jwks_config.cleartext == base64encode("{\"keys\":[]}")
+    error_message = "jwks_config.cleartext must be the base64-encoded JWKS"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.jwt_validation.reserved_claims.issuer == "https://issuer.example.com"
+    error_message = "reserved_claims.issuer must render"
+  }
+}
+
+run "jwt_report_derives_disable_arms" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    jwt_validation = {
+      jwks_cleartext  = "{\"keys\":[]}"
+      action          = "report"
+      target          = "base_paths"
+      base_paths      = ["/api"]
+      validate_period = false
+    }
+  }
+  # issuer omitted -> issuer_disable arm; audiences empty -> audience_disable arm. Both required
+  # oneofs must carry an arm (the API rejects a nil oneof), so the derived disable blocks render.
+  assert {
+    condition     = xcsh_http_loadbalancer.this.jwt_validation.reserved_claims.issuer == null
+    error_message = "issuer must be null when omitted"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.jwt_validation.reserved_claims.issuer_disable != null
+    error_message = "issuer_disable arm must render when issuer omitted"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.jwt_validation.reserved_claims.audience_disable != null
+    error_message = "audience_disable arm must render when audiences empty"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.jwt_validation.reserved_claims.validate_period_disable != null
+    error_message = "validate_period_disable arm must render when validate_period=false"
+  }
+}
+
+run "jwt_target_api_groups_requires_groups" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    jwt_validation = {
+      jwks_cleartext = "{\"keys\":[]}"
+      target         = "api_groups"
+      api_groups     = []
+    }
+  }
+  expect_failures = [var.jwt_validation]
+}
+
+run "jwt_bad_jwks_rejected" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    jwt_validation = { jwks_cleartext = "not-json{{" }
+  }
+  expect_failures = [var.jwt_validation]
+}
+
+run "jwt_bad_action_rejected" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    jwt_validation = { jwks_cleartext = "{}", action = "warn" }
+  }
+  expect_failures = [var.jwt_validation]
+}
+
+run "jwt_omitted_by_default" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.jwt_validation == null
+    error_message = "jwt_validation must be omitted (null) by default"
+  }
+}

--- a/terraform/variables_graphql.tf
+++ b/terraform/variables_graphql.tf
@@ -1,0 +1,6 @@
+# Root passthrough for GraphQL inspection (LPC-3). Object list uses type = any (shape in module).
+variable "graphql_rules" {
+  description = "GraphQL inspection rules on the LB (see module for shape)."
+  type        = any
+  default     = []
+}

--- a/terraform/variables_jwt.tf
+++ b/terraform/variables_jwt.tf
@@ -1,0 +1,6 @@
+# Root passthrough for JWT validation (LPC-3). Object uses type = any (shape in module).
+variable "jwt_validation" {
+  description = "JWT validation on the LB (see module for shape). null omits."
+  type        = any
+  default     = null
+}


### PR DESCRIPTION
## Summary

LPC-3 of the LB-protection coverage effort (task #70): parameterize, plan-test, and
live-verify the two remaining LB top-level API-protection features.

- **`jwt_validation`** (inline JWKS): action (block/report), target (all_endpoint / api_groups /
  base_paths), mandatory_claims, reserved_claims (issuer / audience / validate_period), and
  token_location (bearer_token). Default null → omitted (0-change).
- **`graphql_rules[]`**: per-rule path/domain/method match + query limits (max_depth /
  max_total_length / max_value_length / max_batched_queries) + introspection control. Default
  `[]` → nothing created.

Single-knob string selectors validated with `contains()`; dynamic blocks per oneof arm;
self-contained validations; thin `type = any` root passthrough.

## Root cause fixed (module-side, no provider change)

`jwt_validation.jwks_config.cleartext` is misnamed in the F5 XC API: despite "cleartext", the
server validates it as **base64** and returns a bare `500`
(`failed to decode base64 cleartext JWKS`) on raw JSON. The module now accepts a readable JWKS
JSON document and `base64encode`s it for the API — callers pass plain JSON. A `can(jsondecode())`
validation rejects a non-JSON JWKS at plan time.

`graphql_rules` needed no provider change (import-clean on v3.72.6). The provider is unchanged.

## Write-only secret on import (expected, classified)

`jwks_config.cleartext` is a write-only secret the API masks as `"Redacted"` on read, so the
whole-LB import round-trip always re-applies it (same class as other clear secrets, e.g. SP2).
The matrix flags jwt-bearing variants `SECRET` and classifies their import round-trip with
`scripts/lpc3_import_check.py`: PASS only if that one secret leaf is the sole meaningful drift —
any other changed leaf is a real import bug. graphql-only variants must be fully 0-change.

## Verification

- `terraform test -filter=tests/jwt_graphql.tftest.hcl` → **11 passed, 0 failed** (render,
  null-default regression, every validation via `expect_failures`, base64-encoding assert).
- Live AETG all-pairs matrix (`scripts/jwt-graphql-matrix.sh`, 8 variants + canonical):
  apply → idempotent (plan 0) → whole-LB import round-trip → canonical-restore 0-change.
  **9/9 PASS, 0 FAIL, 0 SKIP** — jwt block/report x gql any/exact + jwt-only + gql-only.
  jwt (SECRET) variants pass via the secret classifier (only jwks_config.cleartext
  re-applies); gql-only (LIVE) variants are fully 0-change; canonical-restore clean.

Closes #101.
