### PR TITLE
Re-enable waf_exclusion signature_id=0 coverage (provider v3.72.10 / #1129)

### DIFF
--- a/scripts/waf_exclusion_pairs.py
+++ b/scripts/waf_exclusion_pairs.py
@@ -78,12 +78,15 @@ def _excl_fields(excl: str) -> dict[str, object]:
         return {"action": "skip"}
     base: dict[str, object] = {"action": "detection_control"}
     if excl == "signature":
+        # signature_id 0 = "exclude ALL signatures for the context"; round-trips faithfully since
+        # provider v3.72.10 (#1129, meaningful-zero int64 read). A real ID is the 200000001+ range.
         base["exclude_signatures"] = [
+            {"signature_id": 0, "context": "CONTEXT_ANY"},
             {
                 "signature_id": 200002147,
                 "context": "CONTEXT_HEADER",
                 "context_name": "x-api",
-            }
+            },
         ]
     elif excl == "violation":
         base["exclude_violations"] = [{"violation": "VIOL_JSON_MALFORMED"}]

--- a/scripts/waf_exclusion_policy_pairs.py
+++ b/scripts/waf_exclusion_policy_pairs.py
@@ -19,20 +19,20 @@ SKIP_RULE = {
     "path_value": "/waf-excl-probe",
     "action": "skip",
 }
-# Use a real signature ID (200000001-299999999). signature_id=0 ("all signatures") hits a
-# distinct provider zero-value-omission bug (marshal drops the 0 -> read-back null -> apply
-# "inconsistent result"); tracked separately, not exercised here.
+# signature_id 0 = "exclude ALL signatures for the context"; round-trips faithfully since
+# provider v3.72.10 (#1129, meaningful-zero int64 read). A real ID is the 200000001+ range.
 DC_RULE = {
     "name": "excl-sig",
     "domain": "exact",
     "domain_value": "api.f5-sales-demo.com",
     "action": "detection_control",
     "exclude_signatures": [
+        {"signature_id": 0, "context": "CONTEXT_ANY"},
         {
             "signature_id": 200002147,
             "context": "CONTEXT_HEADER",
             "context_name": "x-api",
-        }
+        },
     ],
     "exclude_violations": [{"violation": "VIOL_JSON_MALFORMED"}],
 }

--- a/terraform/modules/http-lb/versions.tf
+++ b/terraform/modules/http-lb/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     xcsh = {
       source  = "f5-sales-demo/xcsh"
-      version = ">= 3.72.9"
+      version = ">= 3.72.10"
     }
   }
 }

--- a/terraform/tests/waf_exclusion.tftest.hcl
+++ b/terraform/tests/waf_exclusion.tftest.hcl
@@ -42,11 +42,14 @@ run "detection_control_rule_renders" {
   module { source = "./modules/http-lb" }
   variables {
     waf_exclusion_rules = [{
-      name               = "excl-sig"
-      domain             = "exact"
-      domain_value       = "api.f5-sales-demo.com"
-      action             = "detection_control"
-      exclude_signatures = [{ signature_id = 200002147, context = "CONTEXT_HEADER", context_name = "x-api" }]
+      name         = "excl-sig"
+      domain       = "exact"
+      domain_value = "api.f5-sales-demo.com"
+      action       = "detection_control"
+      exclude_signatures = [
+        { signature_id = 0, context = "CONTEXT_ANY" },
+        { signature_id = 200002147, context = "CONTEXT_HEADER", context_name = "x-api" },
+      ]
       exclude_violations = [{ violation = "VIOL_JSON_MALFORMED" }]
     }]
   }
@@ -54,8 +57,13 @@ run "detection_control_rule_renders" {
     condition     = xcsh_http_loadbalancer.this.waf_exclusion.waf_exclusion_inline_rules.rules[0].exact_value == "api.f5-sales-demo.com"
     error_message = "exact_value must render for domain=exact"
   }
+  # signature_id 0 = "all signatures"; round-trips since provider v3.72.10 (#1129).
   assert {
-    condition     = xcsh_http_loadbalancer.this.waf_exclusion.waf_exclusion_inline_rules.rules[0].app_firewall_detection_control.exclude_signature_contexts[0].signature_id == 200002147
+    condition     = xcsh_http_loadbalancer.this.waf_exclusion.waf_exclusion_inline_rules.rules[0].app_firewall_detection_control.exclude_signature_contexts[0].signature_id == 0
+    error_message = "signature_id=0 (all signatures) must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.waf_exclusion.waf_exclusion_inline_rules.rules[0].app_firewall_detection_control.exclude_signature_contexts[1].signature_id == 200002147
     error_message = "exclude_signature_contexts signature_id must render"
   }
   assert {

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -49,7 +49,7 @@ terraform {
       # >= 3.72.6: LPC-2 more_option import suppressions (provider #1125) — custom_errors /
       # no_request_limit_per_connection empty markers, so a more_option header config
       # round-trip-imports clean.
-      # >= 3.72.9: LPC-5b origin_pool advanced_options import suppressions (provider #1130) —
+      # >= 3.72.7: LPC-5b origin_pool advanced_options import suppressions (provider #1130) —
       # auto_http_config / default_circuit_breaker / disable_outlier_detection / disable_subsets
       # / no_panic_threshold / no_request_limit_per_connection, so an advanced_options config
       # round-trip-imports clean.
@@ -57,7 +57,9 @@ terraform {
       # + auto_host_rewrite, so a simple_route config round-trip-imports clean.
       # >= 3.72.9: CR-3 route advanced_options import suppressions (provider #1138) — 8 oneof-base
       # markers (buffer/hash/retry/mirror/prefix-rewrite/spdy/websocket/cluster defaults).
-      version = ">= 3.72.9"
+      # >= 3.72.10: meaningful-zero int64 read (provider #1129) — signature_id=0 ("all signatures")
+      # round-trips faithfully, re-enabling that waf_exclusion case.
+      version = ">= 3.72.10"
     }
     # Azure providers: this plan also deploys its OWN Azure origin server and
     # traffic generator (modules/origin-server, modules/traffic-generator), which


### PR DESCRIPTION
## Problem

WAF-exclusion coverage (LPC-4a/4b) accepts `signature_id` but the matrices/tests deliberately
avoided `signature_id = 0` ("exclude ALL signatures for the context") because it hit a provider
bug (xcsh#1129): the generated int64 read dropped a returned 0, so a config that set 0 failed
apply with "Provider produced inconsistent result" and drifted on import.

xcsh#1129 is fixed in provider **v3.72.10** (meaningful-zero int64 read). This re-enables and
live-verifies the `signature_id = 0` case.

## Scope

- Repin `xcsh >= 3.72.10`.
- Restore `signature_id = 0` in the waf_exclusion generators (`waf_exclusion_pairs.py`
  signature variant; `waf_exclusion_policy_pairs.py` DC_RULE) and drop the stale "bug, not
  exercised" comments.
- Add a `signature_id = 0` plan-test assertion.
- Live-verify: inline waf_exclusion sig0 whole-LB import round-trip; standalone
  waf_exclusion_policy sig0 via the policy matrix.

## Acceptance criteria

- [ ] `terraform test` green.
- [ ] sig0 applies + idempotent + import round-trip clean (both inline + standalone paths).
- [ ] CI green; PR closes this issue.

## Verification
- `terraform test` **8/8**. Live on v3.72.10: inline waf_exclusion signature_id=0 whole-LB import round-trip **clean** (direct probe); standalone waf_exclusion_policy signature_id=0 via the policy matrix **4/4** (round-trips policy resource + whole LB). Canonical 0-change.

Closes #121