### PR TITLE
LPC-5b: origin_pool coverage (loadbalancer_algorithm, endpoint_selection, advanced_options)

### DIFF
--- a/scripts/origin-pool-matrix.sh
+++ b/scripts/origin-pool-matrix.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# xcsh_origin_pool (LPC-5b) live coverage-matrix harness.
+#
+# Cycles the LIVE origin pool through the origin_pool_pairs variant set and verifies
+# each variant (a) applies, (b) is idempotent (immediate plan = No changes), and (c) is
+# round-trip-import clean for xcsh_origin_pool.origin (state rm -> import -> plan clean). Ends
+# on canonical-restore so the live pool is left at ROUND_ROBIN / DISTRIBUTED / no advanced_options.
+# Results append to reports/origin-pool-matrix.txt.
+#
+# Only the load-balancing algorithm, endpoint selection, and advanced_options timeouts vary;
+# origin_servers (public_ip) and TLS (no_tls) are fixed, so the LB keeps serving www/api
+# throughout. Sequential — no concurrent terraform against the shared azurerm state.
+#
+# Usage: origin-pool-matrix.sh [START [END]]  (inclusive 0-based index range).
+set -uo pipefail
+
+umask 077
+trap 'rm -rf /tmp/lpc5b-variants 2>/dev/null; rm -f /tmp/lpc5b-*.log 2>/dev/null' EXIT
+
+cd "$(dirname "$0")/../terraform" || exit 1
+ARM_ACCESS_KEY=$(az storage account keys list -n f5salesdemotfstate -g f5-sales-demo-tfstate --query "[0].value" -o tsv)
+export ARM_ACCESS_KEY
+
+NS="webapp-api-protection"
+POOL_ADDR="module.http_lb.xcsh_origin_pool.origin"
+POOL_ID="${NS}/origin-pool"
+COMMON=(-input=false -lock=true
+  -var 'lb_domains=["www.f5-sales-demo.com","api.f5-sales-demo.com"]'
+  -var 'subscription_id=75f86c46-9cbc-4f6c-85ea-195e3d3c8ac0')
+VARDIR=/tmp/lpc5b-variants
+REPORT=../reports/origin-pool-matrix.txt
+mkdir -p ../reports
+
+START="${1:-0}"
+END="${2:-9999}"
+
+[ "$#" -eq 0 ] && : >"$REPORT"
+
+count=$(python3 ../scripts/origin_pool_pairs.py --emit "$VARDIR")
+echo "generated $count variants into $VARDIR (running [$START..$END])"
+
+round_trip() {
+  local label="$1" vf="$2"
+  terraform state rm "$POOL_ADDR" >/dev/null 2>&1 || {
+    echo "FAIL $label state-rm" >>"$REPORT"
+    return
+  }
+  terraform import "${COMMON[@]}" -var-file="$vf" "$POOL_ADDR" "$POOL_ID" >/tmp/lpc5b-import.log 2>&1 || {
+    echo "FAIL $label import ($(grep -iE 'error' /tmp/lpc5b-import.log | head -1 | cut -c1-60))" >>"$REPORT"
+    return
+  }
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$vf" >/tmp/lpc5b-rt-plan.log 2>&1
+  case $? in
+  0) echo "PASS $label" >>"$REPORT" ;;
+  2) echo "FAIL $label import-drift" >>"$REPORT" ;;
+  *) echo "FAIL $label rt-plan-error" >>"$REPORT" ;;
+  esac
+}
+
+while read -r idx name vf _flag; do
+  [ "$idx" -lt "$START" ] && continue
+  [ "$idx" -gt "$END" ] && continue
+  label="$idx-$name"
+  echo "--- $label ---"
+  varfile="${VARDIR}/${vf}"
+  if ! terraform apply -auto-approve "${COMMON[@]}" -var-file="$varfile" >/tmp/lpc5b-apply.log 2>&1; then
+    echo "FAIL $label apply ($(grep -iE 'error' /tmp/lpc5b-apply.log | head -1 | cut -c1-80))" >>"$REPORT"
+    continue
+  fi
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$varfile" >/tmp/lpc5b-plan.log 2>&1
+  case $? in
+  0) round_trip "$label" "$varfile" ;;
+  2) echo "FAIL $label not-idempotent" >>"$REPORT" ;;
+  *) echo "FAIL $label plan-error" >>"$REPORT" ;;
+  esac
+done <"${VARDIR}/manifest.txt"
+
+echo "===== ORIGIN POOL MATRIX RESULTS ($START..$END) ====="
+cat "$REPORT"
+echo "PASS=$(grep -c '^PASS ' "$REPORT") FAIL=$(grep -c '^FAIL ' "$REPORT") SKIP=$(grep -c '^SKIP ' "$REPORT")"

