### PR TITLE
LPC-5a: exhaustive xcsh_healthcheck coverage (http/tcp, host oneof, thresholds)

### DIFF
--- a/scripts/healthcheck-matrix.sh
+++ b/scripts/healthcheck-matrix.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# xcsh_healthcheck (LPC-5a) live coverage-matrix harness.
+#
+# Cycles the LIVE origin health check through the healthcheck_pairs variant set and verifies
+# each variant (a) applies, (b) is idempotent (immediate plan = No changes), and (c) is
+# round-trip-import clean for xcsh_healthcheck.origin (state rm -> import -> plan clean). Ends
+# on canonical-restore so the live health check is left at http /health (200, 3/1/3/15).
+# Results append to reports/healthcheck-matrix.txt.
+#
+# Every variant keeps the HTTP origin healthy (http on /health with 200 accepted, or a tcp
+# probe on the pool port), so the LB keeps serving www/api throughout. Sequential — no
+# concurrent terraform against the shared azurerm state.
+#
+# Usage: healthcheck-matrix.sh [START [END]]  (inclusive 0-based index range).
+set -uo pipefail
+
+umask 077
+trap 'rm -rf /tmp/lpc5a-variants 2>/dev/null; rm -f /tmp/lpc5a-*.log 2>/dev/null' EXIT
+
+cd "$(dirname "$0")/../terraform" || exit 1
+ARM_ACCESS_KEY=$(az storage account keys list -n f5salesdemotfstate -g f5-sales-demo-tfstate --query "[0].value" -o tsv)
+export ARM_ACCESS_KEY
+
+NS="webapp-api-protection"
+HC_ADDR="module.http_lb.xcsh_healthcheck.origin"
+HC_ID="${NS}/origin-healthcheck"
+COMMON=(-input=false -lock=true
+  -var 'lb_domains=["www.f5-sales-demo.com","api.f5-sales-demo.com"]'
+  -var 'subscription_id=75f86c46-9cbc-4f6c-85ea-195e3d3c8ac0')
+VARDIR=/tmp/lpc5a-variants
+REPORT=../reports/healthcheck-matrix.txt
+mkdir -p ../reports
+
+START="${1:-0}"
+END="${2:-9999}"
+
+[ "$#" -eq 0 ] && : >"$REPORT"
+
+count=$(python3 ../scripts/healthcheck_pairs.py --emit "$VARDIR")
+echo "generated $count variants into $VARDIR (running [$START..$END])"
+
+round_trip() {
+  local label="$1" vf="$2"
+  terraform state rm "$HC_ADDR" >/dev/null 2>&1 || {
+    echo "FAIL $label state-rm" >>"$REPORT"
+    return
+  }
+  terraform import "${COMMON[@]}" -var-file="$vf" "$HC_ADDR" "$HC_ID" >/tmp/lpc5a-import.log 2>&1 || {
+    echo "FAIL $label import ($(grep -iE 'error' /tmp/lpc5a-import.log | head -1 | cut -c1-60))" >>"$REPORT"
+    return
+  }
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$vf" >/tmp/lpc5a-rt-plan.log 2>&1
+  case $? in
+  0) echo "PASS $label" >>"$REPORT" ;;
+  2) echo "FAIL $label import-drift" >>"$REPORT" ;;
+  *) echo "FAIL $label rt-plan-error" >>"$REPORT" ;;
+  esac
+}
+
+while read -r idx name vf _flag; do
+  [ "$idx" -lt "$START" ] && continue
+  [ "$idx" -gt "$END" ] && continue
+  label="$idx-$name"
+  echo "--- $label ---"
+  varfile="${VARDIR}/${vf}"
+  if ! terraform apply -auto-approve "${COMMON[@]}" -var-file="$varfile" >/tmp/lpc5a-apply.log 2>&1; then
+    echo "FAIL $label apply ($(grep -iE 'error' /tmp/lpc5a-apply.log | head -1 | cut -c1-80))" >>"$REPORT"
+    continue
+  fi
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$varfile" >/tmp/lpc5a-plan.log 2>&1
+  case $? in
+  0) round_trip "$label" "$varfile" ;;
+  2) echo "FAIL $label not-idempotent" >>"$REPORT" ;;
+  *) echo "FAIL $label plan-error" >>"$REPORT" ;;
+  esac
+done <"${VARDIR}/manifest.txt"
+
+echo "===== HEALTHCHECK MATRIX RESULTS ($START..$END) ====="
+cat "$REPORT"
+echo "PASS=$(grep -c '^PASS ' "$REPORT") FAIL=$(grep -c '^FAIL ' "$REPORT") SKIP=$(grep -c '^SKIP ' "$REPORT")"

