### PR TITLE
CR-5: standalone xcsh_route + LB custom_route ref (+ behavioral)

### DIFF
--- a/scripts/route-object-matrix.sh
+++ b/scripts/route-object-matrix.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Standalone route object (CR-5) live coverage-matrix harness.
+#
+# Verifies the standalone xcsh_route resource and the LB custom_route (route_ref) arm. Per
+# variant: apply -> idempotent -> round-trip import (the route object always; plus the whole LB
+# for ROUTE_LB variants where it is attached via custom_route). Ends on canonical-restore so the
+# live LB is left with no custom routes. Results append to reports/route-object-matrix.txt.
+#
+# Custom routes are additive to default_route_pools, so the LB keeps serving throughout.
+# Sequential — no concurrent terraform against the shared azurerm state.
+#
+# Usage: route-object-matrix.sh [START [END]]  (inclusive 0-based index range).
+set -uo pipefail
+
+umask 077
+trap 'rm -rf /tmp/cr5-variants 2>/dev/null; rm -f /tmp/cr5-*.log 2>/dev/null' EXIT
+
+cd "$(dirname "$0")/../terraform" || exit 1
+ARM_ACCESS_KEY=$(az storage account keys list -n f5salesdemotfstate -g f5-sales-demo-tfstate --query "[0].value" -o tsv)
+export ARM_ACCESS_KEY
+
+NS="webapp-api-protection"
+LB_ADDR="module.http_lb.xcsh_http_loadbalancer.this"
+LB_ID="${NS}/${NS}"
+RO_ADDR='module.http_lb.xcsh_route.this["cr5-ro"]'
+RO_ID="${NS}/cr5-ro"
+COMMON=(-input=false -lock=true
+  -var 'lb_domains=["www.f5-sales-demo.com","api.f5-sales-demo.com"]'
+  -var 'subscription_id=75f86c46-9cbc-4f6c-85ea-195e3d3c8ac0')
+VARDIR=/tmp/cr5-variants
+REPORT=../reports/route-object-matrix.txt
+mkdir -p ../reports
+
+START="${1:-0}"
+END="${2:-9999}"
+
+[ "$#" -eq 0 ] && : >"$REPORT"
+
+count=$(python3 ../scripts/route_object_pairs.py --emit "$VARDIR")
+echo "generated $count variants into $VARDIR (running [$START..$END])"
+
+reimport_clean() {
+  local label="$1" vf="$2" addr="$3" id="$4"
+  terraform state rm "$addr" >/dev/null 2>&1 || { echo "FAIL $label state-rm ($addr)" >>"$REPORT"; return 1; }
+  terraform import "${COMMON[@]}" -var-file="$vf" "$addr" "$id" >/tmp/cr5-import.log 2>&1 || {
+    echo "FAIL $label import ($(grep -iE 'error' /tmp/cr5-import.log | head -1 | cut -c1-60))" >>"$REPORT"
+    return 1
+  }
+  return 0
+}
+
+round_trip() {
+  local label="$1" vf="$2" flag="$3"
+  if [ "$flag" = "NONE" ]; then
+    echo "PASS $label" >>"$REPORT"
+    return
+  fi
+  reimport_clean "$label" "$vf" "$RO_ADDR" "$RO_ID" || return
+  if [ "$flag" = "ROUTE_LB" ]; then
+    reimport_clean "$label" "$vf" "$LB_ADDR" "$LB_ID" || return
+  fi
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$vf" >/tmp/cr5-rt-plan.log 2>&1
+  case $? in
+  0) echo "PASS $label" >>"$REPORT" ;;
+  2) echo "FAIL $label import-drift" >>"$REPORT" ;;
+  *) echo "FAIL $label rt-plan-error" >>"$REPORT" ;;
+  esac
+}
+
+while read -r idx name vf flag; do
+  [ "$idx" -lt "$START" ] && continue
+  [ "$idx" -gt "$END" ] && continue
+  label="$idx-$name"
+  echo "--- $label ($flag) ---"
+  varfile="${VARDIR}/${vf}"
+  if ! terraform apply -auto-approve "${COMMON[@]}" -var-file="$varfile" >/tmp/cr5-apply.log 2>&1; then
+    echo "FAIL $label apply ($(grep -iE 'error' /tmp/cr5-apply.log | head -1 | cut -c1-80))" >>"$REPORT"
+    continue
+  fi
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$varfile" >/tmp/cr5-plan.log 2>&1
+  case $? in
+  0) round_trip "$label" "$varfile" "$flag" ;;
+  2) echo "FAIL $label not-idempotent" >>"$REPORT" ;;
+  *) echo "FAIL $label plan-error" >>"$REPORT" ;;
+  esac
+done <"${VARDIR}/manifest.txt"
+
+echo "===== ROUTE OBJECT MATRIX RESULTS ($START..$END) ====="
+cat "$REPORT"
+echo "PASS=$(grep -c '^PASS ' "$REPORT") FAIL=$(grep -c '^FAIL ' "$REPORT") SKIP=$(grep -c '^SKIP ' "$REPORT")"

