### PR TITLE
DDoS-1: cover l7_ddos_protection (rps + clientside_action)

### DIFF
--- a/scripts/ddos-matrix.sh
+++ b/scripts/ddos-matrix.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# LB l7_ddos_protection (DDoS-1) live coverage-matrix harness.
+#
+# Cycles the LIVE webapp-api-protection LB through the ddos_pairs variant set and verifies
+# each variant (a) applies, (b) is idempotent (immediate plan = No changes), and (c) is
+# round-trip-import clean for the whole LB (state rm -> import -> plan clean). The challenge_type
+# is an LB-nested oneof, so the import target is the http_loadbalancer itself. Ends on
+# canonical-restore (challenge unset + MUD on -> the LB's normal enable+attach state). Results
+# append to reports/ddos-matrix.txt.
+#
+# js/captcha challenge ALL traffic transiently; canonical-restore returns the LB to the MUD
+# default so www/api serve normally afterward. Sequential — no concurrent terraform against the
+# shared azurerm state.
+#
+# Usage: challenge-matrix.sh [START [END]]  (inclusive 0-based index range).
+set -uo pipefail
+
+umask 077
+trap 'rm -rf /tmp/ddos-variants 2>/dev/null; rm -f /tmp/ddos-*.log 2>/dev/null' EXIT
+
+cd "$(dirname "$0")/../terraform" || exit 1
+ARM_ACCESS_KEY=$(az storage account keys list -n f5salesdemotfstate -g f5-sales-demo-tfstate --query "[0].value" -o tsv)
+export ARM_ACCESS_KEY
+
+NS="webapp-api-protection"
+LB_ADDR="module.http_lb.xcsh_http_loadbalancer.this"
+LB_ID="${NS}/${NS}"
+COMMON=(-input=false -lock=true
+  -var 'lb_domains=["www.f5-sales-demo.com","api.f5-sales-demo.com"]'
+  -var 'subscription_id=75f86c46-9cbc-4f6c-85ea-195e3d3c8ac0')
+VARDIR=/tmp/ddos-variants
+REPORT=../reports/ddos-matrix.txt
+mkdir -p ../reports
+
+START="${1:-0}"
+END="${2:-9999}"
+
+[ "$#" -eq 0 ] && : >"$REPORT"
+
+count=$(python3 ../scripts/ddos_pairs.py --emit "$VARDIR")
+echo "generated $count variants into $VARDIR (running [$START..$END])"
+
+round_trip() {
+  local label="$1" vf="$2"
+  terraform state rm "$LB_ADDR" >/dev/null 2>&1 || {
+    echo "FAIL $label lb-state-rm" >>"$REPORT"
+    return
+  }
+  terraform import "${COMMON[@]}" -var-file="$vf" "$LB_ADDR" "$LB_ID" >/tmp/ddos-import.log 2>&1 || {
+    echo "FAIL $label lb-import ($(grep -iE 'error' /tmp/ddos-import.log | head -1 | cut -c1-70))" >>"$REPORT"
+    return
+  }
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$vf" >/tmp/ddos-rt-plan.log 2>&1
+  case $? in
+  0) echo "PASS $label" >>"$REPORT" ;;
+  2) echo "FAIL $label import-drift" >>"$REPORT" ;;
+  *) echo "FAIL $label rt-plan-error" >>"$REPORT" ;;
+  esac
+}
+
+while read -r idx name vf _flag; do
+  [ "$idx" -lt "$START" ] && continue
+  [ "$idx" -gt "$END" ] && continue
+  label="$idx-$name"
+  echo "--- $label ---"
+  varfile="${VARDIR}/${vf}"
+  if ! terraform apply -auto-approve "${COMMON[@]}" -var-file="$varfile" >/tmp/ddos-apply.log 2>&1; then
+    echo "FAIL $label apply ($(grep -iE 'error' /tmp/ddos-apply.log | head -1 | cut -c1-80))" >>"$REPORT"
+    continue
+  fi
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$varfile" >/tmp/ddos-plan.log 2>&1
+  case $? in
+  0) round_trip "$label" "$varfile" ;;
+  2) echo "FAIL $label not-idempotent" >>"$REPORT" ;;
+  *) echo "FAIL $label plan-error" >>"$REPORT" ;;
+  esac
+done <"${VARDIR}/manifest.txt"
+
+echo "===== DDOS MATRIX RESULTS ($START..$END) ====="
+cat "$REPORT"
+echo "PASS=$(grep -c '^PASS ' "$REPORT") FAIL=$(grep -c '^FAIL ' "$REPORT") SKIP=$(grep -c '^SKIP ' "$REPORT")"

