### PR TITLE
CR-1: custom routes foundation (routes[] + simple_route path->pool)

### DIFF
--- a/scripts/custom-routes-matrix.sh
+++ b/scripts/custom-routes-matrix.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Custom routes (CR-1) live coverage-matrix harness.
+#
+# Cycles the LIVE webapp-api-protection LB through the custom_routes_pairs variant set and
+# verifies each variant (a) applies, (b) is idempotent (immediate plan = No changes), and (c)
+# is round-trip-import clean for the whole LB (state rm -> import -> plan clean). routes[] is an
+# LB-nested feature, so the import target is the http_loadbalancer itself. Ends on
+# canonical-restore so the live LB is left with no custom routes. Results append to
+# reports/custom-routes-matrix.txt.
+#
+# Custom routes are additive to default_route_pools, so the LB keeps serving www/api throughout.
+# Sequential — no concurrent terraform against the shared azurerm state.
+#
+# Usage: custom-routes-matrix.sh [START [END]]  (inclusive 0-based index range).
+set -uo pipefail
+
+umask 077
+trap 'rm -rf /tmp/cr1-variants 2>/dev/null; rm -f /tmp/cr1-*.log 2>/dev/null' EXIT
+
+cd "$(dirname "$0")/../terraform" || exit 1
+ARM_ACCESS_KEY=$(az storage account keys list -n f5salesdemotfstate -g f5-sales-demo-tfstate --query "[0].value" -o tsv)
+export ARM_ACCESS_KEY
+
+NS="webapp-api-protection"
+LB_ADDR="module.http_lb.xcsh_http_loadbalancer.this"
+LB_ID="${NS}/${NS}"
+COMMON=(-input=false -lock=true
+  -var 'lb_domains=["www.f5-sales-demo.com","api.f5-sales-demo.com"]'
+  -var 'subscription_id=75f86c46-9cbc-4f6c-85ea-195e3d3c8ac0')
+VARDIR=/tmp/cr1-variants
+REPORT=../reports/custom-routes-matrix.txt
+mkdir -p ../reports
+
+START="${1:-0}"
+END="${2:-9999}"
+
+[ "$#" -eq 0 ] && : >"$REPORT"
+
+count=$(python3 ../scripts/custom_routes_pairs.py --emit "$VARDIR")
+echo "generated $count variants into $VARDIR (running [$START..$END])"
+
+round_trip() {
+  local label="$1" vf="$2"
+  terraform state rm "$LB_ADDR" >/dev/null 2>&1 || {
+    echo "FAIL $label lb-state-rm" >>"$REPORT"
+    return
+  }
+  terraform import "${COMMON[@]}" -var-file="$vf" "$LB_ADDR" "$LB_ID" >/tmp/cr1-import.log 2>&1 || {
+    echo "FAIL $label lb-import ($(grep -iE 'error' /tmp/cr1-import.log | head -1 | cut -c1-70))" >>"$REPORT"
+    return
+  }
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$vf" >/tmp/cr1-rt-plan.log 2>&1
+  case $? in
+  0) echo "PASS $label" >>"$REPORT" ;;
+  2) echo "FAIL $label import-drift" >>"$REPORT" ;;
+  *) echo "FAIL $label rt-plan-error" >>"$REPORT" ;;
+  esac
+}
+
+while read -r idx name vf _flag; do
+  [ "$idx" -lt "$START" ] && continue
+  [ "$idx" -gt "$END" ] && continue
+  label="$idx-$name"
+  echo "--- $label ---"
+  varfile="${VARDIR}/${vf}"
+  if ! terraform apply -auto-approve "${COMMON[@]}" -var-file="$varfile" >/tmp/cr1-apply.log 2>&1; then
+    echo "FAIL $label apply ($(grep -iE 'error' /tmp/cr1-apply.log | head -1 | cut -c1-80))" >>"$REPORT"
+    continue
+  fi
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$varfile" >/tmp/cr1-plan.log 2>&1
+  case $? in
+  0) round_trip "$label" "$varfile" ;;
+  2) echo "FAIL $label not-idempotent" >>"$REPORT" ;;
+  *) echo "FAIL $label plan-error" >>"$REPORT" ;;
+  esac
+done <"${VARDIR}/manifest.txt"
+
+echo "===== CUSTOM ROUTES MATRIX RESULTS ($START..$END) ====="
+cat "$REPORT"
+echo "PASS=$(grep -c '^PASS ' "$REPORT") FAIL=$(grep -c '^FAIL ' "$REPORT") SKIP=$(grep -c '^SKIP ' "$REPORT")"

