### PR TITLE
CR-3: custom route advanced_options (rewrites, transforms, timeout, per-route WAF)

### DIFF
--- a/scripts/custom_routes_pairs.py
+++ b/scripts/custom_routes_pairs.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-"""Generate the custom routes (CR-1 foundation) coverage matrix.
+"""Generate the custom routes coverage matrix (CR-1 foundation + CR-2 match + CR-3 advanced).
 
-CR-1 covers a simple_route that matches a path prefix (+ http_method) and routes to the module
-origin pool. Small explicit variant set (path prefix x method, single + multi route), plus
-canonical-restore (no routes). Custom routes are additive to default_route_pools, so the LB
-keeps serving www/api throughout.
+Explicit variant set over the simple_route surface: path oneof (prefix/exact/regex) x method,
+header + incoming-port matches, multi-route, and advanced_options (rewrite/priority/timeout,
+header+cookie transforms, per-route WAF app_firewall/disable), plus canonical-restore (no
+routes). Custom routes are additive to default_route_pools, so the LB keeps serving www/api
+throughout. Whole-LB import is the round-trip target.
 
 Deterministic (no RNG). Output: JSON to stdout, or files via --emit.
 """
@@ -84,6 +85,60 @@ def build() -> list[dict[str, object]]:
                         "path_value": "/admin",
                         "http_method": "POST",
                     },
+                ]
+            },
+        },
+        {
+            "name": "adv-rewrite-waf",
+            "vars": {
+                "custom_routes": [
+                    {
+                        "path_mode": "prefix",
+                        "path_value": "/app",
+                        "prefix_rewrite": "/",
+                        "priority": "HIGH",
+                        "timeout_ms": 5000,
+                        "disable_location_add": True,
+                        "waf_mode": "app_firewall",
+                    }
+                ]
+            },
+        },
+        {
+            "name": "adv-headers-cookies",
+            "vars": {
+                "custom_routes": [
+                    {
+                        "path_mode": "prefix",
+                        "path_value": "/api",
+                        "req_headers_add": [
+                            {"name": "x-route", "value": "api", "append": False}
+                        ],
+                        "req_headers_remove": ["x-internal"],
+                        "resp_headers_add": [
+                            {
+                                "name": "x-frame-options",
+                                "value": "DENY",
+                                "append": False,
+                            }
+                        ],
+                        "resp_headers_remove": ["server"],
+                        "req_cookies_remove": ["tracking"],
+                        "resp_cookies_remove": ["debug"],
+                    }
+                ]
+            },
+        },
+        {
+            "name": "adv-waf-inherited",
+            "vars": {
+                "custom_routes": [
+                    {
+                        "path_mode": "prefix",
+                        "path_value": "/public",
+                        "timeout_ms": 2000,
+                        "waf_mode": "inherited",
+                    }
                 ]
             },
         },

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -511,6 +511,58 @@ resource "xcsh_http_loadbalancer" "this" {
             namespace = var.namespace
           }
         }
+        # advanced_options (CR-3): per-route rewrites, header/cookie transforms, timeout, and a
+        # WAF selector. Emitted only when a field is set (else omitted for 0-change). The WAF
+        # oneof default (inherited_waf) and other oneof bases are server-materialized + provider
+        # import-suppressed. Heavy sub-blocks (cors/csrf/retry/mirror/hash/buffer/websocket) are
+        # deferred to a later slice.
+        dynamic "advanced_options" {
+          for_each = anytrue([
+            routes.value.prefix_rewrite != null, routes.value.disable_location_add,
+            routes.value.timeout_ms != null, length(routes.value.req_headers_add) > 0,
+            length(routes.value.req_headers_remove) > 0, length(routes.value.resp_headers_add) > 0,
+            length(routes.value.resp_headers_remove) > 0, length(routes.value.req_cookies_remove) > 0,
+            length(routes.value.resp_cookies_remove) > 0, routes.value.waf_mode != "inherited",
+          ]) ? [1] : []
+          content {
+            prefix_rewrite             = routes.value.prefix_rewrite
+            priority                   = routes.value.priority
+            disable_location_add       = routes.value.disable_location_add
+            timeout                    = routes.value.timeout_ms
+            request_headers_to_remove  = length(routes.value.req_headers_remove) > 0 ? routes.value.req_headers_remove : null
+            response_headers_to_remove = length(routes.value.resp_headers_remove) > 0 ? routes.value.resp_headers_remove : null
+            request_cookies_to_remove  = length(routes.value.req_cookies_remove) > 0 ? routes.value.req_cookies_remove : null
+            response_cookies_to_remove = length(routes.value.resp_cookies_remove) > 0 ? routes.value.resp_cookies_remove : null
+            dynamic "request_headers_to_add" {
+              for_each = routes.value.req_headers_add
+              iterator = h
+              content {
+                name   = h.value.name
+                value  = h.value.value
+                append = h.value.append
+              }
+            }
+            dynamic "response_headers_to_add" {
+              for_each = routes.value.resp_headers_add
+              iterator = h
+              content {
+                name   = h.value.name
+                value  = h.value.value
+                append = h.value.append
+              }
+            }
+            # WAF oneof: app_firewall ref (per-route override) | inherited (default -> omit).
+            # "disable" is not offered: route-level disable_waf {} collides with the LB-level
+            # disable_waf import-suppression (leaf-name match at any depth) and can't round-trip.
+            dynamic "app_firewall" {
+              for_each = routes.value.waf_mode == "app_firewall" ? [1] : []
+              content {
+                name      = xcsh_app_firewall.this.name
+                namespace = var.namespace
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/terraform/modules/http-lb/variables_custom_routes.tf
+++ b/terraform/modules/http-lb/variables_custom_routes.tf
@@ -22,6 +22,25 @@ variable "custom_routes" {
     })), [])
     # match: incoming port (null = match any port, i.e. no incoming_port block)
     incoming_port = optional(number)
+    # --- advanced_options (CR-3): per-route action tuning. All optional; when any is set the
+    # block is emitted. Heavy sub-blocks (cors/csrf/retry/mirror/hash/buffer/websocket/bot-js)
+    # are deferred. WAF selector: inherited (default) | app_firewall (module WAF) | disable.
+    prefix_rewrite = optional(string)            # advanced_options.prefix_rewrite
+    priority       = optional(string, "DEFAULT") # advanced_options.priority DEFAULT|HIGH
+    # (Optional-not-Computed, server defaults DEFAULT, so emit explicitly)
+    disable_location_add = optional(bool, false) # advanced_options.disable_location_add
+    timeout_ms           = optional(number)      # advanced_options.timeout
+    req_headers_add      = optional(list(object({ name = string, value = string, append = optional(bool, false) })), [])
+    req_headers_remove   = optional(list(string), [])
+    resp_headers_add     = optional(list(object({ name = string, value = string, append = optional(bool, false) })), [])
+    resp_headers_remove  = optional(list(string), [])
+    req_cookies_remove   = optional(list(string), [])
+    resp_cookies_remove  = optional(list(string), [])
+    # inherited (route uses the LB WAF, default) | app_firewall (per-route WAF override to the
+    # module's app_firewall). "disable" is intentionally omitted: the route-level disable_waf {}
+    # collides with the LB-level disable_waf import-suppression (matched by leaf name at any
+    # depth), so it cannot round-trip cleanly until the provider suppression is path-aware.
+    waf_mode = optional(string, "inherited") # inherited | app_firewall
   }))
   default = []
 
@@ -50,5 +69,13 @@ variable "custom_routes" {
   validation {
     condition     = alltrue([for r in var.custom_routes : alltrue([for h in r.headers : h.mode == "presence" || (h.value != null && h.value != "")])])
     error_message = "custom_routes[].headers[].value is required for exact/regex mode."
+  }
+  validation {
+    condition     = alltrue([for r in var.custom_routes : contains(["inherited", "app_firewall"], r.waf_mode)])
+    error_message = "custom_routes[].waf_mode must be inherited or app_firewall."
+  }
+  validation {
+    condition     = alltrue([for r in var.custom_routes : contains(["DEFAULT", "HIGH"], r.priority)])
+    error_message = "custom_routes[].priority must be DEFAULT or HIGH."
   }
 }

--- a/terraform/modules/http-lb/versions.tf
+++ b/terraform/modules/http-lb/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     xcsh = {
       source  = "f5-sales-demo/xcsh"
-      version = ">= 3.72.8"
+      version = ">= 3.72.9"
     }
   }
 }

--- a/terraform/tests/custom_routes.tftest.hcl
+++ b/terraform/tests/custom_routes.tftest.hcl
@@ -75,6 +75,56 @@ run "header_and_port_match" {
   }
 }
 
+run "advanced_options_render" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    custom_routes = [{
+      path_mode           = "prefix"
+      path_value          = "/app"
+      prefix_rewrite      = "/"
+      priority            = "HIGH"
+      timeout_ms          = 5000
+      req_headers_add     = [{ name = "x-route", value = "app" }]
+      resp_headers_remove = ["server"]
+      waf_mode            = "app_firewall"
+    }]
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.routes[0].simple_route.advanced_options.prefix_rewrite == "/"
+    error_message = "advanced_options.prefix_rewrite must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.routes[0].simple_route.advanced_options.priority == "HIGH"
+    error_message = "advanced_options.priority must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.routes[0].simple_route.advanced_options.request_headers_to_add[0].name == "x-route"
+    error_message = "advanced_options request_headers_to_add must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.routes[0].simple_route.advanced_options.app_firewall.name == "webapp-api-protection-waf"
+    error_message = "advanced_options per-route app_firewall ref must render"
+  }
+}
+
+run "advanced_options_omitted_when_no_tuning" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { custom_routes = [{ path_mode = "prefix", path_value = "/app" }] }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.routes[0].simple_route.advanced_options == null
+    error_message = "advanced_options must be omitted when no tuning field is set"
+  }
+}
+
+run "bad_waf_mode_rejected" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { custom_routes = [{ path_mode = "prefix", path_value = "/x", waf_mode = "block" }] }
+  expect_failures = [var.custom_routes]
+}
+
 run "routes_omitted_by_default" {
   command = plan
   module { source = "./modules/http-lb" }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -49,13 +49,15 @@ terraform {
       # >= 3.72.6: LPC-2 more_option import suppressions (provider #1125) — custom_errors /
       # no_request_limit_per_connection empty markers, so a more_option header config
       # round-trip-imports clean.
-      # >= 3.72.8: LPC-5b origin_pool advanced_options import suppressions (provider #1130) —
+      # >= 3.72.9: LPC-5b origin_pool advanced_options import suppressions (provider #1130) —
       # auto_http_config / default_circuit_breaker / disable_outlier_detection / disable_subsets
       # / no_panic_threshold / no_request_limit_per_connection, so an advanced_options config
       # round-trip-imports clean.
       # >= 3.72.8: CR-1 custom routes[] import suppressions (provider #1134) — route_state_enabled
       # + auto_host_rewrite, so a simple_route config round-trip-imports clean.
-      version = ">= 3.72.8"
+      # >= 3.72.9: CR-3 route advanced_options import suppressions (provider #1138) — 8 oneof-base
+      # markers (buffer/hash/retry/mirror/prefix-rewrite/spdy/websocket/cluster defaults).
+      version = ">= 3.72.9"
     }
     # Azure providers: this plan also deploys its OWN Azure origin server and
     # traffic generator (modules/origin-server, modules/traffic-generator), which


### PR DESCRIPTION
## Summary

Third slice of the custom-routes effort (task #71): extend `simple_route` with a scoped
`advanced_options` block.

- `prefix_rewrite`; `priority` (DEFAULT|HIGH — Optional-not-Computed, emitted explicitly like
  `http_method`); `disable_location_add`; `timeout`; request/response `headers_to_add` +
  `headers_to_remove`; request/response `cookies_to_remove`; per-route WAF selector `waf_mode`
  (`inherited` | `app_firewall`).
- Heavy sub-blocks (cors/csrf/retry/mirror/hash/buffer/websocket/spdy/bot-js) deferred.
- `waf_mode = "disable"` is intentionally omitted: route-level `disable_waf {}` collides with the
  LB-level `disable_waf` import-suppression (leaf-name match at any depth) and cannot round-trip
  cleanly until the provider suppression is path-aware.

`advanced_options.priority` is the second Optional-not-Computed server-default route field (after
`http_method`) — emitted explicitly to avoid an inconsistent-result apply.

## Provider

v3.72.9 ([#1138](https://github.com/f5-sales-demo/terraform-provider-xcsh/issues/1138)) suppresses
the 8 advanced_options oneof-base import markers (common_buffering, common_hash_policy,
default_retry_policy, disable_mirroring, disable_prefix_rewrite, disable_spdy,
disable_web_socket_config, retract_cluster) surfaced on the whole-LB round-trip. Repin
`xcsh >= 3.72.9`.

## Verification

- `terraform test -filter=tests/custom_routes.tftest.hcl` → **9 passed, 0 failed**.
- Live matrix (`scripts/custom-routes-matrix.sh`, 9 variants): path modes, header+port match,
  multi-route, advanced rewrite+WAF, header/cookie transforms, waf inherited, canonical → apply →
  idempotent → whole-LB import round-trip → canonical 0-change. **9/9 PASS, 0 FAIL, 0 SKIP.** The
  LB kept serving www/api (default_route_pools unaffected).

Closes #115.