--- a/scripts/ddos_pairs.py
+++ b/scripts/ddos_pairs.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Generate the L7 DDoS protection (DDoS-1) coverage matrix.
+
+Cycles the LIVE LB through the l7_ddos_protection oneofs — rps (custom vs default),
+clientside_action (none/js/captcha), ddos_policy (none/block) — each applied additively (MUD
+stays at its default, so the LB keeps serving). Ends on canonical-restore (ddos disabled ->
+l7_ddos_protection omitted -> server default, import-suppressed). Deterministic (no RNG).
+Output: JSON to stdout, or files via --emit.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+def build() -> list[dict[str, object]]:
+    """Ordered variant manifest: l7_ddos_protection oneof combinations + canonical."""
+    return [
+        {
+            "name": "custom-rps-js",
+            "vars": {
+                "ddos": {
+                    "l7_enabled": True,
+                    "rps_threshold": 2500,
+                    "clientside_action": "js",
+                    "cs_cookie_expiry": 3600,
+                    "cs_js_script_delay": 2000,
+                }
+            },
+        },
+        {
+            "name": "default-rps-captcha",
+            "vars": {
+                "ddos": {
+                    "l7_enabled": True,
+                    "clientside_action": "captcha",
+                    "cs_cookie_expiry": 7200,
+                }
+            },
+        },
+        {
+            "name": "all-default",
+            "vars": {"ddos": {"l7_enabled": True}},
+        },
+        {
+            "name": "canonical-restore",
+            "vars": {"ddos": {"l7_enabled": False}},
+        },
+    ]
+
+
+def emit(directory: str) -> int:
+    """Write one <NNN>-<name>.tfvars.json per variant plus manifest.txt (all LIVE)."""
+    out_dir = Path(directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for existing in out_dir.iterdir():
+        if existing.name.endswith(".tfvars.json") or existing.name == "manifest.txt":
+            existing.unlink()
+    variants = build()
+    named = [(f"{i:03d}-{v['name']}.tfvars.json", v) for i, v in enumerate(variants)]
+    for fname, v in named:
+        (out_dir / fname).write_text(json.dumps(v["vars"], indent=2) + "\n")
+    lines = [f"{i:03d} {v['name']} {fname} LIVE" for i, (fname, v) in enumerate(named)]
+    (out_dir / "manifest.txt").write_text("\n".join(lines) + "\n")
+    return len(variants)
+
+
+def main(argv: list[str]) -> None:
+    """CLI: --count, --emit <dir>, else JSON to stdout."""
+    match argv[1:]:
+        case ["--count"]:
+            sys.stdout.write(f"{len(build())}\n")
+        case ["--emit", directory]:
+            sys.stdout.write(f"{emit(directory)}\n")
+        case _:
+            json.dump(build(), sys.stdout, indent=2)
+            sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -113,6 +113,7 @@ module "http_lb" {
   mud_user_id_rule                = var.mud_user_id_rule
   mud_mitigation                  = var.mud_mitigation
   challenge                       = var.challenge
+  ddos                            = var.ddos
 
   # API Discovery & Crawler (SP1) passthrough. Defaults keep enable_api_discovery {}
   # bare (0-change). The api-discovery matrix cycles the non-default arms.

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -2592,6 +2592,33 @@ resource "xcsh_http_loadbalancer" "this" {
     }
   }
 
+  # DDoS-1: L7 DDoS protection. Emitted only when ddos.l7_enabled; the module emits ONLY the
+  # non-default arms — the server materializes the default markers (default_rps_threshold,
+  # clientside_action_none, mitigation_block, ddos_policy_none), all import-suppressed (provider
+  # #1155). rps_threshold null omits the attribute (server default). clientside_action none omits
+  # all arms (server clientside_action_none).
+  dynamic "l7_ddos_protection" {
+    for_each = var.ddos.l7_enabled ? [1] : []
+    content {
+      rps_threshold = var.ddos.rps_threshold
+      dynamic "clientside_action_js_challenge" {
+        for_each = var.ddos.clientside_action == "js" ? [1] : []
+        content {
+          cookie_expiry   = var.ddos.cs_cookie_expiry
+          custom_page     = var.ddos.cs_custom_page
+          js_script_delay = var.ddos.cs_js_script_delay
+        }
+      }
+      dynamic "clientside_action_captcha_challenge" {
+        for_each = var.ddos.clientside_action == "captcha" ? [1] : []
+        content {
+          cookie_expiry = var.ddos.cs_cookie_expiry
+          custom_page   = var.ddos.cs_custom_page
+        }
+      }
+    }
+  }
+
   # Fail fast at plan if a crawler domain is configured without a usable password
   # value — a cross-variable check the api_crawler_password variable validation cannot
   # express (clear needs plaintext; blindfold needs location).

--- a/terraform/modules/http-lb/variables_ddos.tf
+++ b/terraform/modules/http-lb/variables_ddos.tf
@@ -1,0 +1,32 @@
+# DDoS-1: L7 DDoS protection (l7_ddos_protection). Emitted only when ddos.l7_enabled = true
+# (the whole block is a server-default otherwise, import-suppressed). The module emits ONLY the
+# non-default arms; the server materializes the default markers (default_rps_threshold,
+# clientside_action_none, mitigation_block, ddos_policy_none — all import-suppressed via provider
+# >= v3.72.15 / #1155), so a minimal config round-trips 0-change:
+#   rps               -> rps_threshold (custom int), else omit (server default_rps_threshold)
+#   clientside_action -> js -> clientside_action_js_challenge, captcha -> _captcha_challenge,
+#                        none (default) -> omit (server clientside_action_none)
+# A live probe showed mitigation_block {} and ddos_policy_none {} are ALWAYS materialized together
+# regardless of input — they are not a user oneof, so no ddos_policy selector is exposed.
+# (ddos_policy_custom, a ref to an external xcsh_ddos_policy, is a later slice — no such object here.)
+variable "ddos" {
+  description = "L7 DDoS protection config. l7_enabled emits l7_ddos_protection; rps_threshold null uses the server default; clientside_action = none|js|captcha."
+  type = object({
+    l7_enabled         = optional(bool, false)
+    rps_threshold      = optional(number)
+    clientside_action  = optional(string, "none")
+    cs_cookie_expiry   = optional(number)
+    cs_custom_page     = optional(string)
+    cs_js_script_delay = optional(number)
+  })
+  default = {}
+
+  validation {
+    condition     = contains(["none", "js", "captcha"], var.ddos.clientside_action)
+    error_message = "ddos.clientside_action must be none, js, or captcha."
+  }
+  validation {
+    condition     = var.ddos.rps_threshold == null || var.ddos.rps_threshold >= 1
+    error_message = "ddos.rps_threshold must be >= 1 when set."
+  }
+}

--- a/terraform/modules/http-lb/versions.tf
+++ b/terraform/modules/http-lb/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     xcsh = {
       source  = "f5-sales-demo/xcsh"
-      version = ">= 3.72.11"
+      version = ">= 3.72.15"
     }
   }
 }