--- a/scripts/custom_routes_pairs.py
+++ b/scripts/custom_routes_pairs.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Generate the custom routes (CR-1 foundation) coverage matrix.
+
+CR-1 covers a simple_route that matches a path prefix (+ http_method) and routes to the module
+origin pool. Small explicit variant set (path prefix x method, single + multi route), plus
+canonical-restore (no routes). Custom routes are additive to default_route_pools, so the LB
+keeps serving www/api throughout.
+
+Deterministic (no RNG). Output: JSON to stdout, or files via --emit.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+def build() -> list[dict[str, object]]:
+    """Ordered variant manifest: single/multi routes over path+method, then canonical."""
+    return [
+        {
+            "name": "app-any",
+            "vars": {"custom_routes": [{"path_prefix": "/app", "http_method": "ANY"}]},
+        },
+        {
+            "name": "api-get",
+            "vars": {"custom_routes": [{"path_prefix": "/api", "http_method": "GET"}]},
+        },
+        {
+            "name": "multi",
+            "vars": {
+                "custom_routes": [
+                    {"path_prefix": "/app", "http_method": "ANY"},
+                    {"path_prefix": "/admin", "http_method": "POST"},
+                ]
+            },
+        },
+        {"name": "canonical-restore", "vars": {"custom_routes": []}},
+    ]
+
+
+def emit(directory: str) -> int:
+    """Write one <NNN>-<name>.tfvars.json per variant plus manifest.txt."""
+    out_dir = Path(directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for existing in out_dir.iterdir():
+        if existing.name.endswith(".tfvars.json") or existing.name == "manifest.txt":
+            existing.unlink()
+    variants = build()
+    named = [(f"{i:03d}-{v['name']}.tfvars.json", v) for i, v in enumerate(variants)]
+    for fname, v in named:
+        (out_dir / fname).write_text(json.dumps(v["vars"], indent=2) + "\n")
+    # canonical creates no routes but the whole LB is always imported, so every variant is LIVE.
+    lines = [f"{i:03d} {v['name']} {fname} LIVE" for i, (fname, v) in enumerate(named)]
+    (out_dir / "manifest.txt").write_text("\n".join(lines) + "\n")
+    return len(variants)
+
+
+def main(argv: list[str]) -> None:
+    """CLI: --count, --emit <dir>, else JSON to stdout."""
+    match argv[1:]:
+        case ["--count"]:
+            sys.stdout.write(f"{len(build())}\n")
+        case ["--emit", directory]:
+            sys.stdout.write(f"{emit(directory)}\n")
+        case _:
+            json.dump(build(), sys.stdout, indent=2)
+            sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -79,6 +79,7 @@ module "http_lb" {
   origin_endpoint_selection    = var.origin_endpoint_selection
   origin_connection_timeout    = var.origin_connection_timeout
   origin_http_idle_timeout     = var.origin_http_idle_timeout
+  custom_routes                = var.custom_routes
   labels                       = var.labels
   waf_mode                     = var.waf_mode
   csd_enabled                  = var.csd_enabled

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -471,6 +471,28 @@ resource "xcsh_http_loadbalancer" "this" {
     # computed tenant re-planning on the pool/WAF refs).
   }
 
+  # Custom routes (CR-1) — evaluated before default_route_pools. CR-1: a simple_route that
+  # matches a path prefix and routes to the module's own origin pool. Additive; the default
+  # route keeps serving. Later slices add full match / advanced_options / redirect / direct /
+  # custom arms.
+  dynamic "routes" {
+    for_each = var.custom_routes
+    content {
+      simple_route {
+        http_method = routes.value.http_method
+        path {
+          prefix = routes.value.path_prefix
+        }
+        origin_pools {
+          pool {
+            name      = xcsh_origin_pool.origin.name
+            namespace = var.namespace
+          }
+        }
+      }
+    }
+  }
+
   advertise_on_public_default_vip {}
 
   # Attach the WAF (oneof: app_firewall vs disable_waf; server default disable_waf).

--- a/terraform/modules/http-lb/variables_custom_routes.tf
+++ b/terraform/modules/http-lb/variables_custom_routes.tf
@@ -1,0 +1,26 @@
+# CR-1 (custom routes foundation): LB routes[] custom routing. CR-1 covers a simple_route that
+# matches a path prefix and routes to the module's own origin pool (origin-pool). Custom routes
+# are additive to default_route_pools (the default route keeps serving). Later slices (CR-2..5)
+# extend this object with full match criteria, advanced_options, redirect/direct-response, and
+# custom (route_ref) arms. Empty list omits routes[] (0-change).
+
+variable "custom_routes" {
+  description = "Custom LB routes. CR-1: simple_route path-prefix -> the module origin pool."
+  type = list(object({
+    path_prefix = string                  # simple_route.path.prefix match criterion
+    http_method = optional(string, "ANY") # simple_route.http_method (server defaults ANY;
+    # schema is Optional-not-Computed, so a null config produces an inconsistent-result apply)
+  }))
+  default = []
+
+  validation {
+    condition     = alltrue([for r in var.custom_routes : startswith(r.path_prefix, "/")])
+    error_message = "custom_routes[].path_prefix must start with '/'."
+  }
+  validation {
+    condition = alltrue([for r in var.custom_routes :
+      contains(["ANY", "GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH", "COPY"], r.http_method)
+    ])
+    error_message = "custom_routes[].http_method must be a valid HTTP method (ANY/GET/HEAD/POST/PUT/DELETE/CONNECT/OPTIONS/TRACE/PATCH/COPY)."
+  }
+}

--- a/terraform/modules/http-lb/versions.tf
+++ b/terraform/modules/http-lb/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     xcsh = {
       source  = "f5-sales-demo/xcsh"
-      version = ">= 3.72.7"
+      version = ">= 3.72.8"
     }
   }
 }