--- a/scripts/origin_pool_pairs.py
+++ b/scripts/origin_pool_pairs.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Generate the origin_pool (LPC-5b) coverage matrix.
+
+AETG all-pairs over the safe origin-pool tuning axes, each applied to the LIVE pool. The pool
+is the serving path, so origin_servers (public_ip) and TLS (no_tls) are fixed — only the
+load-balancing algorithm, endpoint selection, and advanced_options timeouts vary. Plus
+canonical-restore (ROUND_ROBIN / DISTRIBUTED / no advanced_options).
+
+Dimensions:
+  algo  ROUND_ROBIN | LEAST_REQUEST | RANDOM   (RING_HASH/LB_OVERRIDE need companion config)
+  sel   DISTRIBUTED | LOCAL_ONLY | LOCAL_PREFERRED
+  adv   none | timeouts   (advanced_options connection_timeout + http_idle_timeout)
+
+Deterministic (no RNG). Output: JSON to stdout, or files via --emit.
+"""
+
+import itertools
+import json
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+DIMENSIONS = {
+    "algo": ["ROUND_ROBIN", "LEAST_REQUEST", "RANDOM"],
+    "sel": ["DISTRIBUTED", "LOCAL_ONLY", "LOCAL_PREFERRED"],
+    "adv": ["none", "timeouts"],
+}
+
+
+def _best_value(
+    values: list[str],
+    idx: int,
+    row: dict[int, str],
+    uncovered: set[tuple[int, str, int, str]],
+) -> str:
+    """Pick the value for dimension idx covering the most still-uncovered pairs."""
+    best_val, best_gain = values[0], -1
+    for val in values:
+        gain = 0
+        for pidx, pval in row.items():
+            a, b = sorted([(pidx, pval), (idx, val)])
+            if (a[0], a[1], b[0], b[1]) in uncovered:
+                gain += 1
+        if gain > best_gain:
+            best_gain, best_val = gain, val
+    return best_val
+
+
+def all_pairs(dims: dict[str, list[str]]) -> list[dict[str, str]]:
+    """Return AETG-style greedy all-pairs rows ({dim: value})."""
+    names = list(dims)
+    uncovered: set[tuple[int, str, int, str]] = set()
+    for i, j in itertools.combinations(range(len(names)), 2):
+        for vi in dims[names[i]]:
+            for vj in dims[names[j]]:
+                uncovered.add((i, vi, j, vj))
+
+    rows = []
+    while uncovered:
+        si, sv, sj, sv2 = min(uncovered)
+        row = {si: sv, sj: sv2}
+        for idx, name in enumerate(names):
+            if idx not in row:
+                row[idx] = _best_value(dims[name], idx, row, uncovered)
+        for i, j in itertools.combinations(sorted(row), 2):
+            uncovered.discard((i, row[i], j, row[j]))
+        rows.append({names[k]: v for k, v in row.items()})
+    return rows
+
+
+def payloads(v: Mapping[str, object]) -> dict[str, object]:
+    """Expand an LPC-5b row into real tfvars."""
+    out: dict[str, object] = {
+        "origin_lb_algorithm": v["algo"],
+        "origin_endpoint_selection": v["sel"],
+        "origin_connection_timeout": None,
+        "origin_http_idle_timeout": None,
+    }
+    if v["adv"] == "timeouts":
+        out["origin_connection_timeout"] = 3000
+        out["origin_http_idle_timeout"] = 300000
+    return out
+
+
+def canonical() -> dict[str, object]:
+    """Live-canonical end state (ROUND_ROBIN / DISTRIBUTED / no advanced_options)."""
+    return {
+        "origin_lb_algorithm": "ROUND_ROBIN",
+        "origin_endpoint_selection": "DISTRIBUTED",
+        "origin_connection_timeout": None,
+        "origin_http_idle_timeout": None,
+    }
+
+
+def build() -> list[dict[str, object]]:
+    """Build the ordered variant manifest (all-pairs + canonical), deduped."""
+    variants: list[dict[str, object]] = []
+    seen: set[str] = set()
+    idx = 0
+    for row in all_pairs(DIMENSIONS):
+        vars_ = payloads(row)
+        key = json.dumps(vars_, sort_keys=True)
+        if key in seen:
+            continue
+        seen.add(key)
+        variants.append({"name": f"pair-{idx:03d}", "vars": vars_})
+        idx += 1
+    variants.append({"name": "canonical-restore", "vars": canonical()})
+    return variants
+
+
+def emit(directory: str) -> int:
+    """Write one <NNN>-<name>.tfvars.json per variant plus manifest.txt."""
+    out_dir = Path(directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for existing in out_dir.iterdir():
+        if existing.name.endswith(".tfvars.json") or existing.name == "manifest.txt":
+            existing.unlink()
+    variants = build()
+    named = [(f"{i:03d}-{v['name']}.tfvars.json", v) for i, v in enumerate(variants)]
+    for fname, v in named:
+        (out_dir / fname).write_text(json.dumps(v["vars"], indent=2) + "\n")
+    lines = [f"{i:03d} {v['name']} {fname} LIVE" for i, (fname, v) in enumerate(named)]
+    (out_dir / "manifest.txt").write_text("\n".join(lines) + "\n")
+    return len(variants)
+
+
+def main(argv: list[str]) -> None:
+    """CLI: --count, --emit <dir>, else JSON to stdout."""
+    match argv[1:]:
+        case ["--count"]:
+            sys.stdout.write(f"{len(build())}\n")
+        case ["--emit", directory]:
+            sys.stdout.write(f"{emit(directory)}\n")
+        case _:
+            json.dump(build(), sys.stdout, indent=2)
+            sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -75,6 +75,10 @@ module "http_lb" {
   hc_request_headers_to_remove = var.hc_request_headers_to_remove
   hc_tcp_send_payload          = var.hc_tcp_send_payload
   hc_tcp_expected_response     = var.hc_tcp_expected_response
+  origin_lb_algorithm          = var.origin_lb_algorithm
+  origin_endpoint_selection    = var.origin_endpoint_selection
+  origin_connection_timeout    = var.origin_connection_timeout
+  origin_http_idle_timeout     = var.origin_http_idle_timeout
   labels                       = var.labels
   waf_mode                     = var.waf_mode
   csd_enabled                  = var.csd_enabled

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -63,8 +63,15 @@ resource "xcsh_origin_pool" "origin" {
 
   port = var.origin_port
 
+  # LPC-5b: load-balancing algorithm + endpoint selection. Defaults (ROUND_ROBIN / DISTRIBUTED)
+  # match the server defaults, so a plain apply is 0-change.
+  loadbalancer_algorithm = var.origin_lb_algorithm
+  endpoint_selection     = var.origin_endpoint_selection
+
   origin_servers {
-    labels {}
+    # origin_servers[].labels {} is a server-default empty marker the provider import-suppresses
+    # (OriginPool "labels"); emitting it drifts the direct origin_pool import (+ labels {}), same
+    # class as the endpoint_subsets fix (#94). Omit it — the server materializes the default.
     public_ip {
       ip = var.origin_ip
     }
@@ -73,6 +80,16 @@ resource "xcsh_origin_pool" "origin" {
   healthcheck {
     name      = xcsh_healthcheck.origin.name
     namespace = xcsh_healthcheck.origin.namespace
+  }
+
+  # LPC-5b: advanced_options connection tuning. Emitted only when a timeout is set (else the
+  # block is omitted for 0-change). Both are Computed server-default scalars.
+  dynamic "advanced_options" {
+    for_each = (var.origin_connection_timeout != null || var.origin_http_idle_timeout != null) ? [1] : []
+    content {
+      connection_timeout = var.origin_connection_timeout
+      http_idle_timeout  = var.origin_http_idle_timeout
+    }
   }
 
   no_tls {}

--- a/terraform/modules/http-lb/variables_origin_pool.tf
+++ b/terraform/modules/http-lb/variables_origin_pool.tf
@@ -1,0 +1,36 @@
+# LPC-5b: xcsh_origin_pool.origin tuning. origin_servers (public_ip) and TLS (no_tls) are the
+# live serving path and are NOT parameterized here. Defaults reproduce today's pool
+# (ROUND_ROBIN, DISTRIBUTED, no advanced_options) so a plain apply is 0-change.
+
+variable "origin_lb_algorithm" {
+  description = "Origin pool load-balancing algorithm: ROUND_ROBIN | LEAST_REQUEST | RANDOM."
+  type        = string
+  default     = "ROUND_ROBIN"
+  validation {
+    # RING_HASH / LB_OVERRIDE need companion route hash/override config, so they are excluded.
+    condition     = contains(["ROUND_ROBIN", "LEAST_REQUEST", "RANDOM"], var.origin_lb_algorithm)
+    error_message = "origin_lb_algorithm must be ROUND_ROBIN, LEAST_REQUEST, or RANDOM."
+  }
+}
+
+variable "origin_endpoint_selection" {
+  description = "Endpoint selection policy: DISTRIBUTED | LOCAL_ONLY | LOCAL_PREFERRED."
+  type        = string
+  default     = "DISTRIBUTED"
+  validation {
+    condition     = contains(["DISTRIBUTED", "LOCAL_ONLY", "LOCAL_PREFERRED"], var.origin_endpoint_selection)
+    error_message = "origin_endpoint_selection must be DISTRIBUTED, LOCAL_ONLY, or LOCAL_PREFERRED."
+  }
+}
+
+variable "origin_connection_timeout" {
+  description = "advanced_options.connection_timeout (ms) for new connections. null omits advanced_options."
+  type        = number
+  default     = null
+}
+
+variable "origin_http_idle_timeout" {
+  description = "advanced_options.http_idle_timeout (ms) for idle upstream connections. null omits."
+  type        = number
+  default     = null
+}

--- a/terraform/modules/http-lb/versions.tf
+++ b/terraform/modules/http-lb/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     xcsh = {
       source  = "f5-sales-demo/xcsh"
-      version = ">= 3.72.6"
+      version = ">= 3.72.7"
     }
   }
 }

--- a/terraform/tests/origin_pool.tftest.hcl
+++ b/terraform/tests/origin_pool.tftest.hcl
@@ -1,0 +1,77 @@
+# Plan-level tests for LPC-5b: xcsh_origin_pool.origin tuning. Targets ./modules/http-lb.
+# command = plan (no creds).
+variables {
+  namespace         = "webapp-api-protection"
+  lb_domains        = ["www.f5-sales-demo.com"]
+  origin_ip         = "203.0.113.10"
+  origin_port       = 80
+  health_check_path = "/health"
+  labels            = {}
+  csd_enabled       = false
+  mud_enabled       = false
+}
+
+run "defaults_round_robin_distributed" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  assert {
+    condition     = xcsh_origin_pool.origin.loadbalancer_algorithm == "ROUND_ROBIN"
+    error_message = "default loadbalancer_algorithm must be ROUND_ROBIN"
+  }
+  assert {
+    condition     = xcsh_origin_pool.origin.endpoint_selection == "DISTRIBUTED"
+    error_message = "default endpoint_selection must be DISTRIBUTED"
+  }
+  assert {
+    condition     = xcsh_origin_pool.origin.advanced_options == null
+    error_message = "advanced_options must be omitted by default"
+  }
+}
+
+run "algorithm_and_selection_render" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    origin_lb_algorithm       = "LEAST_REQUEST"
+    origin_endpoint_selection = "LOCAL_PREFERRED"
+  }
+  assert {
+    condition     = xcsh_origin_pool.origin.loadbalancer_algorithm == "LEAST_REQUEST"
+    error_message = "loadbalancer_algorithm must render"
+  }
+  assert {
+    condition     = xcsh_origin_pool.origin.endpoint_selection == "LOCAL_PREFERRED"
+    error_message = "endpoint_selection must render"
+  }
+}
+
+run "advanced_options_render" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    origin_connection_timeout = 3000
+    origin_http_idle_timeout  = 300000
+  }
+  assert {
+    condition     = xcsh_origin_pool.origin.advanced_options.connection_timeout == 3000
+    error_message = "advanced_options.connection_timeout must render"
+  }
+  assert {
+    condition     = xcsh_origin_pool.origin.advanced_options.http_idle_timeout == 300000
+    error_message = "advanced_options.http_idle_timeout must render"
+  }
+}
+
+run "bad_algorithm_rejected" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { origin_lb_algorithm = "RING_HASH" }
+  expect_failures = [var.origin_lb_algorithm]
+}
+
+run "bad_selection_rejected" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { origin_endpoint_selection = "GLOBAL" }
+  expect_failures = [var.origin_endpoint_selection]
+}

--- a/terraform/variables_origin_pool.tf
+++ b/terraform/variables_origin_pool.tf
@@ -1,0 +1,17 @@
+# Root passthrough for LPC-5b origin_pool tuning. Defaults mirror the module (0-change).
+variable "origin_lb_algorithm" {
+  type    = string
+  default = "ROUND_ROBIN"
+}
+variable "origin_endpoint_selection" {
+  type    = string
+  default = "DISTRIBUTED"
+}
+variable "origin_connection_timeout" {
+  type    = number
+  default = null
+}
+variable "origin_http_idle_timeout" {
+  type    = number
+  default = null
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -49,7 +49,11 @@ terraform {
       # >= 3.72.6: LPC-2 more_option import suppressions (provider #1125) — custom_errors /
       # no_request_limit_per_connection empty markers, so a more_option header config
       # round-trip-imports clean.
-      version = ">= 3.72.6"
+      # >= 3.72.7: LPC-5b origin_pool advanced_options import suppressions (provider #1130) —
+      # auto_http_config / default_circuit_breaker / disable_outlier_detection / disable_subsets
+      # / no_panic_threshold / no_request_limit_per_connection, so an advanced_options config
+      # round-trip-imports clean.
+      version = ">= 3.72.7"
     }
     # Azure providers: this plan also deploys its OWN Azure origin server and
     # traffic generator (modules/origin-server, modules/traffic-generator), which


### PR DESCRIPTION
## Summary

Final slice of the LB-protection coverage effort (task #70): parameterize and live-verify the
origin pool's routing + tuning knobs. The pool is the live serving path, so `origin_servers`
(public_ip) and TLS (`no_tls`, HTTP origin) are fixed; only these vary:

- `loadbalancer_algorithm`: ROUND_ROBIN | LEAST_REQUEST | RANDOM (RING_HASH/LB_OVERRIDE need
  companion route hash/override config — excluded).
- `endpoint_selection`: DISTRIBUTED | LOCAL_ONLY | LOCAL_PREFERRED.
- `advanced_options`: connection_timeout, http_idle_timeout.

Defaults reproduce today's pool (ROUND_ROBIN / DISTRIBUTED / no advanced_options) → plain apply
is 0-change.

## Import-cleanliness

- Removed `origin_servers[].labels {}` from the module — it is a provider-suppressed server
  default (OriginPool `labels`), and emitting it drifts the direct origin_pool import
  (`+ labels {}`); same class as the endpoint_subsets fix (#94).
- `advanced_options` materializes six server-default oneof-base markers (auto_http_config,
  default_circuit_breaker, disable_outlier_detection, disable_subsets, no_panic_threshold,
  no_request_limit_per_connection); suppressed in provider **v3.72.7**
  ([#1130](https://github.com/f5-sales-demo/terraform-provider-xcsh/issues/1130)). Repin
  `xcsh >= 3.72.7`.

## Verification

- `terraform test -filter=tests/origin_pool.tftest.hcl` → **5 passed, 0 failed**.
- Live AETG all-pairs matrix (`scripts/origin-pool-matrix.sh`, 9 variants + canonical) on
  v3.72.7: algorithm × endpoint_selection × advanced_options → apply → idempotent →
  `xcsh_origin_pool.origin` import round-trip → canonical 0-change. **10/10 PASS, 0 FAIL, 0
  SKIP.** The pool kept serving (public_ip + no_tls) throughout.

Closes #109.
