### PR TITLE
Re-enable custom-route waf_mode=disable (provider v3.72.11 / #1145)

### DIFF
--- a/scripts/custom_routes_pairs.py
+++ b/scripts/custom_routes_pairs.py
@@ -143,6 +143,20 @@ def build() -> list[dict[str, object]]:
             },
         },
         {
+            # waf_mode=disable -> route advanced_options.disable_waf {}. Round-trips since
+            # provider v3.72.11 (#1145 root-only import suppression); previously dropped (CR-3).
+            "name": "adv-waf-disable",
+            "vars": {
+                "custom_routes": [
+                    {
+                        "path_mode": "prefix",
+                        "path_value": "/no-waf",
+                        "waf_mode": "disable",
+                    }
+                ]
+            },
+        },
+        {
             "name": "redirect",
             "vars": {
                 "custom_routes": [

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -554,15 +554,20 @@ resource "xcsh_http_loadbalancer" "this" {
                   append = h.value.append
                 }
               }
-              # WAF oneof: app_firewall ref (per-route override) | inherited (default -> omit).
-              # "disable" is not offered: route-level disable_waf {} collides with the LB-level
-              # disable_waf import-suppression (leaf-name match at any depth) and can't round-trip.
+              # WAF oneof: app_firewall ref (per-route override) | disable (route disable_waf {}) |
+              # inherited (default -> omit). disable round-trips since provider v3.72.11 (#1145):
+              # the LB-level disable_waf import-suppression is now root-only, so the nested
+              # route-level disable_waf is read back instead of stripped on import.
               dynamic "app_firewall" {
                 for_each = routes.value.waf_mode == "app_firewall" ? [1] : []
                 content {
                   name      = xcsh_app_firewall.this.name
                   namespace = var.namespace
                 }
+              }
+              dynamic "disable_waf" {
+                for_each = routes.value.waf_mode == "disable" ? [1] : []
+                content {}
               }
             }
           }

--- a/terraform/modules/http-lb/variables_custom_routes.tf
+++ b/terraform/modules/http-lb/variables_custom_routes.tf
@@ -41,10 +41,10 @@ variable "custom_routes" {
     req_cookies_remove   = optional(list(string), [])
     resp_cookies_remove  = optional(list(string), [])
     # inherited (route uses the LB WAF, default) | app_firewall (per-route WAF override to the
-    # module's app_firewall). "disable" is intentionally omitted: the route-level disable_waf {}
-    # collides with the LB-level disable_waf import-suppression (matched by leaf name at any
-    # depth), so it cannot round-trip cleanly until the provider suppression is path-aware.
-    waf_mode = optional(string, "inherited") # inherited | app_firewall
+    # module's app_firewall) | disable (turn WAF off for this route -> route disable_waf {}).
+    # disable round-trips since provider v3.72.11 (#1145): the LB-level disable_waf import-
+    # suppression is now root-only scoped, so the nested route-level disable_waf reads back.
+    waf_mode = optional(string, "inherited") # inherited | app_firewall | disable
     # --- redirect_route (type=redirect): route_redirect ---
     redirect_host           = optional(string)                   # host_redirect
     redirect_path           = optional(string)                   # path_redirect (exact new path; excl. w/ prefix rewrite)
@@ -85,8 +85,8 @@ variable "custom_routes" {
     error_message = "custom_routes[].headers[].value is required for exact/regex mode."
   }
   validation {
-    condition     = alltrue([for r in var.custom_routes : contains(["inherited", "app_firewall"], r.waf_mode)])
-    error_message = "custom_routes[].waf_mode must be inherited or app_firewall."
+    condition     = alltrue([for r in var.custom_routes : contains(["inherited", "app_firewall", "disable"], r.waf_mode)])
+    error_message = "custom_routes[].waf_mode must be inherited, app_firewall, or disable."
   }
   validation {
     condition     = alltrue([for r in var.custom_routes : contains(["simple", "redirect", "direct_response"], r.type)])

--- a/terraform/modules/http-lb/versions.tf
+++ b/terraform/modules/http-lb/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     xcsh = {
       source  = "f5-sales-demo/xcsh"
-      version = ">= 3.72.10"
+      version = ">= 3.72.11"
     }
   }
 }

--- a/terraform/tests/custom_routes.tftest.hcl
+++ b/terraform/tests/custom_routes.tftest.hcl
@@ -108,6 +108,28 @@ run "advanced_options_render" {
   }
 }
 
+run "waf_mode_disable_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    custom_routes = [{
+      path_mode  = "prefix"
+      path_value = "/no-waf"
+      waf_mode   = "disable"
+    }]
+  }
+  # waf_mode=disable -> route advanced_options.disable_waf {} (round-trips since provider
+  # v3.72.11 / #1145 root-only import suppression). app_firewall arm must be absent.
+  assert {
+    condition     = xcsh_http_loadbalancer.this.routes[0].simple_route.advanced_options.disable_waf != null
+    error_message = "waf_mode=disable must render advanced_options.disable_waf"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.routes[0].simple_route.advanced_options.app_firewall == null
+    error_message = "waf_mode=disable must not render the app_firewall arm"
+  }
+}
+
 run "advanced_options_omitted_when_no_tuning" {
   command = plan
   module { source = "./modules/http-lb" }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -59,7 +59,10 @@ terraform {
       # markers (buffer/hash/retry/mirror/prefix-rewrite/spdy/websocket/cluster defaults).
       # >= 3.72.10: meaningful-zero int64 read (provider #1129) — signature_id=0 ("all signatures")
       # round-trips faithfully, re-enabling that waf_exclusion case.
-      version = ">= 3.72.10"
+      # >= 3.72.11: root-only import suppression (provider #1145) — disable_waf is suppressed only
+      # at the LB root, so a route-level advanced_options.disable_waf {} (waf_mode=disable) reads
+      # back and round-trips instead of being stripped on import. Re-enables CR-3's dropped arm.
+      version = ">= 3.72.11"
     }
     # Azure providers: this plan also deploys its OWN Azure origin server and
     # traffic generator (modules/origin-server, modules/traffic-generator), which


### PR DESCRIPTION
## Summary

Re-enables the route-level WAF `disable` arm that CR-3 was forced to drop. A route declaring
`disable_waf {}` had it stripped on import (the LB-level `disable_waf` import-default suppression
matched by leaf name at any depth), so the next plan drifted. Provider **v3.72.11** (#1145) scopes
that suppression to the resource root, so a nested route-level `disable_waf` reads back and
round-trips.

## Changes

- `custom_routes[].waf_mode` now accepts `disable` (validation + docs updated).
- Route `advanced_options` emits `disable_waf {}` when `waf_mode = "disable"` (oneof sibling of the
  `app_firewall` arm).
- Provider pin bumped to `>= 3.72.11` (module + root `versions.tf`).
- Plan-test `waf_mode_disable_renders` (renders `disable_waf`, omits `app_firewall`).
- Live-matrix `adv-waf-disable` variant in `scripts/custom_routes_pairs.py`.

## Verification

- `terraform test` custom_routes: **19/19 pass** (incl. `waf_mode_disable_renders`).
- Live matrix on f5-sales-demo (dev_overrides built from regenerated v3.72.11 code):
  - `008-adv-waf-disable`: **PASS** — apply → idempotent (plan 0-change) → whole-LB `state rm` +
    `import` + re-plan **0-change** (round-trip clean; the exact case that failed pre-fix).
  - `012-canonical-restore`: **PASS**; live LB confirmed **0-change** (canonical restored).

Closes #123