--- a/scripts/route-object-matrix.sh
+++ b/scripts/route-object-matrix.sh
@@ -41,7 +41,10 @@ echo "generated $count variants into $VARDIR (running [$START..$END])"
 
 reimport_clean() {
   local label="$1" vf="$2" addr="$3" id="$4"
-  terraform state rm "$addr" >/dev/null 2>&1 || { echo "FAIL $label state-rm ($addr)" >>"$REPORT"; return 1; }
+  terraform state rm "$addr" >/dev/null 2>&1 || {
+    echo "FAIL $label state-rm ($addr)" >>"$REPORT"
+    return 1
+  }
   terraform import "${COMMON[@]}" -var-file="$vf" "$addr" "$id" >/tmp/cr5-import.log 2>&1 || {
     echo "FAIL $label import ($(grep -iE 'error' /tmp/cr5-import.log | head -1 | cut -c1-60))" >>"$REPORT"
     return 1

--- a/scripts/route_object_pairs.py
+++ b/scripts/route_object_pairs.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Generate the standalone route object (CR-5) coverage matrix.
+
+The inline route arms are exhausted by CR-1..CR-4; this verifies the standalone xcsh_route
+resource round-trip and the LB custom_route (route_ref) arm. Small explicit variant set
+(standalone route attached to the LB, standalone-only), plus canonical-restore (nothing).
+
+Deterministic. Output: JSON to stdout, or files via --emit.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+RO = {
+    "name": "cr5-ro",
+    "path_prefix": "/cr5-route",
+    "response_code": 200,
+    "response_body": "routed via xcsh_route",
+}
+
+
+def build() -> list[dict[str, object]]:
+    """Ordered variants: route attached to LB, standalone-only, canonical."""
+    return [
+        {
+            "name": "route-attached",
+            "vars": {"route_objects": [RO], "custom_route_ref": "cr5-ro"},
+        },
+        {
+            "name": "route-standalone",
+            "vars": {"route_objects": [RO], "custom_route_ref": None},
+        },
+        {
+            "name": "canonical-restore",
+            "vars": {"route_objects": [], "custom_route_ref": None},
+        },
+    ]
+
+
+def emit(directory: str) -> int:
+    """Write one <NNN>-<name>.tfvars.json per variant plus manifest.txt (flag = round-trip mode)."""
+    out_dir = Path(directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for existing in out_dir.iterdir():
+        if existing.name.endswith(".tfvars.json") or existing.name == "manifest.txt":
+            existing.unlink()
+    variants = build()
+    named = [(f"{i:03d}-{v['name']}.tfvars.json", v) for i, v in enumerate(variants)]
+    for fname, v in named:
+        (out_dir / fname).write_text(json.dumps(v["vars"], indent=2) + "\n")
+    lines = []
+    for i, (fname, v) in enumerate(named):
+        vars_ = v["vars"]
+        if not (isinstance(vars_, dict) and vars_.get("route_objects")):
+            flag = "NONE"  # nothing created -> no round-trip
+        elif vars_.get("custom_route_ref"):
+            flag = "ROUTE_LB"  # round-trip the route object AND the whole LB
+        else:
+            flag = "ROUTE"  # round-trip the route object only
+        lines.append(f"{i:03d} {v['name']} {fname} {flag}")
+    (out_dir / "manifest.txt").write_text("\n".join(lines) + "\n")
+    return len(variants)
+
+
+def main(argv: list[str]) -> None:
+    """CLI: --count, --emit <dir>, else JSON to stdout."""
+    match argv[1:]:
+        case ["--count"]:
+            sys.stdout.write(f"{len(build())}\n")
+        case ["--emit", directory]:
+            sys.stdout.write(f"{emit(directory)}\n")
+        case _:
+            json.dump(build(), sys.stdout, indent=2)
+            sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -80,6 +80,8 @@ module "http_lb" {
   origin_connection_timeout    = var.origin_connection_timeout
   origin_http_idle_timeout     = var.origin_http_idle_timeout
   custom_routes                = var.custom_routes
+  route_objects                = var.route_objects
+  custom_route_ref             = var.custom_route_ref
   labels                       = var.labels
   waf_mode                     = var.waf_mode
   csd_enabled                  = var.csd_enabled

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -654,6 +654,20 @@ resource "xcsh_http_loadbalancer" "this" {
     }
   }
 
+  # custom_route (CR-5): a routes[] entry that references a standalone xcsh_route object. A second
+  # dynamic "routes" block — Terraform concatenates same-named dynamic blocks into the one list.
+  dynamic "routes" {
+    for_each = var.custom_route_ref != null ? [1] : []
+    content {
+      custom_route_object {
+        route_ref {
+          name      = xcsh_route.this[var.custom_route_ref].name
+          namespace = var.namespace
+        }
+      }
+    }
+  }
+
   advertise_on_public_default_vip {}
 
   # Attach the WAF (oneof: app_firewall vs disable_waf; server default disable_waf).
@@ -2449,6 +2463,12 @@ resource "xcsh_http_loadbalancer" "this" {
     precondition {
       condition     = length(var.api_crawler_domains) == 0 || local.api_crawler_password_secret.url != null || local.api_crawler_password_secret.location != null
       error_message = "api_crawler_domains is set but api_crawler_password has no value: set plaintext (clear) or location (blindfold)."
+    }
+
+    # CR-5: a custom_route_ref must name a defined route_objects entry.
+    precondition {
+      condition     = var.custom_route_ref == null || contains([for r in var.route_objects : r.name], var.custom_route_ref)
+      error_message = "custom_route_ref must name an entry in route_objects."
     }
 
     # WAF exclusion is a oneof: inline rules (waf_exclusion_rules) XOR a policy reference

--- a/terraform/modules/http-lb/route.tf
+++ b/terraform/modules/http-lb/route.tf
@@ -1,0 +1,31 @@
+# Standalone WAF/route objects (CR-5). for_each keyed by name so the LB custom_route arm can
+# reference a specific route via xcsh_route.this[<name>]. Minimal: one route matching a path
+# prefix and returning a direct response (the object's full surface mirrors the inline routes).
+resource "xcsh_route" "this" {
+  for_each = { for r in var.route_objects : r.name => r }
+
+  name      = each.value.name
+  namespace = var.namespace
+
+  routes {
+    # disable_location_add is Optional-not-Computed with a server default — emit explicitly.
+    disable_location_add = false
+    match {
+      # http_method is the server-default "ANY" (Optional-not-Computed) — emit explicitly.
+      http_method = "ANY"
+      path {
+        prefix = each.value.path_prefix
+      }
+    }
+    route_direct_response {
+      response_code = each.value.response_code
+      # response_body_encoded is a string:///<base64> URI ref (same as the inline direct route).
+      response_body_encoded = "string:///${base64encode(each.value.response_body)}"
+    }
+    # waf_type is a required oneof the server materializes on apply (was-absent-now-present);
+    # emit the inherit arm so the route uses the LB WAF and the apply is consistent.
+    waf_type {
+      inherit_waf {}
+    }
+  }
+}

--- a/terraform/modules/http-lb/variables_route.tf
+++ b/terraform/modules/http-lb/variables_route.tf
@@ -1,0 +1,26 @@
+# CR-5: standalone xcsh_route objects, referenceable by the LB via a custom_route (route_ref).
+# A route object is authored once (a match -> direct-response) and attached to the LB. Kept
+# minimal (match path prefix -> direct_response code+body); the route object's full surface
+# mirrors the inline routes covered in CR-1..CR-4. Empty list creates nothing (0-change).
+
+variable "route_objects" {
+  description = "Standalone xcsh_route objects (name -> match prefix -> direct response), referenceable by the LB."
+  type = list(object({
+    name          = string
+    path_prefix   = string # routes[].match[].path.prefix
+    response_code = optional(number, 200)
+    response_body = optional(string, "routed via xcsh_route")
+  }))
+  default = []
+
+  validation {
+    condition     = alltrue([for r in var.route_objects : startswith(r.path_prefix, "/")])
+    error_message = "route_objects[].path_prefix must start with '/'."
+  }
+}
+
+variable "custom_route_ref" {
+  description = "Name of a route_objects entry to attach to the LB as a custom_route. null = none."
+  type        = string
+  default     = null
+}

--- a/terraform/tests/custom_routes.tftest.hcl
+++ b/terraform/tests/custom_routes.tftest.hcl
@@ -203,6 +203,54 @@ run "redirect_path_and_prefix_mutually_exclusive" {
   expect_failures = [var.custom_routes]
 }
 
+run "standalone_route_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    route_objects = [{ name = "ro-a", path_prefix = "/ro", response_code = 200, response_body = "hi from route obj" }]
+  }
+  assert {
+    condition     = xcsh_route.this["ro-a"].routes[0].match[0].path.prefix == "/ro"
+    error_message = "standalone route match prefix must render"
+  }
+  assert {
+    condition     = xcsh_route.this["ro-a"].routes[0].route_direct_response.response_body_encoded == "string:///${base64encode("hi from route obj")}"
+    error_message = "standalone route direct-response body must be the string:/// URI ref"
+  }
+}
+
+run "lb_custom_route_ref_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    route_objects    = [{ name = "ro-a", path_prefix = "/ro" }]
+    custom_route_ref = "ro-a"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.routes[0].custom_route_object.route_ref.name == "ro-a"
+    error_message = "LB custom_route_object route_ref must render the referenced route object"
+  }
+}
+
+run "custom_route_ref_must_exist" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    route_objects    = [{ name = "ro-a", path_prefix = "/ro" }]
+    custom_route_ref = "missing"
+  }
+  expect_failures = [xcsh_http_loadbalancer.this]
+}
+
+run "no_route_objects_by_default" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  assert {
+    condition     = length(xcsh_route.this) == 0
+    error_message = "no standalone route objects by default"
+  }
+}
+
 run "routes_omitted_by_default" {
   command = plan
   module { source = "./modules/http-lb" }

--- a/terraform/variables_route.tf
+++ b/terraform/variables_route.tf
@@ -1,0 +1,12 @@
+# Root passthrough for standalone route objects + LB custom_route ref (CR-5).
+variable "route_objects" {
+  description = "Standalone xcsh_route objects (see module for shape)."
+  type        = any
+  default     = []
+}
+
+variable "custom_route_ref" {
+  description = "Name of a route_objects entry to attach to the LB as a custom_route. null = none."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
## Summary

Final slice of the custom-routes effort (task #71): the **custom_route** arm — a routes[] entry
that references a standalone `xcsh_route` object — plus end-to-end behavioral verification.

- Standalone `xcsh_route` resource (`route_objects` list, for_each by name): a minimal route
  matching a path prefix and returning a direct response.
- LB `custom_route_object.route_ref` arm via `custom_route_ref`; lifecycle precondition (the ref
  must name a `route_objects` entry). Emitted as a second `dynamic "routes"` block (Terraform
  concatenates same-named dynamic blocks into the one list).

## Standalone-route findings (both fixed)

- `routes[].disable_location_add` is Optional-not-Computed → emit `false` explicitly.
- `routes[].waf_type` is a required oneof the server materializes on apply ("was absent, now
  present") → emit `waf_type { inherit_waf {} }`.

No provider change: both the route object and the whole LB (with the ref) import round-trip clean
on v3.72.9.

## Verification

- `terraform test -filter=tests/custom_routes.tftest.hcl` → **18 passed, 0 failed**.
- Live matrix (`scripts/route-object-matrix.sh`, 3 variants): route attached / standalone /
  canonical → apply → idempotent → **route object + whole-LB import round-trip** → canonical
  0-change. **3/3 PASS.**
- **Behavioral (live)**: redirect `/cr5-old` → **301** `Location: .../new-location`; inline
  direct-response `/cr5-teapot` → **418** (code applied); custom_route `/cr5-route` → **200**
  "routed via xcsh_route" (served by the referenced `xcsh_route`). LB kept serving www/api.

Closes #119.