--- a/scripts/healthcheck_pairs.py
+++ b/scripts/healthcheck_pairs.py
@@ -32,7 +32,7 @@ CANONICAL = {
 
 def _v(name: str, **overrides: object) -> dict[str, object]:
     """A variant = canonical with the named overrides applied."""
-    vars_ = dict(CANONICAL)
+    vars_: dict[str, object] = dict(CANONICAL)
     vars_.update(overrides)
     return {"name": name, "vars": vars_}
 

--- a/scripts/healthcheck_pairs.py
+++ b/scripts/healthcheck_pairs.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Generate the xcsh_healthcheck (LPC-5a) coverage matrix.
+
+Explicit safe variants over the health-check surface, each applied to the LIVE origin health
+check. The type oneof (http/tcp) makes a full cartesian degenerate, so variants are enumerated
+directly. EVERY variant must keep the HTTP origin healthy (http on /health with 200 in the
+accepted codes, or a tcp connect/send probe on the pool port) so the LB keeps serving —
+udp_icmp is intentionally excluded. Ends on canonical-restore (http /health, 200, 3/1/3/15).
+
+Deterministic (no RNG). Output: JSON to stdout, or files via --emit.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+CANONICAL = {
+    "health_check_type": "http",
+    "hc_http_host_header": None,
+    "hc_expected_status_codes": ["200"],
+    "hc_expected_response": None,
+    "hc_request_headers_to_remove": [],
+    "hc_tcp_send_payload": None,
+    "hc_tcp_expected_response": None,
+    "hc_healthy_threshold": 3,
+    "hc_unhealthy_threshold": 1,
+    "hc_timeout": 3,
+    "hc_interval": 15,
+    "hc_jitter_percent": None,
+}
+
+
+def _v(name: str, **overrides: object) -> dict[str, object]:
+    """A variant = canonical with the named overrides applied."""
+    vars_ = dict(CANONICAL)
+    vars_.update(overrides)
+    return {"name": name, "vars": vars_}
+
+
+def build() -> list[dict[str, object]]:
+    """Ordered variant manifest. Every http variant keeps 200 in the accepted codes."""
+    return [
+        _v("http-host-header", hc_http_host_header="www.f5-sales-demo.com"),
+        _v(
+            "http-codes-range-headers",
+            hc_expected_status_codes=["200", "301-302"],
+            hc_request_headers_to_remove=["x-debug"],
+        ),
+        _v(
+            "http-tuned-thresholds",
+            hc_healthy_threshold=5,
+            hc_unhealthy_threshold=2,
+            hc_timeout=5,
+            hc_interval=30,
+            hc_jitter_percent=20,
+        ),
+        _v("tcp-connect-only", health_check_type="tcp"),
+        _v("tcp-send-payload", health_check_type="tcp", hc_tcp_send_payload="50494e47"),
+        _v("canonical-restore"),
+    ]
+
+
+def emit(directory: str) -> int:
+    """Write one <NNN>-<name>.tfvars.json per variant plus manifest.txt."""
+    out_dir = Path(directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for existing in out_dir.iterdir():
+        if existing.name.endswith(".tfvars.json") or existing.name == "manifest.txt":
+            existing.unlink()
+    variants = build()
+    named = [(f"{i:03d}-{v['name']}.tfvars.json", v) for i, v in enumerate(variants)]
+    for fname, v in named:
+        (out_dir / fname).write_text(json.dumps(v["vars"], indent=2) + "\n")
+    lines = [f"{i:03d} {v['name']} {fname} LIVE" for i, (fname, v) in enumerate(named)]
+    (out_dir / "manifest.txt").write_text("\n".join(lines) + "\n")
+    return len(variants)
+
+
+def main(argv: list[str]) -> None:
+    """CLI: --count, --emit <dir>, else JSON to stdout."""
+    match argv[1:]:
+        case ["--count"]:
+            sys.stdout.write(f"{len(build())}\n")
+        case ["--emit", directory]:
+            sys.stdout.write(f"{emit(directory)}\n")
+        case _:
+            json.dump(build(), sys.stdout, indent=2)
+            sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -61,9 +61,23 @@ module "http_lb" {
   origin_ip         = module.origin_server.public_ip
   origin_port       = var.origin_port
   health_check_path = var.health_check_path
-  labels            = var.labels
-  waf_mode          = var.waf_mode
-  csd_enabled       = var.csd_enabled
+
+  # LPC-5a healthcheck parameterization passthrough (defaults reproduce the http /health check).
+  health_check_type            = var.health_check_type
+  hc_healthy_threshold         = var.hc_healthy_threshold
+  hc_unhealthy_threshold       = var.hc_unhealthy_threshold
+  hc_timeout                   = var.hc_timeout
+  hc_interval                  = var.hc_interval
+  hc_jitter_percent            = var.hc_jitter_percent
+  hc_http_host_header          = var.hc_http_host_header
+  hc_expected_status_codes     = var.hc_expected_status_codes
+  hc_expected_response         = var.hc_expected_response
+  hc_request_headers_to_remove = var.hc_request_headers_to_remove
+  hc_tcp_send_payload          = var.hc_tcp_send_payload
+  hc_tcp_expected_response     = var.hc_tcp_expected_response
+  labels                       = var.labels
+  waf_mode                     = var.waf_mode
+  csd_enabled                  = var.csd_enabled
 
   # WAF (app_firewall) exhaustive-coverage passthrough.
   waf_allowed_response_codes_mode = var.waf_allowed_response_codes_mode

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -22,16 +22,37 @@ resource "xcsh_healthcheck" "origin" {
   namespace = var.namespace
   labels    = var.labels
 
-  healthy_threshold   = 3
-  unhealthy_threshold = 1
-  timeout             = 3
-  interval            = 15
+  healthy_threshold   = var.hc_healthy_threshold
+  unhealthy_threshold = var.hc_unhealthy_threshold
+  timeout             = var.hc_timeout
+  interval            = var.hc_interval
+  jitter_percent      = var.hc_jitter_percent
 
-  http_health_check {
-    # The origin server's nginx returns 200 on /health for any Host, so no
-    # host_header override is needed (unlike the previous public_name origin).
-    path                  = var.health_check_path
-    expected_status_codes = ["200"]
+  # LPC-5a: http vs tcp health check (oneof). Defaults reproduce the original config (http on
+  # health_check_path expecting 200). The origin nginx returns 200 on /health for any Host, so
+  # host handling defaults to none; a tcp check is a connect-only probe on the pool port.
+  dynamic "http_health_check" {
+    for_each = var.health_check_type == "http" ? [1] : []
+    content {
+      path                  = var.health_check_path
+      expected_status_codes = var.hc_expected_status_codes
+      # http host oneof: explicit host_header, else use_origin_server_name (the server default
+      # when no host_header). Emit exactly one arm to match the server on import.
+      host_header = var.hc_http_host_header
+      dynamic "use_origin_server_name" {
+        for_each = var.hc_http_host_header == null ? [1] : []
+        content {}
+      }
+      expected_response         = var.hc_expected_response
+      request_headers_to_remove = length(var.hc_request_headers_to_remove) > 0 ? var.hc_request_headers_to_remove : null
+    }
+  }
+  dynamic "tcp_health_check" {
+    for_each = var.health_check_type == "tcp" ? [1] : []
+    content {
+      send_payload      = var.hc_tcp_send_payload
+      expected_response = var.hc_tcp_expected_response
+    }
   }
 }
 

--- a/terraform/modules/http-lb/variables_healthcheck.tf
+++ b/terraform/modules/http-lb/variables_healthcheck.tf
@@ -1,0 +1,90 @@
+# LPC-5a: xcsh_healthcheck.origin parameterization. Defaults reproduce today's config exactly
+# (http health check on health_check_path expecting 200; thresholds 3/1/3/15) so a plain apply
+# is 0-change. The check must keep the HTTP origin healthy — udp_icmp is intentionally not
+# offered (it would mark the origin down and stop the LB serving).
+
+variable "health_check_type" {
+  description = "Health check type: http or tcp. (udp_icmp is unsupported here — it breaks the HTTP origin.)"
+  type        = string
+  default     = "http"
+  validation {
+    condition     = contains(["http", "tcp"], var.health_check_type)
+    error_message = "health_check_type must be http or tcp."
+  }
+}
+
+variable "hc_healthy_threshold" {
+  description = "Consecutive successful checks to mark the origin healthy."
+  type        = number
+  default     = 3
+}
+
+variable "hc_unhealthy_threshold" {
+  description = "Consecutive failed checks to mark the origin unhealthy."
+  type        = number
+  default     = 1
+}
+
+variable "hc_timeout" {
+  description = "Health check timeout (seconds)."
+  type        = number
+  default     = 3
+}
+
+variable "hc_interval" {
+  description = "Health check interval (seconds)."
+  type        = number
+  default     = 15
+}
+
+variable "hc_jitter_percent" {
+  description = "Jitter percent applied to the interval. null omits (server default)."
+  type        = number
+  default     = null
+}
+
+# --- http_health_check fields ---
+# Host handling is the http host oneof: set hc_http_host_header to send an explicit Host header;
+# leave it null to use the origin server name (use_origin_server_name {}), which is the F5 XC
+# server default whenever no host_header is set. The module emits exactly one arm to match the
+# server, so the import round-trip stays clean.
+variable "hc_http_host_header" {
+  description = "Host header for the health check. null => use_origin_server_name (server default)."
+  type        = string
+  default     = null
+}
+
+variable "hc_expected_status_codes" {
+  description = "HTTP status codes considered healthy (single codes or start-end ranges)."
+  type        = list(string)
+  default     = ["200"]
+}
+
+variable "hc_expected_response" {
+  description = "Hex-encoded raw bytes expected in the response body. null = not checked."
+  type        = string
+  default     = null
+}
+
+variable "hc_request_headers_to_remove" {
+  description = "HTTP headers removed from each health-check request."
+  type        = list(string)
+  default     = []
+}
+
+# use_http2 is intentionally not exposed: the provider import-suppresses it on Healthcheck, so a
+# module-emitted value cannot round-trip cleanly (tracked for a follow-up provider rework). The
+# server default (HTTP/1.1) stands.
+
+# --- tcp_health_check fields ---
+variable "hc_tcp_send_payload" {
+  description = "Hex-encoded bytes to send (tcp). Empty = connect-only check."
+  type        = string
+  default     = null
+}
+
+variable "hc_tcp_expected_response" {
+  description = "Hex-encoded bytes expected in the tcp response. null = connect-only."
+  type        = string
+  default     = null
+}

--- a/terraform/tests/healthcheck.tftest.hcl
+++ b/terraform/tests/healthcheck.tftest.hcl
@@ -1,0 +1,101 @@
+# Plan-level tests for LPC-5a: xcsh_healthcheck.origin parameterization. Targets
+# ./modules/http-lb. command = plan (no creds).
+variables {
+  namespace         = "webapp-api-protection"
+  lb_domains        = ["www.f5-sales-demo.com"]
+  origin_ip         = "203.0.113.10"
+  origin_port       = 80
+  health_check_path = "/health"
+  labels            = {}
+  csd_enabled       = false
+  mud_enabled       = false
+}
+
+run "default_is_http_health_check" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  assert {
+    condition     = xcsh_healthcheck.origin.http_health_check.path == "/health"
+    error_message = "default must be an http health check on /health"
+  }
+  assert {
+    condition     = xcsh_healthcheck.origin.http_health_check.expected_status_codes[0] == "200"
+    error_message = "default expected_status_codes must be [200]"
+  }
+  assert {
+    condition     = xcsh_healthcheck.origin.tcp_health_check == null
+    error_message = "tcp_health_check must be null by default"
+  }
+}
+
+run "http_host_header_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    hc_http_host_header = "www.f5-sales-demo.com"
+  }
+  assert {
+    condition     = xcsh_healthcheck.origin.http_health_check.host_header == "www.f5-sales-demo.com"
+    error_message = "host_header must render when hc_http_host_header is set"
+  }
+  assert {
+    condition     = xcsh_healthcheck.origin.http_health_check.use_origin_server_name == null
+    error_message = "use_origin_server_name must be omitted when host_header is set"
+  }
+}
+
+run "default_uses_origin_server_name" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  assert {
+    condition     = xcsh_healthcheck.origin.http_health_check.use_origin_server_name != null
+    error_message = "use_origin_server_name arm must render when no host_header (server default)"
+  }
+  assert {
+    condition     = xcsh_healthcheck.origin.http_health_check.host_header == null
+    error_message = "host_header must be null by default"
+  }
+}
+
+run "tcp_health_check_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    health_check_type   = "tcp"
+    hc_tcp_send_payload = "50494e47"
+  }
+  assert {
+    condition     = xcsh_healthcheck.origin.tcp_health_check.send_payload == "50494e47"
+    error_message = "tcp send_payload must render"
+  }
+  assert {
+    condition     = xcsh_healthcheck.origin.http_health_check == null
+    error_message = "http_health_check must be null for type=tcp"
+  }
+}
+
+run "thresholds_render" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    hc_healthy_threshold = 5
+    hc_interval          = 30
+    hc_jitter_percent    = 20
+  }
+  assert {
+    condition     = xcsh_healthcheck.origin.healthy_threshold == 5
+    error_message = "healthy_threshold must render"
+  }
+  assert {
+    condition     = xcsh_healthcheck.origin.jitter_percent == 20
+    error_message = "jitter_percent must render"
+  }
+}
+
+run "bad_type_rejected" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { health_check_type = "udp_icmp" }
+  expect_failures = [var.health_check_type]
+}
+

