### PR TITLE
CR-2: custom route match (path prefix/exact/regex, headers, incoming_port)

### DIFF
--- a/scripts/custom_routes_pairs.py
+++ b/scripts/custom_routes_pairs.py
@@ -15,22 +15,75 @@ from pathlib import Path
 
 
 def build() -> list[dict[str, object]]:
-    """Ordered variant manifest: single/multi routes over path+method, then canonical."""
+    """Ordered variant manifest over the route match surface, then canonical."""
     return [
         {
-            "name": "app-any",
-            "vars": {"custom_routes": [{"path_prefix": "/app", "http_method": "ANY"}]},
+            "name": "prefix-any",
+            "vars": {
+                "custom_routes": [
+                    {"path_mode": "prefix", "path_value": "/app", "http_method": "ANY"}
+                ]
+            },
         },
         {
-            "name": "api-get",
-            "vars": {"custom_routes": [{"path_prefix": "/api", "http_method": "GET"}]},
+            "name": "exact-get",
+            "vars": {
+                "custom_routes": [
+                    {
+                        "path_mode": "exact",
+                        "path_value": "/health",
+                        "http_method": "GET",
+                    }
+                ]
+            },
+        },
+        {
+            "name": "regex-post",
+            "vars": {
+                "custom_routes": [
+                    {
+                        "path_mode": "regex",
+                        "path_value": "^/v[0-9]+/.*$",
+                        "http_method": "POST",
+                    }
+                ]
+            },
+        },
+        {
+            "name": "headers-port",
+            "vars": {
+                "custom_routes": [
+                    {
+                        "path_mode": "prefix",
+                        "path_value": "/api",
+                        "incoming_port": 443,
+                        "headers": [
+                            {"name": "x-canary", "mode": "exact", "value": "on"},
+                            {
+                                "name": "x-legacy",
+                                "mode": "presence",
+                                "invert_match": True,
+                            },
+                            {
+                                "name": "x-trace",
+                                "mode": "regex",
+                                "value": "^[0-9a-f]+$",
+                            },
+                        ],
+                    }
+                ]
+            },
         },
         {
             "name": "multi",
             "vars": {
                 "custom_routes": [
-                    {"path_prefix": "/app", "http_method": "ANY"},
-                    {"path_prefix": "/admin", "http_method": "POST"},
+                    {"path_mode": "prefix", "path_value": "/app"},
+                    {
+                        "path_mode": "exact",
+                        "path_value": "/admin",
+                        "http_method": "POST",
+                    },
                 ]
             },
         },

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -480,8 +480,30 @@ resource "xcsh_http_loadbalancer" "this" {
     content {
       simple_route {
         http_method = routes.value.http_method
+        # path match oneof: prefix | exact (path) | regex
         path {
-          prefix = routes.value.path_prefix
+          prefix = routes.value.path_mode == "prefix" ? routes.value.path_value : null
+          path   = routes.value.path_mode == "exact" ? routes.value.path_value : null
+          regex  = routes.value.path_mode == "regex" ? routes.value.path_value : null
+        }
+        # header matches: name + presence | exact | regex, optionally inverted
+        dynamic "headers" {
+          for_each = routes.value.headers
+          iterator = h
+          content {
+            name         = h.value.name
+            exact        = h.value.mode == "exact" ? h.value.value : null
+            regex        = h.value.mode == "regex" ? h.value.value : null
+            presence     = h.value.mode == "presence" ? true : null
+            invert_match = h.value.invert_match
+          }
+        }
+        # incoming port match (omitted = match any port)
+        dynamic "incoming_port" {
+          for_each = routes.value.incoming_port != null ? [1] : []
+          content {
+            port = routes.value.incoming_port
+          }
         }
         origin_pools {
           pool {

--- a/terraform/modules/http-lb/variables_custom_routes.tf
+++ b/terraform/modules/http-lb/variables_custom_routes.tf
@@ -1,26 +1,54 @@
-# CR-1 (custom routes foundation): LB routes[] custom routing. CR-1 covers a simple_route that
-# matches a path prefix and routes to the module's own origin pool (origin-pool). Custom routes
-# are additive to default_route_pools (the default route keeps serving). Later slices (CR-2..5)
-# extend this object with full match criteria, advanced_options, redirect/direct-response, and
-# custom (route_ref) arms. Empty list omits routes[] (0-change).
+# Custom LB routes[] (CR effort). CR-1 wired a simple_route (path prefix -> origin pool). CR-2
+# adds the full match surface: path oneof (prefix/exact/regex), header matches, and incoming
+# port match. simple_route routes to the module's own origin pool (origin-pool); custom routes
+# are additive to default_route_pools (the default route keeps serving). Later slices (CR-3..5)
+# add advanced_options, redirect/direct-response, and custom (route_ref) arms. Empty list omits
+# routes[] (0-change).
 
 variable "custom_routes" {
-  description = "Custom LB routes. CR-1: simple_route path-prefix -> the module origin pool."
+  description = "Custom LB routes (simple_route match -> origin pool). Empty omits routes[]."
   type = list(object({
-    path_prefix = string                  # simple_route.path.prefix match criterion
-    http_method = optional(string, "ANY") # simple_route.http_method (server defaults ANY;
-    # schema is Optional-not-Computed, so a null config produces an inconsistent-result apply)
+    # match: path oneof (prefix|exact|regex)
+    path_mode  = optional(string, "prefix") # prefix|exact|regex
+    path_value = string
+    # match: http method (server defaults ANY; Optional-not-Computed, so emit explicitly)
+    http_method = optional(string, "ANY")
+    # match: header matches. mode presence|exact|regex; invert flips the match.
+    headers = optional(list(object({
+      name         = string
+      mode         = optional(string, "presence") # presence|exact|regex
+      value        = optional(string)             # required for exact|regex
+      invert_match = optional(bool, false)
+    })), [])
+    # match: incoming port (null = match any port, i.e. no incoming_port block)
+    incoming_port = optional(number)
   }))
   default = []
 
   validation {
-    condition     = alltrue([for r in var.custom_routes : startswith(r.path_prefix, "/")])
-    error_message = "custom_routes[].path_prefix must start with '/'."
+    condition     = alltrue([for r in var.custom_routes : contains(["prefix", "exact", "regex"], r.path_mode)])
+    error_message = "custom_routes[].path_mode must be prefix, exact, or regex."
+  }
+  validation {
+    condition     = alltrue([for r in var.custom_routes : r.path_value != null && r.path_value != ""])
+    error_message = "custom_routes[].path_value is required."
+  }
+  validation {
+    condition     = alltrue([for r in var.custom_routes : r.path_mode == "regex" || startswith(r.path_value, "/")])
+    error_message = "custom_routes[].path_value must start with '/' (except regex mode)."
   }
   validation {
     condition = alltrue([for r in var.custom_routes :
       contains(["ANY", "GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH", "COPY"], r.http_method)
     ])
     error_message = "custom_routes[].http_method must be a valid HTTP method (ANY/GET/HEAD/POST/PUT/DELETE/CONNECT/OPTIONS/TRACE/PATCH/COPY)."
+  }
+  validation {
+    condition     = alltrue([for r in var.custom_routes : alltrue([for h in r.headers : contains(["presence", "exact", "regex"], h.mode)])])
+    error_message = "custom_routes[].headers[].mode must be presence, exact, or regex."
+  }
+  validation {
+    condition     = alltrue([for r in var.custom_routes : alltrue([for h in r.headers : h.mode == "presence" || (h.value != null && h.value != "")])])
+    error_message = "custom_routes[].headers[].value is required for exact/regex mode."
   }
 }

--- a/terraform/tests/custom_routes.tftest.hcl
+++ b/terraform/tests/custom_routes.tftest.hcl
@@ -1,5 +1,5 @@
-# Plan-level tests for CR-1: custom routes foundation (simple_route path-prefix -> pool).
-# Targets ./modules/http-lb. command = plan (no creds).
+# Plan-level tests for custom routes (CR-1 foundation + CR-2 match). Targets ./modules/http-lb.
+# command = plan (no creds).
 variables {
   namespace         = "webapp-api-protection"
   lb_domains        = ["www.f5-sales-demo.com"]
@@ -11,19 +11,67 @@ variables {
   mud_enabled       = false
 }
 
-run "simple_route_renders" {
+run "prefix_route_to_pool" {
   command = plan
   module { source = "./modules/http-lb" }
   variables {
-    custom_routes = [{ path_prefix = "/app" }]
+    custom_routes = [{ path_mode = "prefix", path_value = "/app" }]
   }
   assert {
     condition     = xcsh_http_loadbalancer.this.routes[0].simple_route.path.prefix == "/app"
-    error_message = "simple_route path prefix must render"
+    error_message = "prefix path match must render"
   }
   assert {
     condition     = xcsh_http_loadbalancer.this.routes[0].simple_route.origin_pools[0].pool.name == "origin-pool"
-    error_message = "simple_route origin_pools pool ref must render"
+    error_message = "origin_pools pool ref must render"
+  }
+}
+
+run "exact_and_regex_path" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    custom_routes = [
+      { path_mode = "exact", path_value = "/health" },
+      { path_mode = "regex", path_value = "^/v[0-9]+/.*$" },
+    ]
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.routes[0].simple_route.path.path == "/health"
+    error_message = "exact path match must render on path.path"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.routes[1].simple_route.path.regex == "^/v[0-9]+/.*$"
+    error_message = "regex path match must render"
+  }
+}
+
+run "header_and_port_match" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    custom_routes = [{
+      path_mode     = "prefix"
+      path_value    = "/api"
+      http_method   = "GET"
+      incoming_port = 443
+      headers = [
+        { name = "x-canary", mode = "exact", value = "on" },
+        { name = "x-legacy", mode = "presence", invert_match = true },
+      ]
+    }]
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.routes[0].simple_route.headers[0].exact == "on"
+    error_message = "header exact match must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.routes[0].simple_route.headers[1].invert_match == true
+    error_message = "header invert_match must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.routes[0].simple_route.incoming_port.port == 443
+    error_message = "incoming_port match must render"
   }
 }
 
@@ -36,9 +84,18 @@ run "routes_omitted_by_default" {
   }
 }
 
-run "bad_path_prefix_rejected" {
+run "bad_path_mode_rejected" {
   command = plan
   module { source = "./modules/http-lb" }
-  variables { custom_routes = [{ path_prefix = "app" }] }
+  variables { custom_routes = [{ path_mode = "glob", path_value = "/x" }] }
+  expect_failures = [var.custom_routes]
+}
+
+run "header_exact_requires_value" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    custom_routes = [{ path_mode = "prefix", path_value = "/x", headers = [{ name = "h", mode = "exact" }] }]
+  }
   expect_failures = [var.custom_routes]
 }


### PR DESCRIPTION
## Problem

CR-1 wired custom `routes[]` with a minimal simple_route (path prefix). The full route **match**
surface is uncovered: path oneof (prefix/exact/regex), header matches, and incoming-port match.

This is CR-2 of the custom-routes coverage effort (task #71), after CR-1 (#111).

## Scope

- Extend `custom_routes`: `path_mode` (prefix|exact|regex) + `path_value`; `headers[]` (name +
  presence|exact|regex + invert_match); `incoming_port` (match a port; null = any). http_method
  already covered (CR-1). Restructures the CR-1 `path_prefix` field (clean-break; nothing live
  depends on custom_routes).
- Plan-TDD + live matrix over the match surface; whole-LB import round-trip; canonical.

## Acceptance criteria

- [ ] `terraform test` green.
- [ ] Live matrix idempotent + whole-LB import clean; canonical 0-change; LB keeps serving.
- [ ] CI green; PR closes this issue.

## Verification
- terraform test 6/6; live matrix **6/6 PASS** (prefix/exact/regex path, header matches exact/regex/presence/invert, incoming_port, multi-route, canonical) -> apply -> idempotent -> whole-LB import round-trip -> canonical 0-change. No provider change (import-clean on v3.72.8).

Closes #113