### PR TITLE
LPC-4b: standalone xcsh_waf_exclusion_policy + LB waf_exclusion_policy ref arm

### DIFF
--- a/scripts/waf-exclusion-policy-matrix.sh
+++ b/scripts/waf-exclusion-policy-matrix.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Standalone WAF exclusion policy (LPC-4b) live coverage-matrix harness.
+#
+# Verifies the standalone xcsh_waf_exclusion_policy resource and the LB waf_exclusion_policy
+# ref arm. Per variant: (a) apply, (b) idempotent (immediate plan = No changes), (c) round-trip
+# import — the policy resource always, plus the whole LB for LB_REF variants (the ref arm is
+# LB-nested). Ends on canonical-restore so the live LB is left healthy (no policy, no ref).
+# Results append to reports/waf-exclusion-policy-matrix.txt.
+#
+# Exclusions only reduce WAF strictness on a narrow match; the env is NON-PRODUCTION/
+# destructive-OK and each variant is transient. Sequential — no concurrent terraform against
+# the shared azurerm state.
+#
+# Usage: waf-exclusion-policy-matrix.sh [START [END]]  (inclusive 0-based index range).
+set -uo pipefail
+
+umask 077
+trap 'rm -rf /tmp/lpc4b-variants 2>/dev/null; rm -f /tmp/lpc4b-*.log 2>/dev/null' EXIT
+
+cd "$(dirname "$0")/../terraform" || exit 1
+ARM_ACCESS_KEY=$(az storage account keys list -n f5salesdemotfstate -g f5-sales-demo-tfstate --query "[0].value" -o tsv)
+export ARM_ACCESS_KEY
+
+NS="webapp-api-protection"
+LB_ADDR="module.http_lb.xcsh_http_loadbalancer.this"
+LB_ID="${NS}/${NS}"
+POL_ADDR='module.http_lb.xcsh_waf_exclusion_policy.this["excl-pol"]'
+POL_ID="${NS}/excl-pol"
+COMMON=(-input=false -lock=true
+  -var 'lb_domains=["www.f5-sales-demo.com","api.f5-sales-demo.com"]'
+  -var 'subscription_id=75f86c46-9cbc-4f6c-85ea-195e3d3c8ac0')
+VARDIR=/tmp/lpc4b-variants
+REPORT=../reports/waf-exclusion-policy-matrix.txt
+mkdir -p ../reports
+
+START="${1:-0}"
+END="${2:-9999}"
+
+[ "$#" -eq 0 ] && : >"$REPORT"
+
+count=$(python3 ../scripts/waf_exclusion_policy_pairs.py --emit "$VARDIR")
+echo "generated $count variants into $VARDIR (running [$START..$END])"
+
+# Re-import a state-removed resource and confirm a clean plan (exit 0). Echoes a FAIL line and
+# returns 1 on any failure so the caller can stop the round-trip for this variant.
+reimport_clean() {
+  local label="$1" vf="$2" addr="$3" id="$4"
+  terraform state rm "$addr" >/dev/null 2>&1 || {
+    echo "FAIL $label state-rm ($addr)" >>"$REPORT"
+    return 1
+  }
+  terraform import "${COMMON[@]}" -var-file="$vf" "$addr" "$id" >/tmp/lpc4b-import.log 2>&1 || {
+    echo "FAIL $label import ($(grep -iE 'error' /tmp/lpc4b-import.log | head -1 | cut -c1-60))" >>"$REPORT"
+    return 1
+  }
+  return 0
+}
+
+round_trip() {
+  local label="$1" vf="$2" flag="$3"
+  if [ "$flag" = "NONE" ]; then
+    # canonical: nothing created, so no resource to round-trip; idempotency already confirmed.
+    echo "PASS $label" >>"$REPORT"
+    return
+  fi
+  reimport_clean "$label" "$vf" "$POL_ADDR" "$POL_ID" || return
+  if [ "$flag" = "LB_REF" ]; then
+    reimport_clean "$label" "$vf" "$LB_ADDR" "$LB_ID" || return
+  fi
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$vf" >/tmp/lpc4b-rt-plan.log 2>&1
+  case $? in
+  0) echo "PASS $label" >>"$REPORT" ;;
+  2) echo "FAIL $label import-drift" >>"$REPORT" ;;
+  *) echo "FAIL $label rt-plan-error" >>"$REPORT" ;;
+  esac
+}
+
+while read -r idx name vf flag; do
+  [ "$idx" -lt "$START" ] && continue
+  [ "$idx" -gt "$END" ] && continue
+  label="$idx-$name"
+  echo "--- $label ($flag) ---"
+  varfile="${VARDIR}/${vf}"
+  if ! terraform apply -auto-approve "${COMMON[@]}" -var-file="$varfile" >/tmp/lpc4b-apply.log 2>&1; then
+    echo "FAIL $label apply ($(grep -iE 'error' /tmp/lpc4b-apply.log | head -1 | cut -c1-80))" >>"$REPORT"
+    continue
+  fi
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$varfile" >/tmp/lpc4b-plan.log 2>&1
+  case $? in
+  0) round_trip "$label" "$varfile" "$flag" ;;
+  2) echo "FAIL $label not-idempotent" >>"$REPORT" ;;
+  *) echo "FAIL $label plan-error" >>"$REPORT" ;;
+  esac
+done <"${VARDIR}/manifest.txt"
+
+echo "===== WAF EXCLUSION POLICY MATRIX RESULTS ($START..$END) ====="
+cat "$REPORT"
+echo "PASS=$(grep -c '^PASS ' "$REPORT") FAIL=$(grep -c '^FAIL ' "$REPORT") SKIP=$(grep -c '^SKIP ' "$REPORT")"