--- a/terraform/variables_healthcheck.tf
+++ b/terraform/variables_healthcheck.tf
@@ -1,0 +1,50 @@
+# Root passthrough for LPC-5a healthcheck parameterization. Defaults mirror the module so a
+# plain apply is 0-change.
+variable "health_check_type" {
+  type    = string
+  default = "http"
+}
+variable "hc_healthy_threshold" {
+  type    = number
+  default = 3
+}
+variable "hc_unhealthy_threshold" {
+  type    = number
+  default = 1
+}
+variable "hc_timeout" {
+  type    = number
+  default = 3
+}
+variable "hc_interval" {
+  type    = number
+  default = 15
+}
+variable "hc_jitter_percent" {
+  type    = number
+  default = null
+}
+variable "hc_http_host_header" {
+  type    = string
+  default = null
+}
+variable "hc_expected_status_codes" {
+  type    = list(string)
+  default = ["200"]
+}
+variable "hc_expected_response" {
+  type    = string
+  default = null
+}
+variable "hc_request_headers_to_remove" {
+  type    = list(string)
+  default = []
+}
+variable "hc_tcp_send_payload" {
+  type    = string
+  default = null
+}
+variable "hc_tcp_expected_response" {
+  type    = string
+  default = null
+}


### PR DESCRIPTION
## Summary