--- a/terraform/tests/ddos.tftest.hcl
+++ b/terraform/tests/ddos.tftest.hcl
@@ -1,0 +1,99 @@
+# Plan-level tests for DDoS-1: l7_ddos_protection. The module emits only non-default arms
+# (custom rps_threshold, js/captcha clientside_action); the server materializes the default
+# markers (default_rps_threshold / clientside_action_none / mitigation_block / ddos_policy_none),
+# import-suppressed by the provider (#1155). command = plan, targets ./modules/http-lb.
+variables {
+  namespace         = "webapp-api-protection"
+  lb_domains        = ["www.f5-sales-demo.com"]
+  origin_ip         = "203.0.113.10"
+  origin_port       = 80
+  health_check_path = "/health"
+  labels            = {}
+  csd_enabled       = false
+  mud_enabled       = false
+}
+
+run "omitted_by_default" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.l7_ddos_protection == null
+    error_message = "l7_ddos_protection must be omitted unless ddos.l7_enabled"
+  }
+}
+
+run "custom_rps_js_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    ddos = {
+      l7_enabled         = true
+      rps_threshold      = 2500
+      clientside_action  = "js"
+      cs_cookie_expiry   = 3600
+      cs_js_script_delay = 2000
+    }
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.l7_ddos_protection.rps_threshold == 2500
+    error_message = "custom rps_threshold must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.l7_ddos_protection.clientside_action_js_challenge.js_script_delay == 2000
+    error_message = "clientside_action_js_challenge must render for js"
+  }
+  # default markers are NOT emitted by the module (server materializes + provider suppresses them)
+  assert {
+    condition     = xcsh_http_loadbalancer.this.l7_ddos_protection.clientside_action_captcha_challenge == null
+    error_message = "captcha arm must be absent for clientside_action=js"
+  }
+}
+
+run "captcha_default_rps_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    ddos = {
+      l7_enabled        = true
+      clientside_action = "captcha"
+      cs_cookie_expiry  = 7200
+    }
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.l7_ddos_protection.clientside_action_captcha_challenge.cookie_expiry == 7200
+    error_message = "clientside_action_captcha_challenge must render for captcha"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.l7_ddos_protection.rps_threshold == null
+    error_message = "rps_threshold must be null (server default) when unset"
+  }
+}
+
+run "enabled_minimal_renders_block" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { ddos = { l7_enabled = true } }
+  # minimal: block present, no custom arms (server applies all defaults)
+  assert {
+    condition     = xcsh_http_loadbalancer.this.l7_ddos_protection != null
+    error_message = "l7_ddos_protection must render when l7_enabled"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.l7_ddos_protection.clientside_action_js_challenge == null && xcsh_http_loadbalancer.this.l7_ddos_protection.rps_threshold == null
+    error_message = "minimal l7_ddos_protection must emit no custom arm"
+  }
+}
+
+run "bad_clientside_action_rejected" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { ddos = { l7_enabled = true, clientside_action = "block" } }
+  expect_failures = [var.ddos]
+}
+
+run "bad_rps_threshold_rejected" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { ddos = { l7_enabled = true, rps_threshold = 0 } }
+  expect_failures = [var.ddos]
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -114,6 +114,19 @@ variable "challenge" {
   default = {}
 }
 
