### PR TITLE
CH-2: cover policy_based_challenge parameter + activation oneofs

### DIFF
--- a/scripts/challenge_pairs.py
+++ b/scripts/challenge_pairs.py
@@ -59,6 +59,40 @@ def build() -> list[dict[str, object]]:
             },
         },
         {
+            # policy_based custom js params + always_js activation (standalone, MUD off).
+            "name": "pbc-custom-js",
+            "vars": {
+                "mud_enabled": False,
+                "challenge": {
+                    "mode": "policy_based",
+                    "policy_based": {
+                        "activation": "always_js",
+                        "js_params": {"cookie_expiry": 1800, "js_script_delay": 2000},
+                    },
+                },
+            },
+        },
+        {
+            # policy_based custom captcha params + temporary_user_blocking + always_captcha.
+            "name": "pbc-custom-captcha-temp",
+            "vars": {
+                "mud_enabled": False,
+                "challenge": {
+                    "mode": "policy_based",
+                    "policy_based": {
+                        "activation": "always_captcha",
+                        "captcha_params": {"cookie_expiry": 1800},
+                        "temporary_blocking": {"custom_page": "string:///QmxvY2tlZC4="},
+                    },
+                },
+            },
+        },
+        {
+            # policy_based all-default (empty body -> server default_* arms).
+            "name": "pbc-all-default",
+            "vars": {"mud_enabled": False, "challenge": {"mode": "policy_based"}},
+        },
+        {
             "name": "none",
             "vars": {"mud_enabled": False, "challenge": {"mode": "none"}},
         },

--- a/terraform/modules/http-lb/locals_challenge.tf
+++ b/terraform/modules/http-lb/locals_challenge.tf
@@ -15,4 +15,10 @@ locals {
   challenge_attach_mud = (
     local.challenge_explicit ? var.challenge.attach_malicious_user_mitigation : var.mud_enabled
   )
+
+  # CH-2: policy_based_challenge body. Emit only the CUSTOM arm of each default-vs-custom oneof
+  # (js/captcha/temp-blocking params, mitigation ref) and the chosen activation member; omitting a
+  # choice lets the server apply its default_* arm (import-suppressed). Null when not configured.
+  challenge_pbc            = try(var.challenge.policy_based, null)
+  challenge_pbc_activation = try(var.challenge.policy_based.activation, "default")
 }

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -2475,12 +2475,50 @@ resource "xcsh_http_loadbalancer" "this" {
   dynamic "policy_based_challenge" {
     for_each = local.challenge_mode == "policy_based" ? [1] : []
     content {
+      # mitigation choice: ref arm (attach) vs the server default (default_mitigation_settings,
+      # emitted by the server when omitted; import-suppressed).
       dynamic "malicious_user_mitigation" {
         for_each = local.challenge_attach_mud ? [1] : []
         content {
           name      = xcsh_malicious_user_mitigation.mud[0].name
           namespace = xcsh_malicious_user_mitigation.mud[0].namespace
         }
+      }
+      # js/captcha/temp-blocking parameter choices — emit the custom arm only; omission -> server
+      # default_* arm (CH-2 probe: js_script_delay must be >= 1000).
+      dynamic "js_challenge_parameters" {
+        for_each = try(local.challenge_pbc.js_params, null) != null ? [1] : []
+        content {
+          cookie_expiry   = try(local.challenge_pbc.js_params.cookie_expiry, null)
+          custom_page     = try(local.challenge_pbc.js_params.custom_page, null)
+          js_script_delay = try(local.challenge_pbc.js_params.js_script_delay, null)
+        }
+      }
+      dynamic "captcha_challenge_parameters" {
+        for_each = try(local.challenge_pbc.captcha_params, null) != null ? [1] : []
+        content {
+          cookie_expiry = try(local.challenge_pbc.captcha_params.cookie_expiry, null)
+          custom_page   = try(local.challenge_pbc.captcha_params.custom_page, null)
+        }
+      }
+      dynamic "temporary_user_blocking" {
+        for_each = try(local.challenge_pbc.temporary_blocking, null) != null ? [1] : []
+        content {
+          custom_page = try(local.challenge_pbc.temporary_blocking.custom_page, null)
+        }
+      }
+      # activation choice (oneof): omit for the server default; rule_list is CH-3.
+      dynamic "no_challenge" {
+        for_each = local.challenge_pbc_activation == "no_challenge" ? [1] : []
+        content {}
+      }
+      dynamic "always_enable_js_challenge" {
+        for_each = local.challenge_pbc_activation == "always_js" ? [1] : []
+        content {}
+      }
+      dynamic "always_enable_captcha_challenge" {
+        for_each = local.challenge_pbc_activation == "always_captcha" ? [1] : []
+        content {}
       }
     }
   }

--- a/terraform/modules/http-lb/variables_challenge.tf
+++ b/terraform/modules/http-lb/variables_challenge.tf
@@ -21,6 +21,16 @@ variable "challenge" {
     custom_page                      = optional(string)
     js_script_delay                  = optional(number)
     attach_malicious_user_mitigation = optional(bool, false)
+    # CH-2: policy_based_challenge body. Each of js_params/captcha_params/temporary_blocking is a
+    # default-vs-custom oneof — null selects the default_* arm, an object the custom arm. activation
+    # is the oneof {default(omit) | no_challenge | always_js | always_captcha}. Mitigation choice
+    # reuses attach_malicious_user_mitigation (ref arm) vs default_mitigation_settings. rule_list=CH-3.
+    policy_based = optional(object({
+      activation         = optional(string, "default")
+      js_params          = optional(object({ cookie_expiry = optional(number), custom_page = optional(string), js_script_delay = optional(number) }))
+      captcha_params     = optional(object({ cookie_expiry = optional(number), custom_page = optional(string) }))
+      temporary_blocking = optional(object({ custom_page = optional(string) }))
+    }))
   })
   default = {}
 
