### PR TITLE
CH-4: challenge behavioral verify + traffic-gen (interstitial served)

### DIFF
--- a/scripts/challenge-verify.sh
+++ b/scripts/challenge-verify.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Challenge behavioral verification (CH-4).
+#
+# Closed-loop check that the F5 XC LB actually SERVES a JavaScript/CAPTCHA challenge interstitial
+# for challenged traffic (not just that the config applied). Unlike the API-protection verify
+# (which reads the security-events data plane), a challenge is served INLINE in the HTTP response,
+# so the assertion must fetch the LB from a client that can reach it. The LB is only reachable from
+# the deployed traffic-generator VM, so this drives the fetch there via `az vm run-command`
+# (matching the SP5 pattern) and asserts the XC challenge interstitial signature.
+#
+# Two steps:
+#   1. Control plane (reachable anywhere): confirm an ALL-TRAFFIC challenge is active on the LB
+#      (js_challenge / captcha_challenge, or policy_based_challenge always_enable_*). A risk-based
+#      enable_challenge / policy_based rule_list is NOT asserted here — those are conditioned on
+#      malicious-user scoring and do not challenge an anonymous request.
+#   2. Data path (from the VM): fetch the target over HTTP and assert the interstitial —
+#      HTTP 200 whose body carries the XC JS challenge (a `function SHA1` proof-of-work + the
+#      word "challenge") and is NOT the origin home page. A CAPTCHA challenge asserts the CAPTCHA
+#      markers instead.
+#
+# Read-only against both planes (no config change). Env: XCSH_API_URL, XCSH_API_TOKEN, and Azure
+# CLI logged in for run-command. Usage: challenge-verify.sh
+set -uo pipefail
+
+: "${XCSH_API_URL:?XCSH_API_URL must be set}"
+: "${XCSH_API_TOKEN:?XCSH_API_TOKEN must be set}"
+NS="${NS:-webapp-api-protection}"
+LB="${LB:-webapp-api-protection}"
+TARGET="${TARGET:-http://www.f5-sales-demo.com/}"
+VM_NAME="${VM_NAME:-vm-traffic-generator-rmordasiewicz}"
+VM_RG="${VM_RG:-rg-traffic-generator-webapp-api-protection-rmordasiewicz}"
+base="${XCSH_API_URL%/}"
+auth=(-H "Authorization: APIToken ${XCSH_API_TOKEN}")
+
+echo "== 1) Is an all-traffic challenge active on the LB? =="
+cfg=$(curl -s "${auth[@]}" "${base}/api/config/namespaces/${NS}/http_loadbalancers/${LB}?response_format=GET_RSP_FORMAT_DEFAULT")
+active=$(printf '%s' "$cfg" | python3 -c '
+import sys, json
+s = (json.load(sys.stdin) or {}).get("spec", {})
+if s.get("js_challenge") is not None: print("js"); sys.exit(0)
+if s.get("captcha_challenge") is not None: print("captcha"); sys.exit(0)
+pbc = s.get("policy_based_challenge") or {}
+if pbc.get("always_enable_js_challenge") is not None: print("js"); sys.exit(0)
+if pbc.get("always_enable_captcha_challenge") is not None: print("captcha"); sys.exit(0)
+print("none"); sys.exit(1)
+') || {
+  echo "  => no all-traffic challenge active (js/captcha/always_enable). Enable one before verifying;"
+  echo "     risk-based enable_challenge / rule_list challenges are not served to anonymous requests."
+  exit 2
+}
+echo "  active challenge: ${active}"
+
+echo "== 2) Fetch the target from the traffic-generator VM and assert the interstitial =="
+remote=$(
+  cat <<REMOTE
+code=\$(curl -s -m 15 -o /tmp/chv -w '%{http_code}' -A 'challenge-verify' '${TARGET}')
+bytes=\$(wc -c </tmp/chv)
+echo "HTTP \${code} \${bytes} bytes"
+if [ "${active}" = "captcha" ]; then
+  grep -qiE 'captcha|recaptcha|g-recaptcha' /tmp/chv && echo "CHALLENGE_OK captcha" || echo "CHALLENGE_MISSING"
+else
+  { grep -qi 'function SHA1' /tmp/chv && grep -qi 'challenge' /tmp/chv; } && echo "CHALLENGE_OK js" || echo "CHALLENGE_MISSING"
+fi
+REMOTE
+)
+msg=$(az vm run-command invoke --name "${VM_NAME}" --resource-group "${VM_RG}" \
+  --command-id RunShellScript --scripts "${remote}" --query "value[0].message" -o tsv 2>&1)
+echo "${msg}" | grep -E 'HTTP |CHALLENGE_'
+if printf '%s' "${msg}" | grep -q "CHALLENGE_OK"; then
+  echo "PASS: LB served the ${active} challenge interstitial."
+  exit 0
+fi
+echo "FAIL: challenge active on config but no interstitial served (dataplane lag? check propagation)."
+exit 1