+variable "ddos" {
+  description = "L7 DDoS protection config (l7_ddos_protection). See module ./modules/http-lb variables_ddos.tf."
+  type = object({
+    l7_enabled         = optional(bool, false)
+    rps_threshold      = optional(number)
+    clientside_action  = optional(string, "none")
+    cs_cookie_expiry   = optional(number)
+    cs_custom_page     = optional(string)
+    cs_js_script_delay = optional(number)
+  })
+  default = {}
+}
+
 variable "mud_bad_traffic" {
   description = "Have the traffic generator emit identifiable malicious-user traffic (WAF-triggering payloads, forbidden-path scanning, failed logins) so MUD flags a user and applies mitigation. Only takes effect when mud_enabled. Off by default to keep the baseline demo benign."
   type        = bool

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -62,7 +62,11 @@ terraform {
       # >= 3.72.11: root-only import suppression (provider #1145) — disable_waf is suppressed only
       # at the LB root, so a route-level advanced_options.disable_waf {} (waf_mode=disable) reads
       # back and round-trips instead of being stripped on import. Re-enables CR-3's dropped arm.
-      version = ">= 3.72.11"
+      # >= 3.72.15: l7_ddos_protection nested server-default markers (provider #1155) — the server
+      # materializes mitigation_block / default_rps_threshold / clientside_action_none /
+      # ddos_policy_none for any l7_ddos_protection config, so a DDoS-1 config that omits them
+      # round-trips 0-change on import.
+      version = ">= 3.72.15"
     }
     # Azure providers: this plan also deploys its OWN Azure origin server and
     # traffic generator (modules/origin-server, modules/traffic-generator), which


### PR DESCRIPTION
## Summary

First DDoS slice — a `ddos` variable driving `l7_ddos_protection` (rps_threshold + clientside_action).

## Changes

- `ddos` var: `l7_enabled`, `rps_threshold` (custom; null → server default), `clientside_action`
  = none|js|captcha (+ cs_cookie_expiry/cs_custom_page/cs_js_script_delay).
- Module emits ONLY non-default arms. A live PUT+GET probe found the server **always** materializes
  `mitigation_block` / `default_rps_threshold` / `clientside_action_none` / `ddos_policy_none` for
  any config (mitigation_block + ddos_policy_none are not a user oneof) → import-suppressed by
  provider **v3.72.15** (#1155); pin bumped. `ddos_policy_custom` (external ref) deferred.

## Verification (live, f5-sales-demo, v3.72.15)

- `terraform test`: **371/371** (ddos suite 6/6).
- Live matrix (`scripts/ddos_pairs.py` + `ddos-matrix.sh`) **4/4 PASS**: custom-rps-js,
  default-rps-captcha, all-default, canonical-restore — apply → idempotent → whole-LB import
  **0-change**; canonical restored. (Pre-fix, all enabled variants drifted; v3.72.15 resolves it.)

Closes #143