--- a/terraform/tests/custom_routes.tftest.hcl
+++ b/terraform/tests/custom_routes.tftest.hcl
@@ -1,0 +1,44 @@
+# Plan-level tests for CR-1: custom routes foundation (simple_route path-prefix -> pool).
+# Targets ./modules/http-lb. command = plan (no creds).
+variables {
+  namespace         = "webapp-api-protection"
+  lb_domains        = ["www.f5-sales-demo.com"]
+  origin_ip         = "203.0.113.10"
+  origin_port       = 80
+  health_check_path = "/health"
+  labels            = {}
+  csd_enabled       = false
+  mud_enabled       = false
+}
+
+run "simple_route_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    custom_routes = [{ path_prefix = "/app" }]
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.routes[0].simple_route.path.prefix == "/app"
+    error_message = "simple_route path prefix must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.routes[0].simple_route.origin_pools[0].pool.name == "origin-pool"
+    error_message = "simple_route origin_pools pool ref must render"
+  }
+}
+
+run "routes_omitted_by_default" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  assert {
+    condition     = length(xcsh_http_loadbalancer.this.routes) == 0
+    error_message = "routes must be empty by default"
+  }
+}
+
+run "bad_path_prefix_rejected" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { custom_routes = [{ path_prefix = "app" }] }
+  expect_failures = [var.custom_routes]
+}

--- a/terraform/variables_custom_routes.tf
+++ b/terraform/variables_custom_routes.tf
@@ -1,0 +1,6 @@
+# Root passthrough for custom LB routes (CR effort). Object list uses type = any (shape in module).
+variable "custom_routes" {
+  description = "Custom LB routes (see module for shape)."
+  type        = any
+  default     = []
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -49,11 +49,13 @@ terraform {
       # >= 3.72.6: LPC-2 more_option import suppressions (provider #1125) — custom_errors /
       # no_request_limit_per_connection empty markers, so a more_option header config
       # round-trip-imports clean.
-      # >= 3.72.7: LPC-5b origin_pool advanced_options import suppressions (provider #1130) —
+      # >= 3.72.8: LPC-5b origin_pool advanced_options import suppressions (provider #1130) —
       # auto_http_config / default_circuit_breaker / disable_outlier_detection / disable_subsets
       # / no_panic_threshold / no_request_limit_per_connection, so an advanced_options config
       # round-trip-imports clean.
-      version = ">= 3.72.7"
+      # >= 3.72.8: CR-1 custom routes[] import suppressions (provider #1134) — route_state_enabled
+      # + auto_host_rewrite, so a simple_route config round-trip-imports clean.
+      version = ">= 3.72.8"
     }
     # Azure providers: this plan also deploys its OWN Azure origin server and
     # traffic generator (modules/origin-server, modules/traffic-generator), which


### PR DESCRIPTION
## Summary

First slice of the custom-routes coverage effort (task #71): wire the http_loadbalancer
`routes[]` surface with a minimal `simple_route`, establishing the foundation + provider
import-suppression base for CR-2…CR-5. Custom routes are **additive** to `default_route_pools`
(the default route keeps serving www/api).

- `custom_routes` list variable → `routes[].simple_route { http_method; path { prefix };
  origin_pools { pool { name/namespace } } }` referencing the module's own origin pool.
  Default `[]` → no routes (0-change).

## Findings resolved

- **`simple_route.http_method` is Optional-not-Computed but the server defaults `"ANY"`** → a
  null config produces a "Provider produced inconsistent result" apply error. The module emits
  `http_method` (default `ANY`, method-enum validated).
- **Whole-LB import of a custom route drifts** on `route_state_enabled {}` (route enable
  default) and `simple_route.auto_host_rewrite {}` (host-rewrite oneof base); suppressed in
  provider **v3.72.8**
  ([#1134](https://github.com/f5-sales-demo/terraform-provider-xcsh/issues/1134)). Repin
  `xcsh >= 3.72.8`.

## Verification

- `terraform test -filter=tests/custom_routes.tftest.hcl` → **3 passed, 0 failed**.
- Live matrix (`scripts/custom-routes-matrix.sh`, 4 variants): single route (path+method),
  multi-route, canonical → apply → idempotent → **whole-LB import round-trip** → canonical
  0-change. **4/4 PASS, 0 FAIL, 0 SKIP.** The LB kept serving (default_route_pools unaffected).

Closes #111.