--- a/terraform/modules/http-lb/variables_challenge.tf
+++ b/terraform/modules/http-lb/variables_challenge.tf
@@ -66,6 +66,12 @@ variable "challenge" {
     condition     = var.challenge.policy_based == null || var.challenge.mode == "policy_based"
     error_message = "challenge.policy_based params require challenge.mode = policy_based."
   }
+  # CH-4 (live-discovered): the top-level js/captcha arms require cookie_expiry >= 1 (F5 XC
+  # uint32 gte) — a bare mode=js/captcha without it is rejected 400 by the API at apply.
+  validation {
+    condition     = !contains(["js", "captcha"], coalesce(var.challenge.mode, "none")) || (var.challenge.cookie_expiry != null && var.challenge.cookie_expiry >= 1)
+    error_message = "challenge.cookie_expiry (>= 1) is required for mode js or captcha."
+  }
   validation {
     condition     = try(var.challenge.policy_based.activation, "default") == null ? true : contains(["default", "no_challenge", "always_js", "always_captcha"], try(var.challenge.policy_based.activation, "default"))
     error_message = "challenge.policy_based.activation must be default, no_challenge, always_js, or always_captcha."

--- a/terraform/tests/challenge.tftest.hcl
+++ b/terraform/tests/challenge.tftest.hcl
@@ -253,6 +253,14 @@ run "bad_mode_rejected" {
   expect_failures = [var.challenge]
 }
 
+run "js_requires_cookie_expiry" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  # CH-4: mode=js without cookie_expiry is rejected by the API (uint32 gte 1) — caught at plan.
+  variables { challenge = { mode = "js", js_script_delay = 2000 } }
+  expect_failures = [var.challenge]
+}
+
 run "attach_requires_carrier_arm" {
   command = plan
   module { source = "./modules/http-lb" }


### PR DESCRIPTION
## Summary

Final challenge slice — behavioral proof that the LB actually **serves a challenge interstitial**,
plus a live-discovered validation gap fix.

## Changes

- `scripts/challenge-verify.sh`: (1) confirms an all-traffic challenge is active on the LB config
  (control plane, reachable anywhere); (2) fetches the target from the traffic-generator VM via
  `az vm run-command` — the LB is HTTP-only and only reachable from there — and asserts the XC
  JS-challenge interstitial (`function SHA1` proof-of-work + `"challenge"`, HTTP 200) or CAPTCHA
  markers. Risk-based `enable_challenge` / `rule_list` challenges are intentionally not asserted
  (conditioned on malicious-user scoring, not served to anonymous requests).
- Validation: `mode` js/captcha require `cookie_expiry >= 1` (F5 XC uint32 gte) — live-discovered;
  a bare `mode=js`/`captcha` 400s at apply otherwise.
- Pairs with traffic-generator `suites/challenge-verify/` (PR #330).

## Verification (live, f5-sales-demo)

- `terraform test`: **365/365** (challenge suite 18/18, incl. `js_requires_cookie_expiry`).
- Closed loop: `apply js_challenge` → `challenge-verify.sh` drove the VM → `GET /` returned
  **HTTP 200 / 4368 bytes** carrying the SHA1 challenge routine (`CHALLENGE_OK js`, PASS) →
  canonical restored (plan **0-change**).

Closes #141