### PR TITLE
CR-4: custom route redirect_route + direct_response_route arms

### DIFF
--- a/scripts/custom_routes_pairs.py
+++ b/scripts/custom_routes_pairs.py
@@ -142,6 +142,59 @@ def build() -> list[dict[str, object]]:
                 ]
             },
         },
+        {
+            "name": "redirect",
+            "vars": {
+                "custom_routes": [
+                    {
+                        "type": "redirect",
+                        "path_mode": "prefix",
+                        "path_value": "/old",
+                        "redirect_host": "www.f5-sales-demo.com",
+                        "redirect_prefix_rewrite": "/new",
+                        "redirect_proto": "https",
+                        "redirect_response_code": 301,
+                        "redirect_query": "remove",
+                    }
+                ]
+            },
+        },
+        {
+            "name": "direct-response",
+            "vars": {
+                "custom_routes": [
+                    {
+                        "type": "direct_response",
+                        "path_mode": "exact",
+                        "path_value": "/teapot",
+                        "direct_response_code": 418,
+                        "direct_response_body": "I am a teapot",
+                    }
+                ]
+            },
+        },
+        {
+            "name": "mixed-types",
+            "vars": {
+                "custom_routes": [
+                    {"type": "simple", "path_mode": "prefix", "path_value": "/app"},
+                    {
+                        "type": "redirect",
+                        "path_mode": "prefix",
+                        "path_value": "/legacy",
+                        "redirect_path": "/",
+                        "redirect_response_code": 302,
+                    },
+                    {
+                        "type": "direct_response",
+                        "path_mode": "exact",
+                        "path_value": "/health-direct",
+                        "direct_response_code": 200,
+                        "direct_response_body": "ok",
+                    },
+                ]
+            },
+        },
         {"name": "canonical-restore", "vars": {"custom_routes": []}},
     ]
 

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -478,89 +478,176 @@ resource "xcsh_http_loadbalancer" "this" {
   dynamic "routes" {
     for_each = var.custom_routes
     content {
-      simple_route {
-        http_method = routes.value.http_method
-        # path match oneof: prefix | exact (path) | regex
-        path {
-          prefix = routes.value.path_mode == "prefix" ? routes.value.path_value : null
-          path   = routes.value.path_mode == "exact" ? routes.value.path_value : null
-          regex  = routes.value.path_mode == "regex" ? routes.value.path_value : null
-        }
-        # header matches: name + presence | exact | regex, optionally inverted
-        dynamic "headers" {
-          for_each = routes.value.headers
-          iterator = h
-          content {
-            name         = h.value.name
-            exact        = h.value.mode == "exact" ? h.value.value : null
-            regex        = h.value.mode == "regex" ? h.value.value : null
-            presence     = h.value.mode == "presence" ? true : null
-            invert_match = h.value.invert_match
+      # simple_route (type=simple): match -> origin pool + advanced_options.
+      dynamic "simple_route" {
+        for_each = routes.value.type == "simple" ? [1] : []
+        content {
+          http_method = routes.value.http_method
+          # path match oneof: prefix | exact (path) | regex
+          path {
+            prefix = routes.value.path_mode == "prefix" ? routes.value.path_value : null
+            path   = routes.value.path_mode == "exact" ? routes.value.path_value : null
+            regex  = routes.value.path_mode == "regex" ? routes.value.path_value : null
           }
-        }
-        # incoming port match (omitted = match any port)
-        dynamic "incoming_port" {
-          for_each = routes.value.incoming_port != null ? [1] : []
-          content {
-            port = routes.value.incoming_port
+          # header matches: name + presence | exact | regex, optionally inverted
+          dynamic "headers" {
+            for_each = routes.value.headers
+            iterator = h
+            content {
+              name         = h.value.name
+              exact        = h.value.mode == "exact" ? h.value.value : null
+              regex        = h.value.mode == "regex" ? h.value.value : null
+              presence     = h.value.mode == "presence" ? true : null
+              invert_match = h.value.invert_match
+            }
           }
-        }
-        origin_pools {
-          pool {
-            name      = xcsh_origin_pool.origin.name
-            namespace = var.namespace
+          # incoming port match (omitted = match any port)
+          dynamic "incoming_port" {
+            for_each = routes.value.incoming_port != null ? [1] : []
+            content {
+              port = routes.value.incoming_port
+            }
           }
-        }
-        # advanced_options (CR-3): per-route rewrites, header/cookie transforms, timeout, and a
-        # WAF selector. Emitted only when a field is set (else omitted for 0-change). The WAF
-        # oneof default (inherited_waf) and other oneof bases are server-materialized + provider
-        # import-suppressed. Heavy sub-blocks (cors/csrf/retry/mirror/hash/buffer/websocket) are
-        # deferred to a later slice.
-        dynamic "advanced_options" {
-          for_each = anytrue([
-            routes.value.prefix_rewrite != null, routes.value.disable_location_add,
-            routes.value.timeout_ms != null, length(routes.value.req_headers_add) > 0,
-            length(routes.value.req_headers_remove) > 0, length(routes.value.resp_headers_add) > 0,
-            length(routes.value.resp_headers_remove) > 0, length(routes.value.req_cookies_remove) > 0,
-            length(routes.value.resp_cookies_remove) > 0, routes.value.waf_mode != "inherited",
-          ]) ? [1] : []
-          content {
-            prefix_rewrite             = routes.value.prefix_rewrite
-            priority                   = routes.value.priority
-            disable_location_add       = routes.value.disable_location_add
-            timeout                    = routes.value.timeout_ms
-            request_headers_to_remove  = length(routes.value.req_headers_remove) > 0 ? routes.value.req_headers_remove : null
-            response_headers_to_remove = length(routes.value.resp_headers_remove) > 0 ? routes.value.resp_headers_remove : null
-            request_cookies_to_remove  = length(routes.value.req_cookies_remove) > 0 ? routes.value.req_cookies_remove : null
-            response_cookies_to_remove = length(routes.value.resp_cookies_remove) > 0 ? routes.value.resp_cookies_remove : null
-            dynamic "request_headers_to_add" {
-              for_each = routes.value.req_headers_add
-              iterator = h
-              content {
-                name   = h.value.name
-                value  = h.value.value
-                append = h.value.append
+          origin_pools {
+            pool {
+              name      = xcsh_origin_pool.origin.name
+              namespace = var.namespace
+            }
+          }
+          # advanced_options (CR-3): per-route rewrites, header/cookie transforms, timeout, and a
+          # WAF selector. Emitted only when a field is set (else omitted for 0-change). The WAF
+          # oneof default (inherited_waf) and other oneof bases are server-materialized + provider
+          # import-suppressed. Heavy sub-blocks (cors/csrf/retry/mirror/hash/buffer/websocket) are
+          # deferred to a later slice.
+          dynamic "advanced_options" {
+            for_each = anytrue([
+              routes.value.prefix_rewrite != null, routes.value.disable_location_add,
+              routes.value.timeout_ms != null, length(routes.value.req_headers_add) > 0,
+              length(routes.value.req_headers_remove) > 0, length(routes.value.resp_headers_add) > 0,
+              length(routes.value.resp_headers_remove) > 0, length(routes.value.req_cookies_remove) > 0,
+              length(routes.value.resp_cookies_remove) > 0, routes.value.waf_mode != "inherited",
+            ]) ? [1] : []
+            content {
+              prefix_rewrite             = routes.value.prefix_rewrite
+              priority                   = routes.value.priority
+              disable_location_add       = routes.value.disable_location_add
+              timeout                    = routes.value.timeout_ms
+              request_headers_to_remove  = length(routes.value.req_headers_remove) > 0 ? routes.value.req_headers_remove : null
+              response_headers_to_remove = length(routes.value.resp_headers_remove) > 0 ? routes.value.resp_headers_remove : null
+              request_cookies_to_remove  = length(routes.value.req_cookies_remove) > 0 ? routes.value.req_cookies_remove : null
+              response_cookies_to_remove = length(routes.value.resp_cookies_remove) > 0 ? routes.value.resp_cookies_remove : null
+              dynamic "request_headers_to_add" {
+                for_each = routes.value.req_headers_add
+                iterator = h
+                content {
+                  name   = h.value.name
+                  value  = h.value.value
+                  append = h.value.append
+                }
+              }
+              dynamic "response_headers_to_add" {
+                for_each = routes.value.resp_headers_add
+                iterator = h
+                content {
+                  name   = h.value.name
+                  value  = h.value.value
+                  append = h.value.append
+                }
+              }
+              # WAF oneof: app_firewall ref (per-route override) | inherited (default -> omit).
+              # "disable" is not offered: route-level disable_waf {} collides with the LB-level
+              # disable_waf import-suppression (leaf-name match at any depth) and can't round-trip.
+              dynamic "app_firewall" {
+                for_each = routes.value.waf_mode == "app_firewall" ? [1] : []
+                content {
+                  name      = xcsh_app_firewall.this.name
+                  namespace = var.namespace
+                }
               }
             }
-            dynamic "response_headers_to_add" {
-              for_each = routes.value.resp_headers_add
-              iterator = h
-              content {
-                name   = h.value.name
-                value  = h.value.value
-                append = h.value.append
-              }
+          }
+        }
+
+      }
+
+      # redirect_route (type=redirect): match -> 3xx redirect (host/path/prefix/proto + query).
+      dynamic "redirect_route" {
+        for_each = routes.value.type == "redirect" ? [1] : []
+        content {
+          http_method = routes.value.http_method
+          path {
+            prefix = routes.value.path_mode == "prefix" ? routes.value.path_value : null
+            path   = routes.value.path_mode == "exact" ? routes.value.path_value : null
+            regex  = routes.value.path_mode == "regex" ? routes.value.path_value : null
+          }
+          dynamic "headers" {
+            for_each = routes.value.headers
+            iterator = h
+            content {
+              name         = h.value.name
+              exact        = h.value.mode == "exact" ? h.value.value : null
+              regex        = h.value.mode == "regex" ? h.value.value : null
+              presence     = h.value.mode == "presence" ? true : null
+              invert_match = h.value.invert_match
             }
-            # WAF oneof: app_firewall ref (per-route override) | inherited (default -> omit).
-            # "disable" is not offered: route-level disable_waf {} collides with the LB-level
-            # disable_waf import-suppression (leaf-name match at any depth) and can't round-trip.
-            dynamic "app_firewall" {
-              for_each = routes.value.waf_mode == "app_firewall" ? [1] : []
-              content {
-                name      = xcsh_app_firewall.this.name
-                namespace = var.namespace
-              }
+          }
+          dynamic "incoming_port" {
+            for_each = routes.value.incoming_port != null ? [1] : []
+            content {
+              port = routes.value.incoming_port
             }
+          }
+          route_redirect {
+            host_redirect  = routes.value.redirect_host
+            path_redirect  = routes.value.redirect_path
+            prefix_rewrite = routes.value.redirect_prefix_rewrite
+            proto_redirect = routes.value.redirect_proto
+            response_code  = routes.value.redirect_response_code
+            # query-param handling oneof: retain_all_params | remove_all_params
+            dynamic "retain_all_params" {
+              for_each = routes.value.redirect_query == "retain" ? [1] : []
+              content {}
+            }
+            dynamic "remove_all_params" {
+              for_each = routes.value.redirect_query == "remove" ? [1] : []
+              content {}
+            }
+          }
+        }
+      }
+
+      # direct_response_route (type=direct_response): match -> inline response (code + body).
+      dynamic "direct_response_route" {
+        for_each = routes.value.type == "direct_response" ? [1] : []
+        content {
+          http_method = routes.value.http_method
+          path {
+            prefix = routes.value.path_mode == "prefix" ? routes.value.path_value : null
+            path   = routes.value.path_mode == "exact" ? routes.value.path_value : null
+            regex  = routes.value.path_mode == "regex" ? routes.value.path_value : null
+          }
+          dynamic "headers" {
+            for_each = routes.value.headers
+            iterator = h
+            content {
+              name         = h.value.name
+              exact        = h.value.mode == "exact" ? h.value.value : null
+              regex        = h.value.mode == "regex" ? h.value.value : null
+              presence     = h.value.mode == "presence" ? true : null
+              invert_match = h.value.invert_match
+            }
+          }
+          dynamic "incoming_port" {
+            for_each = routes.value.incoming_port != null ? [1] : []
+            content {
+              port = routes.value.incoming_port
+            }
+          }
+          route_direct_response {
+            response_code = routes.value.direct_response_code
+            # response_body_encoded must be a URI ref: the string:/// scheme with the message
+            # base64-encoded. The module takes plaintext/HTML and builds that form.
+            response_body_encoded = routes.value.direct_response_body != null ? "string:///${base64encode(routes.value.direct_response_body)}" : null
           }
         }
       }

--- a/terraform/modules/http-lb/variables_custom_routes.tf
+++ b/terraform/modules/http-lb/variables_custom_routes.tf
@@ -8,6 +8,10 @@
 variable "custom_routes" {
   description = "Custom LB routes (simple_route match -> origin pool). Empty omits routes[]."
   type = list(object({
+    # route type (CR-4): simple (match -> origin pool + advanced_options) | redirect (match ->
+    # 3xx redirect) | direct_response (match -> inline response). The match block below is shared
+    # by all three; simple-only fields (origin pool + advanced_options) apply when type=simple.
+    type = optional(string, "simple") # simple | redirect | direct_response
     # match: path oneof (prefix|exact|regex)
     path_mode  = optional(string, "prefix") # prefix|exact|regex
     path_value = string
@@ -41,6 +45,16 @@ variable "custom_routes" {
     # collides with the LB-level disable_waf import-suppression (matched by leaf name at any
     # depth), so it cannot round-trip cleanly until the provider suppression is path-aware.
     waf_mode = optional(string, "inherited") # inherited | app_firewall
+    # --- redirect_route (type=redirect): route_redirect ---
+    redirect_host           = optional(string)                   # host_redirect
+    redirect_path           = optional(string)                   # path_redirect (exact new path; excl. w/ prefix rewrite)
+    redirect_prefix_rewrite = optional(string)                   # prefix_rewrite (excl. w/ redirect_path)
+    redirect_proto          = optional(string, "incoming-proto") # incoming-proto (keep) | http | https
+    redirect_response_code  = optional(number)                   # e.g. 301 / 302
+    redirect_query          = optional(string, "retain")         # retain | remove (retain_all_params | remove_all_params)
+    # --- direct_response_route (type=direct_response): route_direct_response ---
+    direct_response_code = optional(number) # e.g. 200 / 404
+    direct_response_body = optional(string) # plaintext/HTML; module base64-encodes for the API
   }))
   default = []
 
@@ -73,6 +87,30 @@ variable "custom_routes" {
   validation {
     condition     = alltrue([for r in var.custom_routes : contains(["inherited", "app_firewall"], r.waf_mode)])
     error_message = "custom_routes[].waf_mode must be inherited or app_firewall."
+  }
+  validation {
+    condition     = alltrue([for r in var.custom_routes : contains(["simple", "redirect", "direct_response"], r.type)])
+    error_message = "custom_routes[].type must be simple, redirect, or direct_response."
+  }
+  validation {
+    condition     = alltrue([for r in var.custom_routes : contains(["incoming-proto", "http", "https"], r.redirect_proto)])
+    error_message = "custom_routes[].redirect_proto must be incoming-proto, http, or https."
+  }
+  validation {
+    condition     = alltrue([for r in var.custom_routes : contains(["retain", "remove"], r.redirect_query)])
+    error_message = "custom_routes[].redirect_query must be retain or remove."
+  }
+  validation {
+    condition     = alltrue([for r in var.custom_routes : r.redirect_path == null || r.redirect_prefix_rewrite == null])
+    error_message = "custom_routes[] cannot set both redirect_path and redirect_prefix_rewrite (mutually exclusive)."
+  }
+  validation {
+    condition     = alltrue([for r in var.custom_routes : r.type != "redirect" || r.redirect_response_code != null])
+    error_message = "custom_routes[] with type=redirect requires redirect_response_code."
+  }
+  validation {
+    condition     = alltrue([for r in var.custom_routes : r.type != "direct_response" || (r.direct_response_code != null && r.direct_response_body != null)])
+    error_message = "custom_routes[] with type=direct_response requires direct_response_code and direct_response_body."
   }
   validation {
     condition     = alltrue([for r in var.custom_routes : contains(["DEFAULT", "HIGH"], r.priority)])

--- a/terraform/tests/custom_routes.tftest.hcl
+++ b/terraform/tests/custom_routes.tftest.hcl
@@ -125,6 +125,84 @@ run "bad_waf_mode_rejected" {
   expect_failures = [var.custom_routes]
 }
 
+run "redirect_route_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    custom_routes = [{
+      type                    = "redirect"
+      path_mode               = "prefix"
+      path_value              = "/old"
+      redirect_host           = "www.f5-sales-demo.com"
+      redirect_prefix_rewrite = "/new"
+      redirect_proto          = "https"
+      redirect_response_code  = 301
+      redirect_query          = "remove"
+    }]
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.routes[0].redirect_route.route_redirect.response_code == 301
+    error_message = "redirect response_code must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.routes[0].redirect_route.route_redirect.prefix_rewrite == "/new"
+    error_message = "redirect prefix_rewrite must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.routes[0].redirect_route.route_redirect.remove_all_params != null
+    error_message = "redirect remove_all_params arm must render for query=remove"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.routes[0].simple_route == null
+    error_message = "simple_route must be null for type=redirect"
+  }
+}
+
+run "direct_response_route_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    custom_routes = [{
+      type                 = "direct_response"
+      path_mode            = "exact"
+      path_value           = "/teapot"
+      direct_response_code = 418
+      direct_response_body = "I am a teapot"
+    }]
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.routes[0].direct_response_route.route_direct_response.response_code == 418
+    error_message = "direct response_code must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.routes[0].direct_response_route.route_direct_response.response_body_encoded == "string:///${base64encode("I am a teapot")}"
+    error_message = "direct response body must be the string:/// base64 URI ref"
+  }
+}
+
+run "redirect_requires_response_code" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { custom_routes = [{ type = "redirect", path_mode = "prefix", path_value = "/x" }] }
+  expect_failures = [var.custom_routes]
+}
+
+run "direct_response_requires_code_and_body" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { custom_routes = [{ type = "direct_response", path_mode = "prefix", path_value = "/x", direct_response_code = 200 }] }
+  expect_failures = [var.custom_routes]
+}
+
+run "redirect_path_and_prefix_mutually_exclusive" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    custom_routes = [{ type = "redirect", path_mode = "prefix", path_value = "/x", redirect_response_code = 302, redirect_path = "/a", redirect_prefix_rewrite = "/b" }]
+  }
+  expect_failures = [var.custom_routes]
+}
+
 run "routes_omitted_by_default" {
   command = plan
   module { source = "./modules/http-lb" }


### PR DESCRIPTION
## Summary

Fourth slice of the custom-routes effort (task #71): add the remaining route action arms via a
`type` selector on `custom_routes` (`simple` | `redirect` | `direct_response`). The match block
(path/headers/incoming_port/http_method) is shared across all three arms.

- **redirect_route.route_redirect**: `host_redirect`, `path_redirect` | `prefix_rewrite`
  (mutually exclusive), `proto_redirect` (incoming-proto|http|https), `response_code`, query
  handling (`retain_all_params` | `remove_all_params`).
- **direct_response_route.route_direct_response**: `response_code` + body. The API requires
  `response_body_encoded` as a `string:///<base64>` URI ref; the module builds that from plaintext.

## Live-probe findings (both fixed)

- `proto_redirect` enum is **lowercase** `incoming-proto`/`http`/`https` (not `HTTP`/`HTTPS`) —
  a 400 `string.in` constraint.
- `response_body_encoded` must be the `string:///` URI-ref form, not bare base64 — a 400
  `uri_ref` constraint.

No provider change: both new arms are import-clean on v3.72.9.

## Verification

- `terraform test -filter=tests/custom_routes.tftest.hcl` → **14 passed, 0 failed**.
- Live matrix (`scripts/custom-routes-matrix.sh`, 12 variants): simple (path modes, header+port,
  advanced), redirect, direct-response, mixed-types, canonical → apply → idempotent → whole-LB
  import round-trip → canonical 0-change. **12/12 PASS, 0 FAIL, 0 SKIP.**

Closes #117.
