### PR TITLE
LPC-4a: LB inline WAF exclusion rules (waf_exclusion.waf_exclusion_inline_rules)

### DIFF
--- a/scripts/waf-exclusion-matrix.sh
+++ b/scripts/waf-exclusion-matrix.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Inline WAF exclusion (LPC-4a) live coverage-matrix harness.
+#
+# Cycles the LIVE webapp-api-protection LB through the waf_exclusion_pairs variant set and
+# verifies each variant (a) applies, (b) is idempotent (immediate plan = No changes), and
+# (c) is round-trip-import clean for the LB (state rm -> import -> plan clean). waf_exclusion is
+# an LB-nested feature, so the import target is the http_loadbalancer itself. Ends on
+# canonical-restore so the live LB is left healthy (no exclusion rules). Results append to
+# reports/waf-exclusion-matrix.txt.
+#
+# Exclusions only REDUCE WAF strictness on a narrow match (specific sig/violation/attack/bot)
+# or skip WAF for a matched request; the env is NON-PRODUCTION/destructive-OK and each variant
+# is transient (canonical-restore clears all rules at the end). An arm F5 XC rejects for
+# entitlement is recorded SKIP (word signals; a bare status number is not matched) rather than
+# FAIL. Sequential — no concurrent terraform against the shared azurerm state.
+#
+# Usage: waf-exclusion-matrix.sh [START [END]]  (inclusive 0-based index range).
+set -uo pipefail
+
+umask 077
+trap 'rm -rf /tmp/lpc4-variants 2>/dev/null; rm -f /tmp/lpc4-*.log 2>/dev/null' EXIT
+
+cd "$(dirname "$0")/../terraform" || exit 1
+ARM_ACCESS_KEY=$(az storage account keys list -n f5salesdemotfstate -g f5-sales-demo-tfstate --query "[0].value" -o tsv)
+export ARM_ACCESS_KEY
+
+NS="webapp-api-protection"
+LB_ADDR="module.http_lb.xcsh_http_loadbalancer.this"
+LB_ID="${NS}/${NS}"
+COMMON=(-input=false -lock=true
+  -var 'lb_domains=["www.f5-sales-demo.com","api.f5-sales-demo.com"]'
+  -var 'subscription_id=75f86c46-9cbc-4f6c-85ea-195e3d3c8ac0')
+VARDIR=/tmp/lpc4-variants
+REPORT=../reports/waf-exclusion-matrix.txt
+mkdir -p ../reports
+
+START="${1:-0}"
+END="${2:-9999}"
+GATED_RE='entitlement|not subscribed|not entitled|not enabled for|permission denied|unauthorized|AS_NOT_SUBSCRIBED|status: 401|status: 403'
+
+[ "$#" -eq 0 ] && : >"$REPORT"
+
+count=$(python3 ../scripts/waf_exclusion_pairs.py --emit "$VARDIR")
+echo "generated $count variants into $VARDIR (running [$START..$END])"
+
+round_trip() {
+  local label="$1" vf="$2"
+  terraform state rm "$LB_ADDR" >/dev/null 2>&1 || {
+    echo "FAIL $label lb-state-rm" >>"$REPORT"
+    return
+  }
+  terraform import "${COMMON[@]}" -var-file="$vf" "$LB_ADDR" "$LB_ID" >/tmp/lpc4-import.log 2>&1 || {
+    echo "FAIL $label lb-import ($(grep -iE 'error' /tmp/lpc4-import.log | head -1 | cut -c1-70))" >>"$REPORT"
+    return
+  }
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$vf" >/tmp/lpc4-rt-plan.log 2>&1
+  case $? in
+  0) echo "PASS $label" >>"$REPORT" ;;
+  2) echo "FAIL $label import-drift" >>"$REPORT" ;;
+  *) echo "FAIL $label rt-plan-error" >>"$REPORT" ;;
+  esac
+}
+
+while read -r idx name vf _flag; do
+  [ "$idx" -lt "$START" ] && continue
+  [ "$idx" -gt "$END" ] && continue
+  label="$idx-$name"
+  echo "--- $label ---"
+  varfile="${VARDIR}/${vf}"
+  if ! terraform apply -auto-approve "${COMMON[@]}" -var-file="$varfile" >/tmp/lpc4-apply.log 2>&1; then
+    if grep -qiE "$GATED_RE" /tmp/lpc4-apply.log; then
+      echo "SKIP $label gated-arm ($(grep -oiE "$GATED_RE" /tmp/lpc4-apply.log | head -1))" >>"$REPORT"
+    else
+      echo "FAIL $label apply ($(grep -iE 'error' /tmp/lpc4-apply.log | head -1 | cut -c1-80))" >>"$REPORT"
+    fi
+    continue
+  fi
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$varfile" >/tmp/lpc4-plan.log 2>&1
+  case $? in
+  0) round_trip "$label" "$varfile" ;;
+  2) echo "FAIL $label not-idempotent" >>"$REPORT" ;;
+  *) echo "FAIL $label plan-error" >>"$REPORT" ;;
+  esac
+done <"${VARDIR}/manifest.txt"
+
+echo "===== WAF EXCLUSION MATRIX RESULTS ($START..$END) ====="
+cat "$REPORT"
+echo "PASS=$(grep -c '^PASS ' "$REPORT") FAIL=$(grep -c '^FAIL ' "$REPORT") SKIP=$(grep -c '^SKIP ' "$REPORT")"