LPC-5a of the LB-protection coverage effort (task #70): parameterize and live-verify the origin
health check (`xcsh_healthcheck.origin`), previously hardcoded.

- `health_check_type` oneof: `http` | `tcp` (udp_icmp excluded — it would mark the HTTP origin
  unhealthy and stop the LB serving www/api).
- http host oneof: `hc_http_host_header` (explicit Host) vs `use_origin_server_name` (server
  default when no host_header).
- http: `hc_expected_status_codes`, `hc_expected_response`, `hc_request_headers_to_remove`.
- tcp: `hc_tcp_send_payload`, `hc_tcp_expected_response`.
- thresholds: healthy/unhealthy, timeout, interval, jitter_percent.

Defaults reproduce today's config (http /health, 200, 3/1/3/15) so a plain apply is 0-change.

## Import-cleanliness (module-side, no provider change)

- Emit exactly one http host arm to match the server oneof: `host_header` when set, else
  `use_origin_server_name {}` (the server default). Otherwise the whole-LB import drifts
  `- use_origin_server_name {}`.
- `use_http2` is intentionally not exposed: the provider import-suppresses it on Healthcheck, so
  a module-emitted value cannot round-trip cleanly. The server default (HTTP/1.1) stands; tracked
  for a follow-up provider rework.

## Verification

- `terraform test -filter=tests/healthcheck.tftest.hcl` → **6 passed, 0 failed** (default http,
  host_header, default use_origin_server_name, tcp, thresholds, bad-type `expect_failures`).
- Live matrix (`scripts/healthcheck-matrix.sh`, 6 variants): http (host_header /
  codes-range+headers / tuned-thresholds), tcp (connect-only / send-payload), canonical → apply →
  idempotent → `xcsh_healthcheck.origin` import round-trip → canonical 0-change. **6/6 PASS, 0
  FAIL, 0 SKIP.** The origin stayed healthy and the LB kept serving throughout.

Closes #107.