@@ -31,5 +41,17 @@ variable "challenge" {
   validation {
     condition     = !var.challenge.attach_malicious_user_mitigation || contains(["enable", "policy_based"], coalesce(var.challenge.mode, "none"))
     error_message = "challenge.attach_malicious_user_mitigation is valid only for mode enable or policy_based."
+  }
+  validation {
+    condition     = var.challenge.policy_based == null || var.challenge.mode == "policy_based"
+    error_message = "challenge.policy_based params require challenge.mode = policy_based."
+  }
+  validation {
+    condition     = try(var.challenge.policy_based.activation, "default") == null ? true : contains(["default", "no_challenge", "always_js", "always_captcha"], try(var.challenge.policy_based.activation, "default"))
+    error_message = "challenge.policy_based.activation must be default, no_challenge, always_js, or always_captcha."
+  }
+  validation {
+    condition     = try(var.challenge.policy_based.js_params.js_script_delay, null) == null || try(var.challenge.policy_based.js_params.js_script_delay, 0) >= 1000
+    error_message = "challenge.policy_based.js_params.js_script_delay must be >= 1000 (F5 XC uint32 gte constraint)."
   }
 }

--- a/terraform/tests/challenge.tftest.hcl
+++ b/terraform/tests/challenge.tftest.hcl
@@ -1,5 +1,6 @@
-# Plan-level tests for CH-1: the unified `challenge` variable owning the LB challenge_type
-# oneof (no_challenge/enable/js/captcha/policy_based). command = plan, targets ./modules/http-lb.
+# Plan-level tests for the unified `challenge` variable owning the LB challenge_type oneof
+# (no_challenge/enable/js/captcha/policy_based). CH-1: mode selection + js/captcha arms + MUD
+# derivation. CH-2: policy_based_challenge parameter + activation oneofs. command = plan.
 variables {
   namespace         = "webapp-api-protection"
   lb_domains        = ["www.f5-sales-demo.com"]
@@ -93,6 +94,74 @@ run "explicit_enable_with_mud_attaches_ref" {
     condition     = xcsh_http_loadbalancer.this.enable_challenge.malicious_user_mitigation.name == "webapp-api-protection-mud"
     error_message = "explicit enable + attach must reference the mitigation policy"
   }
+}
+
+run "policy_based_custom_params_render" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    challenge = {
+      mode = "policy_based"
+      policy_based = {
+        activation         = "always_js"
+        js_params          = { cookie_expiry = 1800, js_script_delay = 2000 }
+        captcha_params     = { cookie_expiry = 1800 }
+        temporary_blocking = { custom_page = "string:///QmxvY2tlZC4=" }
+      }
+    }
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.policy_based_challenge.js_challenge_parameters.js_script_delay == 2000
+    error_message = "custom js_challenge_parameters must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.policy_based_challenge.captcha_challenge_parameters.cookie_expiry == 1800
+    error_message = "custom captcha_challenge_parameters must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.policy_based_challenge.temporary_user_blocking != null
+    error_message = "custom temporary_user_blocking must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.policy_based_challenge.always_enable_js_challenge != null
+    error_message = "activation always_js must render always_enable_js_challenge"
+  }
+}
+
+run "policy_based_defaults_omit_custom_arms" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  # mode=policy_based with no params -> empty policy_based_challenge (server applies default_* arms)
+  variables { challenge = { mode = "policy_based" } }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.policy_based_challenge != null
+    error_message = "policy_based_challenge block must render for mode=policy_based"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.policy_based_challenge.js_challenge_parameters == null && xcsh_http_loadbalancer.this.policy_based_challenge.captcha_challenge_parameters == null && xcsh_http_loadbalancer.this.policy_based_challenge.always_enable_js_challenge == null
+    error_message = "no custom arm may render when policy_based params are unset"
+  }
+}
+
+run "js_script_delay_min_rejected" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { challenge = { mode = "policy_based", policy_based = { js_params = { js_script_delay = 500 } } } }
+  expect_failures = [var.challenge]
+}
+
+run "policy_based_requires_policy_based_mode" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { challenge = { mode = "js", policy_based = { activation = "always_js" } } }
+  expect_failures = [var.challenge]
+}
+
+run "bad_activation_rejected" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { challenge = { mode = "policy_based", policy_based = { activation = "always_everything" } } }
+  expect_failures = [var.challenge]
 }
 
 run "bad_mode_rejected" {


### PR DESCRIPTION
## Summary

Second slice of the challenge-coverage effort. Extends the unified `challenge` variable with a
`policy_based` sub-object covering the `policy_based_challenge` body. The oneof structure was
confirmed by a **live PUT-probe** against the tenant (conflicting members →
`400 "Oneof fields […] should be exclusive at path spec.challenge_type.policy_based_challenge.<choice>"`).

## Changes

- `challenge.policy_based`: `js_params` / `captcha_params` / `temporary_blocking` (each the CUSTOM
  arm of a default-vs-custom oneof — omission → server `default_*` arm), `activation`
  (default/no_challenge/always_js/always_captcha). Mitigation choice reuses
  `attach_malicious_user_mitigation` (ref) vs `default_mitigation_settings`.
- Validations: `policy_based` requires `mode = policy_based`; `js_params.js_script_delay >= 1000`
  (F5 XC uint32 gte); activation enum.
- MUD carrier unchanged (policy_based null → only the mitigation ref, byte-identical to CH-1).
  `rule_list` deferred to CH-3.

## Verification

- `terraform test`: **360/360** (challenge suite 13/13; MUD suites regression green).
- Live matrix (`scripts/challenge_pairs.py` + `challenge-matrix.sh`), new variants:
  `pbc-custom-js`, `pbc-custom-captcha-temp`, `pbc-all-default` — each applies, is idempotent,
  and whole-LB `state rm`+`import`+re-plan is **0-change**; canonical restored (LB 0-change).
- Server-echoed `default_*` markers round-trip cleanly → **no provider change needed**.

Closes #131