--- a/scripts/waf_exclusion_pairs.py
+++ b/scripts/waf_exclusion_pairs.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Generate the inline WAF exclusion (LPC-4a) coverage matrix.
+
+AETG all-pairs over the rule's domain oneof, path oneof, and exclusion action, each variant
+applied to the LIVE LB. Plus canonical-restore (no rules).
+
+Dimensions:
+  domain  any | exact | suffix        (any_domain / exact_value / suffix_value)
+  path    any | prefix | regex        (any_path / path_prefix / path_regex)
+  excl    skip | signature | violation | attack | bot
+          skip      -> waf_skip_processing (skip WAF for the match)
+          signature -> app_firewall_detection_control.exclude_signature_contexts
+          violation -> ...exclude_violation_contexts
+          attack    -> ...exclude_attack_type_contexts
+          bot       -> ...exclude_bot_name_contexts
+
+Env is NON-PRODUCTION/destructive-OK; a matched skip rule is transient (applied, verified,
+then canonical-restore clears it). Deterministic (no RNG). Output: JSON to stdout, or --emit.
+"""
+
+import itertools
+import json
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+DIMENSIONS = {
+    "domain": ["any", "exact", "suffix"],
+    "path": ["any", "prefix", "regex"],
+    "excl": ["skip", "signature", "violation", "attack", "bot"],
+}
+
+
+def _best_value(
+    values: list[str],
+    idx: int,
+    row: dict[int, str],
+    uncovered: set[tuple[int, str, int, str]],
+) -> str:
+    """Pick the value for dimension idx covering the most still-uncovered pairs."""
+    best_val, best_gain = values[0], -1
+    for val in values:
+        gain = 0
+        for pidx, pval in row.items():
+            a, b = sorted([(pidx, pval), (idx, val)])
+            if (a[0], a[1], b[0], b[1]) in uncovered:
+                gain += 1
+        if gain > best_gain:
+            best_gain, best_val = gain, val
+    return best_val
+
+
+def all_pairs(dims: dict[str, list[str]]) -> list[dict[str, str]]:
+    """Return AETG-style greedy all-pairs rows ({dim: value})."""
+    names = list(dims)
+    uncovered: set[tuple[int, str, int, str]] = set()
+    for i, j in itertools.combinations(range(len(names)), 2):
+        for vi in dims[names[i]]:
+            for vj in dims[names[j]]:
+                uncovered.add((i, vi, j, vj))
+
+    rows = []
+    while uncovered:
+        si, sv, sj, sv2 = min(uncovered)
+        row = {si: sv, sj: sv2}
+        for idx, name in enumerate(names):
+            if idx not in row:
+                row[idx] = _best_value(dims[name], idx, row, uncovered)
+        for i, j in itertools.combinations(sorted(row), 2):
+            uncovered.discard((i, row[i], j, row[j]))
+        rows.append({names[k]: v for k, v in row.items()})
+    return rows
+
+
+def _excl_fields(excl: str) -> dict[str, object]:
+    """Expand an excl dimension value into the rule's action + exclusion lists."""
+    if excl == "skip":
+        return {"action": "skip"}
+    base: dict[str, object] = {"action": "detection_control"}
+    if excl == "signature":
+        base["exclude_signatures"] = [
+            {
+                "signature_id": 200002147,
+                "context": "CONTEXT_HEADER",
+                "context_name": "x-api",
+            }
+        ]
+    elif excl == "violation":
+        base["exclude_violations"] = [{"violation": "VIOL_JSON_MALFORMED"}]
+    elif excl == "attack":
+        base["exclude_attack_types"] = [
+            {
+                "attack_type": "ATTACK_TYPE_SQL_INJECTION",
+                "context": "CONTEXT_PARAMETER",
+                "context_name": "q",
+            }
+        ]
+    elif excl == "bot":
+        base["exclude_bot_names"] = ["Googlebot"]
+    return base
+
+
+def _rule(row: Mapping[str, object]) -> dict[str, object]:
+    """Build one waf_exclusion rule from an all-pairs row."""
+    domain, path, excl = str(row["domain"]), str(row["path"]), str(row["excl"])
+    rule: dict[str, object] = {
+        "name": f"excl-{domain}-{path}-{excl}",
+        "domain": domain,
+        "path": path,
+        "methods": ["GET", "POST"],
+    }
+    if domain == "exact":
+        rule["domain_value"] = "api.f5-sales-demo.com"
+    elif domain == "suffix":
+        rule["domain_value"] = "f5-sales-demo.com"
+    if path == "prefix":
+        rule["path_value"] = "/waf-excl-probe"
+    elif path == "regex":
+        rule["path_value"] = "^/waf-excl/.*$"
+    rule.update(_excl_fields(excl))
+    return rule
+
+
+def build() -> list[dict[str, object]]:
+    """Build the ordered variant manifest (all-pairs + canonical), deduped."""
+    variants: list[dict[str, object]] = []
+    seen: set[str] = set()
+    idx = 0
+    for row in all_pairs(DIMENSIONS):
+        vars_ = {"waf_exclusion_rules": [_rule(row)]}
+        key = json.dumps(vars_, sort_keys=True)
+        if key in seen:
+            continue
+        seen.add(key)
+        variants.append({"name": f"pair-{idx:03d}", "vars": vars_})
+        idx += 1
+    variants.append({"name": "canonical-restore", "vars": {"waf_exclusion_rules": []}})
+    return variants
+
+
+def emit(directory: str) -> int:
+    """Write one <NNN>-<name>.tfvars.json per variant plus manifest.txt."""
+    out_dir = Path(directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for existing in out_dir.iterdir():
+        if existing.name.endswith(".tfvars.json") or existing.name == "manifest.txt":
+            existing.unlink()
+    variants = build()
+    named = [(f"{i:03d}-{v['name']}.tfvars.json", v) for i, v in enumerate(variants)]
+    for fname, v in named:
+        (out_dir / fname).write_text(json.dumps(v["vars"], indent=2) + "\n")
+    lines = [f"{i:03d} {v['name']} {fname} LIVE" for i, (fname, v) in enumerate(named)]
+    (out_dir / "manifest.txt").write_text("\n".join(lines) + "\n")
+    return len(variants)
+
+
+def main(argv: list[str]) -> None:
+    """CLI: --count, --emit <dir>, else JSON to stdout."""
+    match argv[1:]:
+        case ["--count"]:
+            sys.stdout.write(f"{len(build())}\n")
+        case ["--emit", directory]:
+            sys.stdout.write(f"{emit(directory)}\n")
+        case _:
+            json.dump(build(), sys.stdout, indent=2)
+            sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -188,8 +188,9 @@ module "http_lb" {
   disable_default_error_pages = var.disable_default_error_pages
 
   # GraphQL inspection (LPC-3) passthrough.
-  graphql_rules  = var.graphql_rules
-  jwt_validation = var.jwt_validation
+  graphql_rules       = var.graphql_rules
+  jwt_validation      = var.jwt_validation
+  waf_exclusion_rules = var.waf_exclusion_rules
 
   # API Testing (SP4) passthrough. Defaults keep it off (disable_api_testing
   # suppressed => 0-change) and create no standalone resource.

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -1608,6 +1608,84 @@ resource "xcsh_http_loadbalancer" "this" {
     }
   }
 
+  # WAF exclusion (LPC-4a) — inline rules that match domain+path+methods and then either skip
+  # WAF (waf_skip_processing) or exclude specific signatures/violations/attack-types/bot-names
+  # (app_firewall_detection_control). Omitted when no rule. Omit a matcher's concrete arm for
+  # "match any" (any_domain / any_path base members are import-suppressed by the provider).
+  dynamic "waf_exclusion" {
+    for_each = length(var.waf_exclusion_rules) > 0 ? [1] : []
+    content {
+      waf_exclusion_inline_rules {
+        dynamic "rules" {
+          for_each = var.waf_exclusion_rules
+          content {
+            metadata {
+              name             = rules.value.name
+              description_spec = rules.value.description
+            }
+            dynamic "any_domain" {
+              for_each = rules.value.domain == "any" ? [1] : []
+              content {}
+            }
+            exact_value  = rules.value.domain == "exact" ? rules.value.domain_value : null
+            suffix_value = rules.value.domain == "suffix" ? rules.value.domain_value : null
+            dynamic "any_path" {
+              for_each = rules.value.path == "any" ? [1] : []
+              content {}
+            }
+            path_prefix          = rules.value.path == "prefix" ? rules.value.path_value : null
+            path_regex           = rules.value.path == "regex" ? rules.value.path_value : null
+            methods              = length(rules.value.methods) > 0 ? rules.value.methods : null
+            expiration_timestamp = rules.value.expiration_timestamp
+            dynamic "waf_skip_processing" {
+              for_each = rules.value.action == "skip" ? [1] : []
+              content {}
+            }
+            dynamic "app_firewall_detection_control" {
+              for_each = rules.value.action == "detection_control" ? [1] : []
+              content {
+                dynamic "exclude_signature_contexts" {
+                  for_each = rules.value.exclude_signatures
+                  iterator = s
+                  content {
+                    signature_id = s.value.signature_id
+                    context      = s.value.context
+                    context_name = s.value.context_name
+                  }
+                }
+                dynamic "exclude_violation_contexts" {
+                  for_each = rules.value.exclude_violations
+                  iterator = v
+                  content {
+                    exclude_violation = v.value.violation
+                    context           = v.value.context
+                    context_name      = v.value.context_name
+                  }
+                }
+                dynamic "exclude_attack_type_contexts" {
+                  for_each = rules.value.exclude_attack_types
+                  iterator = a
+                  content {
+                    exclude_attack_type = a.value.attack_type
+                    context             = a.value.context
+                    context_name        = a.value.context_name
+                  }
+                }
+                dynamic "exclude_bot_name_contexts" {
+                  for_each = rules.value.exclude_bot_names
+                  iterator = b
+                  content {
+                    bot_name = b.value
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
   # API protection rules (Coverage Batch D) — allow/deny access to API endpoints
   # (api_endpoint_rules) or API groups / base paths (api_groups_rules), each scoped by
   # a PER-RULE client_matcher (full oneof) + request_matcher. Omitted when both lists

--- a/terraform/modules/http-lb/variables_waf_exclusion.tf
+++ b/terraform/modules/http-lb/variables_waf_exclusion.tf
@@ -1,0 +1,80 @@
+# LPC-4a: LB inline WAF exclusion rules (waf_exclusion.waf_exclusion_inline_rules.rules[]).
+# Each rule matches a domain + path + methods and then either skips WAF entirely
+# (waf_skip_processing) or excludes specific signatures / violations / attack types / bot names
+# from triggering (app_firewall_detection_control). Empty list omits the whole block (0-change).
+
+variable "waf_exclusion_rules" {
+  description = "Inline WAF exclusion rules on the LB. Empty omits the waf_exclusion block."
+  type = list(object({
+    name                 = string                     # metadata.name
+    description          = optional(string)           # metadata.description_spec
+    domain               = optional(string, "any")    # any|exact|suffix (any_domain / exact_value / suffix_value)
+    domain_value         = optional(string)           # value for domain=exact|suffix
+    path                 = optional(string, "any")    # any|prefix|regex (any_path / path_prefix / path_regex)
+    path_value           = optional(string)           # value for path=prefix|regex
+    methods              = optional(list(string), []) # ANY|GET|HEAD|POST|PUT|DELETE|CONNECT|OPTIONS|TRACE|PATCH|COPY
+    expiration_timestamp = optional(string)           # RFC 3339; rule inactive after this instant
+    action               = optional(string, "skip")   # skip (waf_skip_processing) | detection_control
+    # detection_control exclusions (action=detection_control). context defaults CONTEXT_ANY;
+    # context_name only for HEADER/COOKIE/PARAMETER contexts.
+    exclude_signatures = optional(list(object({
+      signature_id = number # 0 (all) or 200000001-299999999
+      context      = optional(string, "CONTEXT_ANY")
+      context_name = optional(string)
+    })), [])
+    exclude_violations = optional(list(object({
+      violation    = string # VIOL_*
+      context      = optional(string, "CONTEXT_ANY")
+      context_name = optional(string)
+    })), [])
+    exclude_attack_types = optional(list(object({
+      attack_type  = string # ATTACK_TYPE_*
+      context      = optional(string, "CONTEXT_ANY")
+      context_name = optional(string)
+    })), [])
+    exclude_bot_names = optional(list(string), [])
+  }))
+  default = []
+
+  validation {
+    condition     = alltrue([for r in var.waf_exclusion_rules : contains(["any", "exact", "suffix"], r.domain)])
+    error_message = "each waf_exclusion_rules[].domain must be any, exact, or suffix."
+  }
+  validation {
+    condition     = alltrue([for r in var.waf_exclusion_rules : contains(["any", "prefix", "regex"], r.path)])
+    error_message = "each waf_exclusion_rules[].path must be any, prefix, or regex."
+  }
+  validation {
+    condition     = alltrue([for r in var.waf_exclusion_rules : r.domain == "any" || (r.domain_value != null && r.domain_value != "")])
+    error_message = "waf_exclusion_rules[].domain_value is required when domain is exact or suffix."
+  }
+  validation {
+    condition     = alltrue([for r in var.waf_exclusion_rules : r.path == "any" || (r.path_value != null && r.path_value != "")])
+    error_message = "waf_exclusion_rules[].path_value is required when path is prefix or regex."
+  }
+  validation {
+    condition     = alltrue([for r in var.waf_exclusion_rules : contains(["skip", "detection_control"], r.action)])
+    error_message = "each waf_exclusion_rules[].action must be skip or detection_control."
+  }
+  validation {
+    condition = alltrue([for r in var.waf_exclusion_rules : alltrue([
+      for m in r.methods : contains(["ANY", "GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH", "COPY"], m)
+    ])])
+    error_message = "waf_exclusion_rules[].methods entries must be valid HTTP methods (ANY/GET/HEAD/POST/PUT/DELETE/CONNECT/OPTIONS/TRACE/PATCH/COPY)."
+  }
+  validation {
+    condition = alltrue([for r in var.waf_exclusion_rules : alltrue(concat(
+      [for e in r.exclude_signatures : contains(["CONTEXT_ANY", "CONTEXT_BODY", "CONTEXT_REQUEST", "CONTEXT_RESPONSE", "CONTEXT_PARAMETER", "CONTEXT_HEADER", "CONTEXT_COOKIE", "CONTEXT_URL", "CONTEXT_URI"], e.context)],
+      [for e in r.exclude_violations : contains(["CONTEXT_ANY", "CONTEXT_BODY", "CONTEXT_REQUEST", "CONTEXT_RESPONSE", "CONTEXT_PARAMETER", "CONTEXT_HEADER", "CONTEXT_COOKIE", "CONTEXT_URL", "CONTEXT_URI"], e.context)],
+      [for e in r.exclude_attack_types : contains(["CONTEXT_ANY", "CONTEXT_BODY", "CONTEXT_REQUEST", "CONTEXT_RESPONSE", "CONTEXT_PARAMETER", "CONTEXT_HEADER", "CONTEXT_COOKIE", "CONTEXT_URL", "CONTEXT_URI"], e.context)]
+    ))])
+    error_message = "waf_exclusion_rules[] exclusion context values must be a valid CONTEXT_* enum."
+  }
+  validation {
+    condition = alltrue([for r in var.waf_exclusion_rules :
+      r.action != "detection_control" ||
+      (length(r.exclude_signatures) + length(r.exclude_violations) + length(r.exclude_attack_types) + length(r.exclude_bot_names)) > 0
+    ])
+    error_message = "waf_exclusion_rules[] with action=detection_control must define at least one exclusion."
+  }
+}

--- a/terraform/tests/waf_exclusion.tftest.hcl
+++ b/terraform/tests/waf_exclusion.tftest.hcl
@@ -1,0 +1,115 @@
+# Plan-level tests for LPC-4a: LB inline waf_exclusion rules. Targets ./modules/http-lb.
+# command = plan (no creds).
+variables {
+  namespace         = "webapp-api-protection"
+  lb_domains        = ["www.f5-sales-demo.com"]
+  origin_ip         = "203.0.113.10"
+  origin_port       = 80
+  health_check_path = "/health"
+  labels            = {}
+  csd_enabled       = false
+  mud_enabled       = false
+}
+
+run "skip_rule_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    waf_exclusion_rules = [{
+      name       = "skip-health"
+      path       = "prefix"
+      path_value = "/health"
+      methods    = ["GET", "HEAD"]
+      action     = "skip"
+    }]
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.waf_exclusion.waf_exclusion_inline_rules.rules[0].metadata.name == "skip-health"
+    error_message = "rule metadata.name must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.waf_exclusion.waf_exclusion_inline_rules.rules[0].path_prefix == "/health"
+    error_message = "path_prefix must render for path=prefix"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.waf_exclusion.waf_exclusion_inline_rules.rules[0].waf_skip_processing != null
+    error_message = "waf_skip_processing arm must render for action=skip"
+  }
+}
+
+run "detection_control_rule_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    waf_exclusion_rules = [{
+      name               = "excl-sig"
+      domain             = "exact"
+      domain_value       = "api.f5-sales-demo.com"
+      action             = "detection_control"
+      exclude_signatures = [{ signature_id = 200002147, context = "CONTEXT_HEADER", context_name = "x-api" }]
+      exclude_violations = [{ violation = "VIOL_JSON_MALFORMED" }]
+    }]
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.waf_exclusion.waf_exclusion_inline_rules.rules[0].exact_value == "api.f5-sales-demo.com"
+    error_message = "exact_value must render for domain=exact"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.waf_exclusion.waf_exclusion_inline_rules.rules[0].app_firewall_detection_control.exclude_signature_contexts[0].signature_id == 200002147
+    error_message = "exclude_signature_contexts signature_id must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.waf_exclusion.waf_exclusion_inline_rules.rules[0].app_firewall_detection_control.exclude_violation_contexts[0].exclude_violation == "VIOL_JSON_MALFORMED"
+    error_message = "exclude_violation_contexts must render"
+  }
+}
+
+run "waf_exclusion_omitted_by_default" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.waf_exclusion == null
+    error_message = "waf_exclusion must be omitted (null) by default"
+  }
+}
+
+run "bad_domain_rejected" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { waf_exclusion_rules = [{ name = "r", domain = "glob" }] }
+  expect_failures = [var.waf_exclusion_rules]
+}
+
+run "exact_domain_requires_value" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { waf_exclusion_rules = [{ name = "r", domain = "exact" }] }
+  expect_failures = [var.waf_exclusion_rules]
+}
+
+run "bad_method_rejected" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { waf_exclusion_rules = [{ name = "r", methods = ["FETCH"] }] }
+  expect_failures = [var.waf_exclusion_rules]
+}
+
+run "detection_control_requires_exclusion" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { waf_exclusion_rules = [{ name = "r", action = "detection_control" }] }
+  expect_failures = [var.waf_exclusion_rules]
+}
+
+run "bad_context_rejected" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    waf_exclusion_rules = [{
+      name               = "r"
+      action             = "detection_control"
+      exclude_signatures = [{ signature_id = 0, context = "CONTEXT_WHATEVER" }]
+    }]
+  }
+  expect_failures = [var.waf_exclusion_rules]
+}