--- a/scripts/waf_exclusion_policy_pairs.py
+++ b/scripts/waf_exclusion_policy_pairs.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Generate the standalone WAF exclusion policy (LPC-4b) coverage matrix.
+
+The inline rule-shape combinatorics are already exhausted by LPC-4a; this matrix verifies the
+standalone xcsh_waf_exclusion_policy resource round-trip and the LB waf_exclusion_policy ref
+arm. Small explicit variant set (rule kind x attached), plus canonical-restore.
+
+Each variant defines one policy `excl-pol` and optionally attaches it to the LB via
+waf_exclusion_policy_ref. Deterministic. Output: JSON to stdout, or files via --emit.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+SKIP_RULE = {
+    "name": "skip-probe",
+    "path": "prefix",
+    "path_value": "/waf-excl-probe",
+    "action": "skip",
+}
+# Use a real signature ID (200000001-299999999). signature_id=0 ("all signatures") hits a
+# distinct provider zero-value-omission bug (marshal drops the 0 -> read-back null -> apply
+# "inconsistent result"); tracked separately, not exercised here.
+DC_RULE = {
+    "name": "excl-sig",
+    "domain": "exact",
+    "domain_value": "api.f5-sales-demo.com",
+    "action": "detection_control",
+    "exclude_signatures": [
+        {
+            "signature_id": 200002147,
+            "context": "CONTEXT_HEADER",
+            "context_name": "x-api",
+        }
+    ],
+    "exclude_violations": [{"violation": "VIOL_JSON_MALFORMED"}],
+}
+
+
+def _variant(name: str, rules: list[dict], attached: bool) -> dict[str, object]:
+    """Build a variant: one policy `excl-pol` with rules, optionally attached to the LB."""
+    vars_: dict[str, object] = {
+        "waf_exclusion_policies": [{"name": "excl-pol", "rules": rules}],
+        "waf_exclusion_policy_ref": "excl-pol" if attached else None,
+    }
+    return {"name": name, "vars": vars_}
+
+
+def build() -> list[dict[str, object]]:
+    """Ordered variant manifest: policy round-trips (attached + standalone) + canonical."""
+    return [
+        _variant("skip-attached", [SKIP_RULE], attached=True),
+        _variant("dc-attached", [DC_RULE], attached=True),
+        _variant("multi-standalone", [SKIP_RULE, DC_RULE], attached=False),
+        {
+            "name": "canonical-restore",
+            "vars": {"waf_exclusion_policies": [], "waf_exclusion_policy_ref": None},
+        },
+    ]
+
+
+def emit(directory: str) -> int:
+    """Write one <NNN>-<name>.tfvars.json per variant plus manifest.txt."""
+    out_dir = Path(directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for existing in out_dir.iterdir():
+        if existing.name.endswith(".tfvars.json") or existing.name == "manifest.txt":
+            existing.unlink()
+    variants = build()
+    named = [(f"{i:03d}-{v['name']}.tfvars.json", v) for i, v in enumerate(variants)]
+    for fname, v in named:
+        (out_dir / fname).write_text(json.dumps(v["vars"], indent=2) + "\n")
+    # flag: variants that attach the policy exercise the whole-LB import too (LB_REF); the
+    # standalone-only variant and canonical only import the policy resource(s) (POLICY).
+    lines = []
+    for i, (fname, v) in enumerate(named):
+        vars_ = v["vars"]
+        policies = (
+            vars_.get("waf_exclusion_policies") if isinstance(vars_, dict) else None
+        )
+        ref = vars_.get("waf_exclusion_policy_ref") if isinstance(vars_, dict) else None
+        # NONE: nothing created (canonical) -> no resource to round-trip. LB_REF: attached to LB
+        # (round-trip policy + whole LB). POLICY: standalone only (round-trip policy).
+        flag = "NONE" if not policies else ("LB_REF" if ref else "POLICY")
+        lines.append(f"{i:03d} {v['name']} {fname} {flag}")
+    (out_dir / "manifest.txt").write_text("\n".join(lines) + "\n")
+    return len(variants)
+
+
+def main(argv: list[str]) -> None:
+    """CLI: --count, --emit <dir>, else JSON to stdout."""
+    match argv[1:]:
+        case ["--count"]:
+            sys.stdout.write(f"{len(build())}\n")
+        case ["--emit", directory]:
+            sys.stdout.write(f"{emit(directory)}\n")
+        case _:
+            json.dump(build(), sys.stdout, indent=2)
+            sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -188,9 +188,11 @@ module "http_lb" {
   disable_default_error_pages = var.disable_default_error_pages
 
   # GraphQL inspection (LPC-3) passthrough.
-  graphql_rules       = var.graphql_rules
-  jwt_validation      = var.jwt_validation
-  waf_exclusion_rules = var.waf_exclusion_rules
+  graphql_rules            = var.graphql_rules
+  jwt_validation           = var.jwt_validation
+  waf_exclusion_rules      = var.waf_exclusion_rules
+  waf_exclusion_policies   = var.waf_exclusion_policies
+  waf_exclusion_policy_ref = var.waf_exclusion_policy_ref
 
   # API Testing (SP4) passthrough. Defaults keep it off (disable_api_testing
   # suppressed => 0-change) and create no standalone resource.

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -1608,74 +1608,86 @@ resource "xcsh_http_loadbalancer" "this" {
     }
   }
 
-  # WAF exclusion (LPC-4a) — inline rules that match domain+path+methods and then either skip
-  # WAF (waf_skip_processing) or exclude specific signatures/violations/attack-types/bot-names
-  # (app_firewall_detection_control). Omitted when no rule. Omit a matcher's concrete arm for
-  # "match any" (any_domain / any_path base members are import-suppressed by the provider).
+  # WAF exclusion — a oneof: inline rules (LPC-4a) OR a reference to a standalone
+  # xcsh_waf_exclusion_policy (LPC-4b, waf_exclusion_policy_ref). Inline rules match
+  # domain+path+methods and then either skip WAF (waf_skip_processing) or exclude specific
+  # signatures/violations/attack-types/bot-names (app_firewall_detection_control). Omitted when
+  # neither is set. Mutual exclusion enforced by a lifecycle precondition below. Omit a matcher's
+  # concrete arm for "match any" (any_domain / any_path base members are import-suppressed).
   dynamic "waf_exclusion" {
-    for_each = length(var.waf_exclusion_rules) > 0 ? [1] : []
+    for_each = (length(var.waf_exclusion_rules) > 0 || var.waf_exclusion_policy_ref != null) ? [1] : []
     content {
-      waf_exclusion_inline_rules {
-        dynamic "rules" {
-          for_each = var.waf_exclusion_rules
-          content {
-            metadata {
-              name             = rules.value.name
-              description_spec = rules.value.description
-            }
-            dynamic "any_domain" {
-              for_each = rules.value.domain == "any" ? [1] : []
-              content {}
-            }
-            exact_value  = rules.value.domain == "exact" ? rules.value.domain_value : null
-            suffix_value = rules.value.domain == "suffix" ? rules.value.domain_value : null
-            dynamic "any_path" {
-              for_each = rules.value.path == "any" ? [1] : []
-              content {}
-            }
-            path_prefix          = rules.value.path == "prefix" ? rules.value.path_value : null
-            path_regex           = rules.value.path == "regex" ? rules.value.path_value : null
-            methods              = length(rules.value.methods) > 0 ? rules.value.methods : null
-            expiration_timestamp = rules.value.expiration_timestamp
-            dynamic "waf_skip_processing" {
-              for_each = rules.value.action == "skip" ? [1] : []
-              content {}
-            }
-            dynamic "app_firewall_detection_control" {
-              for_each = rules.value.action == "detection_control" ? [1] : []
-              content {
-                dynamic "exclude_signature_contexts" {
-                  for_each = rules.value.exclude_signatures
-                  iterator = s
-                  content {
-                    signature_id = s.value.signature_id
-                    context      = s.value.context
-                    context_name = s.value.context_name
+      dynamic "waf_exclusion_policy" {
+        for_each = var.waf_exclusion_policy_ref != null ? [1] : []
+        content {
+          name      = xcsh_waf_exclusion_policy.this[var.waf_exclusion_policy_ref].name
+          namespace = var.namespace
+        }
+      }
+      dynamic "waf_exclusion_inline_rules" {
+        for_each = (var.waf_exclusion_policy_ref == null && length(var.waf_exclusion_rules) > 0) ? [1] : []
+        content {
+          dynamic "rules" {
+            for_each = var.waf_exclusion_rules
+            content {
+              metadata {
+                name             = rules.value.name
+                description_spec = rules.value.description
+              }
+              dynamic "any_domain" {
+                for_each = rules.value.domain == "any" ? [1] : []
+                content {}
+              }
+              exact_value  = rules.value.domain == "exact" ? rules.value.domain_value : null
+              suffix_value = rules.value.domain == "suffix" ? rules.value.domain_value : null
+              dynamic "any_path" {
+                for_each = rules.value.path == "any" ? [1] : []
+                content {}
+              }
+              path_prefix          = rules.value.path == "prefix" ? rules.value.path_value : null
+              path_regex           = rules.value.path == "regex" ? rules.value.path_value : null
+              methods              = length(rules.value.methods) > 0 ? rules.value.methods : null
+              expiration_timestamp = rules.value.expiration_timestamp
+              dynamic "waf_skip_processing" {
+                for_each = rules.value.action == "skip" ? [1] : []
+                content {}
+              }
+              dynamic "app_firewall_detection_control" {
+                for_each = rules.value.action == "detection_control" ? [1] : []
+                content {
+                  dynamic "exclude_signature_contexts" {
+                    for_each = rules.value.exclude_signatures
+                    iterator = s
+                    content {
+                      signature_id = s.value.signature_id
+                      context      = s.value.context
+                      context_name = s.value.context_name
+                    }
                   }
-                }
-                dynamic "exclude_violation_contexts" {
-                  for_each = rules.value.exclude_violations
-                  iterator = v
-                  content {
-                    exclude_violation = v.value.violation
-                    context           = v.value.context
-                    context_name      = v.value.context_name
+                  dynamic "exclude_violation_contexts" {
+                    for_each = rules.value.exclude_violations
+                    iterator = v
+                    content {
+                      exclude_violation = v.value.violation
+                      context           = v.value.context
+                      context_name      = v.value.context_name
+                    }
                   }
-                }
-                dynamic "exclude_attack_type_contexts" {
-                  for_each = rules.value.exclude_attack_types
-                  iterator = a
-                  content {
-                    exclude_attack_type = a.value.attack_type
-                    context             = a.value.context
-                    context_name        = a.value.context_name
+                  dynamic "exclude_attack_type_contexts" {
+                    for_each = rules.value.exclude_attack_types
+                    iterator = a
+                    content {
+                      exclude_attack_type = a.value.attack_type
+                      context             = a.value.context
+                      context_name        = a.value.context_name
+                    }
                   }
-                }
-                dynamic "exclude_bot_name_contexts" {
-                  for_each = rules.value.exclude_bot_names
-                  iterator = b
-                  content {
-                    bot_name = b.value
+                  dynamic "exclude_bot_name_contexts" {
+                    for_each = rules.value.exclude_bot_names
+                    iterator = b
+                    content {
+                      bot_name = b.value
+                    }
                   }
                 }
               }
@@ -2216,6 +2228,18 @@ resource "xcsh_http_loadbalancer" "this" {
     precondition {
       condition     = length(var.api_crawler_domains) == 0 || local.api_crawler_password_secret.url != null || local.api_crawler_password_secret.location != null
       error_message = "api_crawler_domains is set but api_crawler_password has no value: set plaintext (clear) or location (blindfold)."
+    }
+
+    # WAF exclusion is a oneof: inline rules (waf_exclusion_rules) XOR a policy reference
+    # (waf_exclusion_policy_ref). Both set at once is invalid — a cross-variable check.
+    precondition {
+      condition     = !(length(var.waf_exclusion_rules) > 0 && var.waf_exclusion_policy_ref != null)
+      error_message = "waf_exclusion_rules and waf_exclusion_policy_ref are mutually exclusive (waf_exclusion is a oneof)."
+    }
+    # A referenced policy must be one of the defined waf_exclusion_policies.
+    precondition {
+      condition     = var.waf_exclusion_policy_ref == null || contains([for p in var.waf_exclusion_policies : p.name], var.waf_exclusion_policy_ref)
+      error_message = "waf_exclusion_policy_ref must name an entry in waf_exclusion_policies."
     }
 
     # Code-scan discovery lives inside enable_api_discovery and references the

--- a/terraform/modules/http-lb/outputs_waf_exclusion_policy.tf
+++ b/terraform/modules/http-lb/outputs_waf_exclusion_policy.tf
@@ -1,0 +1,5 @@
+# Names of the standalone WAF exclusion policies created (LPC-4b), for reference/visibility.
+output "waf_exclusion_policy_names" {
+  description = "Names of created standalone xcsh_waf_exclusion_policy resources."
+  value       = [for p in xcsh_waf_exclusion_policy.this : p.name]
+}

--- a/terraform/modules/http-lb/variables_waf_exclusion_policy.tf
+++ b/terraform/modules/http-lb/variables_waf_exclusion_policy.tf
@@ -1,0 +1,64 @@
+# LPC-4b: standalone xcsh_waf_exclusion_policy resources + the LB's waf_exclusion_policy ref
+# arm. A policy is authored once (a named set of exclusion rules) and referenced by the LB via
+# waf_exclusion_policy_ref. The rule shape is identical to the inline waf_exclusion_rules (4a).
+
+variable "waf_exclusion_policies" {
+  description = "Standalone WAF exclusion policies (name -> ordered rules), referenceable by the LB."
+  type = list(object({
+    name = string
+    rules = list(object({
+      name                 = string
+      description          = optional(string)
+      domain               = optional(string, "any") # any|exact|suffix
+      domain_value         = optional(string)
+      path                 = optional(string, "any") # any|prefix|regex
+      path_value           = optional(string)
+      methods              = optional(list(string), [])
+      expiration_timestamp = optional(string)
+      action               = optional(string, "skip") # skip | detection_control
+      exclude_signatures = optional(list(object({
+        signature_id = number
+        context      = optional(string, "CONTEXT_ANY")
+        context_name = optional(string)
+      })), [])
+      exclude_violations = optional(list(object({
+        violation    = string
+        context      = optional(string, "CONTEXT_ANY")
+        context_name = optional(string)
+      })), [])
+      exclude_attack_types = optional(list(object({
+        attack_type  = string
+        context      = optional(string, "CONTEXT_ANY")
+        context_name = optional(string)
+      })), [])
+      exclude_bot_names = optional(list(string), [])
+    }))
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([for p in var.waf_exclusion_policies : alltrue([
+      for r in p.rules : contains(["any", "exact", "suffix"], r.domain) && contains(["any", "prefix", "regex"], r.path) && contains(["skip", "detection_control"], r.action)
+    ])])
+    error_message = "waf_exclusion_policies[].rules[] domain/path/action must be valid selectors."
+  }
+  validation {
+    condition = alltrue([for p in var.waf_exclusion_policies : alltrue([
+      for r in p.rules : (r.domain == "any" || (r.domain_value != null && r.domain_value != "")) && (r.path == "any" || (r.path_value != null && r.path_value != ""))
+    ])])
+    error_message = "waf_exclusion_policies[].rules[] require domain_value/path_value for non-any selectors."
+  }
+  validation {
+    condition = alltrue([for p in var.waf_exclusion_policies : alltrue([
+      for r in p.rules : r.action != "detection_control" ||
+      (length(r.exclude_signatures) + length(r.exclude_violations) + length(r.exclude_attack_types) + length(r.exclude_bot_names)) > 0
+    ])])
+    error_message = "waf_exclusion_policies[].rules[] with action=detection_control must define at least one exclusion."
+  }
+}
+
+variable "waf_exclusion_policy_ref" {
+  description = "Name of a waf_exclusion_policies entry to attach to the LB (ref arm). null = none."
+  type        = string
+  default     = null
+}

--- a/terraform/modules/http-lb/waf_exclusion_policy.tf
+++ b/terraform/modules/http-lb/waf_exclusion_policy.tf
@@ -1,0 +1,77 @@
+# Standalone WAF exclusion policies (LPC-4b). See variables_waf_exclusion_policy.tf. for_each
+# keyed by name so the LB waf_exclusion.waf_exclusion_policy arm can reference a specific policy
+# via xcsh_waf_exclusion_policy.this[<name>]. The rule shape mirrors the inline arm (4a).
+resource "xcsh_waf_exclusion_policy" "this" {
+  for_each = { for p in var.waf_exclusion_policies : p.name => p }
+
+  name      = each.value.name
+  namespace = var.namespace
+
+  dynamic "waf_exclusion_rules" {
+    for_each = each.value.rules
+    iterator = rule
+    content {
+      metadata {
+        name             = rule.value.name
+        description_spec = rule.value.description
+      }
+      dynamic "any_domain" {
+        for_each = rule.value.domain == "any" ? [1] : []
+        content {}
+      }
+      exact_value  = rule.value.domain == "exact" ? rule.value.domain_value : null
+      suffix_value = rule.value.domain == "suffix" ? rule.value.domain_value : null
+      dynamic "any_path" {
+        for_each = rule.value.path == "any" ? [1] : []
+        content {}
+      }
+      path_prefix          = rule.value.path == "prefix" ? rule.value.path_value : null
+      path_regex           = rule.value.path == "regex" ? rule.value.path_value : null
+      methods              = length(rule.value.methods) > 0 ? rule.value.methods : null
+      expiration_timestamp = rule.value.expiration_timestamp
+      dynamic "waf_skip_processing" {
+        for_each = rule.value.action == "skip" ? [1] : []
+        content {}
+      }
+      dynamic "app_firewall_detection_control" {
+        for_each = rule.value.action == "detection_control" ? [1] : []
+        content {
+          dynamic "exclude_signature_contexts" {
+            for_each = rule.value.exclude_signatures
+            iterator = s
+            content {
+              signature_id = s.value.signature_id
+              context      = s.value.context
+              context_name = s.value.context_name
+            }
+          }
+          dynamic "exclude_violation_contexts" {
+            for_each = rule.value.exclude_violations
+            iterator = v
+            content {
+              exclude_violation = v.value.violation
+              context           = v.value.context
+              context_name      = v.value.context_name
+            }
+          }
+          dynamic "exclude_attack_type_contexts" {
+            for_each = rule.value.exclude_attack_types
+            iterator = a
+            content {
+              exclude_attack_type = a.value.attack_type
+              context             = a.value.context
+              context_name        = a.value.context_name
+            }
+          }
+          dynamic "exclude_bot_name_contexts" {
+            for_each = rule.value.exclude_bot_names
+            iterator = b
+            content {
+              bot_name = b.value
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/terraform/tests/waf_exclusion_policy.tftest.hcl
+++ b/terraform/tests/waf_exclusion_policy.tftest.hcl
@@ -1,0 +1,86 @@
+# Plan-level tests for LPC-4b: standalone xcsh_waf_exclusion_policy + LB waf_exclusion_policy
+# ref arm. Targets ./modules/http-lb. command = plan (no creds).
+variables {
+  namespace         = "webapp-api-protection"
+  lb_domains        = ["www.f5-sales-demo.com"]
+  origin_ip         = "203.0.113.10"
+  origin_port       = 80
+  health_check_path = "/health"
+  labels            = {}
+  csd_enabled       = false
+  mud_enabled       = false
+}
+
+run "standalone_policy_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    waf_exclusion_policies = [{
+      name = "excl-pol-a"
+      rules = [{
+        name       = "skip-probe"
+        path       = "prefix"
+        path_value = "/probe"
+        action     = "skip"
+      }]
+    }]
+  }
+  assert {
+    condition     = xcsh_waf_exclusion_policy.this["excl-pol-a"].name == "excl-pol-a"
+    error_message = "standalone policy name must render"
+  }
+  assert {
+    condition     = xcsh_waf_exclusion_policy.this["excl-pol-a"].waf_exclusion_rules[0].path_prefix == "/probe"
+    error_message = "standalone policy rule must render"
+  }
+}
+
+run "lb_ref_arm_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    waf_exclusion_policies = [{
+      name  = "excl-pol-a"
+      rules = [{ name = "r", action = "skip" }]
+    }]
+    waf_exclusion_policy_ref = "excl-pol-a"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.waf_exclusion.waf_exclusion_policy.name == "excl-pol-a"
+    error_message = "LB waf_exclusion_policy ref arm must render the referenced policy name"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.waf_exclusion.waf_exclusion_inline_rules == null
+    error_message = "inline arm must be omitted when the policy ref arm is used"
+  }
+}
+
+run "policy_and_inline_mutually_exclusive" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    waf_exclusion_policies   = [{ name = "p", rules = [{ name = "r", action = "skip" }] }]
+    waf_exclusion_policy_ref = "p"
+    waf_exclusion_rules      = [{ name = "inline", action = "skip" }]
+  }
+  expect_failures = [xcsh_http_loadbalancer.this]
+}
+
+run "ref_must_exist_in_policies" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    waf_exclusion_policies   = [{ name = "p", rules = [{ name = "r", action = "skip" }] }]
+    waf_exclusion_policy_ref = "does-not-exist"
+  }
+  expect_failures = [xcsh_http_loadbalancer.this]
+}
+
+run "no_policies_by_default" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  assert {
+    condition     = length(xcsh_waf_exclusion_policy.this) == 0
+    error_message = "no standalone policies by default"
+  }
+}

--- a/terraform/variables_waf_exclusion_policy.tf
+++ b/terraform/variables_waf_exclusion_policy.tf
@@ -1,0 +1,12 @@
+# Root passthrough for standalone WAF exclusion policies + LB ref selector (LPC-4b).
+variable "waf_exclusion_policies" {
+  description = "Standalone WAF exclusion policies (see module for shape)."
+  type        = any
+  default     = []
+}
+
+variable "waf_exclusion_policy_ref" {
+  description = "Name of a waf_exclusion_policies entry to attach to the LB. null = none."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
## Summary

Completes LPC-4 (task #70): the reusable standalone `xcsh_waf_exclusion_policy` resource and
the LB `waf_exclusion.waf_exclusion_policy` **reference arm** — the other side of the
waf_exclusion oneof, complementing LPC-4a's inline rules (#103).

- `waf_exclusion_policies` (list of `{name, rules}`) → `for_each xcsh_waf_exclusion_policy.this`,
  reusing the LPC-4a rule shape (metadata, domain/path oneofs, methods, expiration, action
  oneof `waf_skip_processing` | `app_firewall_detection_control`).
- `waf_exclusion_policy_ref` selector → the LB `waf_exclusion_policy` ref arm.
- lifecycle preconditions: inline `waf_exclusion_rules` and `waf_exclusion_policy_ref` are
  mutually exclusive (the oneof); a referenced policy must name a defined
  `waf_exclusion_policies` entry.

## No provider change

The standalone resource round-trips import-clean with real signature IDs. `signature_id = 0`
("all signatures") hits a distinct provider zero-value-omission bug filed as
[terraform-provider-xcsh#1129](https://github.com/f5-sales-demo/terraform-provider-xcsh/issues/1129);
the matrix uses real signature IDs (200000001–299999999) and is unaffected.

## Verification

- `terraform test -filter=tests/waf_exclusion_policy.tftest.hcl` → **5 passed, 0 failed**
  (standalone render, LB ref-arm render, mutual-exclusion + ref-exists preconditions via
  `expect_failures`, null-default).
- Live matrix (`scripts/waf-exclusion-policy-matrix.sh`, 4 variants): standalone policy
  (skip / detection_control, single + multi rules) + LB ref arm + canonical → apply →
  idempotent → **round-trip import of the policy resource and the whole LB** → canonical
  0-change. **4/4 PASS, 0 FAIL, 0 SKIP.** LB left canonical.

Closes #105.