--- a/terraform/variables_waf_exclusion.tf
+++ b/terraform/variables_waf_exclusion.tf
@@ -1,0 +1,7 @@
+# Root passthrough for inline WAF exclusion rules (LPC-4a). Object list uses type = any
+# (shape in module).
+variable "waf_exclusion_rules" {
+  description = "Inline WAF exclusion rules on the LB (see module for shape)."
+  type        = any
+  default     = []
+}


### PR DESCRIPTION
## Summary

LPC-4a of the LB-protection coverage effort (task #70): parameterize and live-verify the LB
top-level `waf_exclusion` inline-rules arm.

`waf_exclusion_rules` → `waf_exclusion.waf_exclusion_inline_rules.rules[]`. Per rule:
- metadata (name/description),
- domain oneof: `any` / `exact` / `suffix` (any_domain / exact_value / suffix_value),
- path oneof: `any` / `prefix` / `regex` (any_path / path_prefix / path_regex),
- methods[] (enum ANY/GET/…/COPY), expiration_timestamp,
- action oneof: `skip` (waf_skip_processing — skip WAF for the match) or `detection_control`
  (app_firewall_detection_control: exclude_signature / exclude_violation / exclude_attack_type
  / exclude_bot_name contexts, each with a CONTEXT_* enum + context_name).

Single-knob string selectors validated with `contains()`; self-contained validations
(domain/path value required for non-any; detection_control requires ≥1 exclusion; method +
context enums); `[]` omits the block (0-change). Thin `type = any` root passthrough.

## No provider change

The inline rules — including the `any_domain` / `any_path` base oneof members — are
import-clean on provider v3.72.6; the whole-LB import round-trip needs no new suppression.

## Verification

- `terraform test -filter=tests/waf_exclusion.tftest.hcl` → **8 passed, 0 failed** (skip +
  detection_control render, null-default regression, every validation via `expect_failures`).
- Live AETG all-pairs matrix (`scripts/waf-exclusion-matrix.sh`, 16 variants + canonical):
  apply → idempotent (plan 0) → whole-LB import round-trip (plan 0) → canonical-restore 0-change.
  **17/17 PASS, 0 FAIL, 0 SKIP** over domain × path × exclusion (skip/signature/violation/
  attack/bot). LB left canonical.

Closes #103.
