### PR TITLE
DDoS-3: cover ddos_mitigation_rules[] (block by country/asn/ip/tls/ja4)

### DIFF
--- a/scripts/ddos_pairs.py
+++ b/scripts/ddos_pairs.py
@@ -60,7 +60,11 @@ def build() -> list[dict[str, object]]:
                             "ip_prefixes": ["198.51.100.0/24"],
                             "ip_invert": False,
                         },
-                        {"name": "block-tls", "source": "tls", "tls_classes": ["TRICKBOT"]},
+                        {
+                            "name": "block-tls",
+                            "source": "tls",
+                            "tls_classes": ["TRICKBOT"],
+                        },
                     ]
                 }
             },

--- a/scripts/ddos_pairs.py
+++ b/scripts/ddos_pairs.py
@@ -43,6 +43,29 @@ def build() -> list[dict[str, object]]:
             "vars": {"ddos": {"l7_enabled": True}},
         },
         {
+            # DDoS-3: manual block rules, one per ddos_client_source arm (country/asn/ip/tls).
+            "name": "mitigation-rules",
+            "vars": {
+                "ddos": {
+                    "mitigation_rules": [
+                        {
+                            "name": "block-cn",
+                            "source": "country",
+                            "countries": ["COUNTRY_CN", "COUNTRY_RU"],
+                        },
+                        {"name": "block-asn", "source": "asn", "as_numbers": [64512]},
+                        {
+                            "name": "block-ip",
+                            "source": "ip",
+                            "ip_prefixes": ["198.51.100.0/24"],
+                            "ip_invert": False,
+                        },
+                        {"name": "block-tls", "source": "tls", "tls_classes": ["TRICKBOT"]},
+                    ]
+                }
+            },
+        },
+        {
             "name": "canonical-restore",
             "vars": {"ddos": {"l7_enabled": False}},
         },

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -2619,6 +2619,54 @@ resource "xcsh_http_loadbalancer" "this" {
     }
   }
 
+  # DDoS-3: manual L7 DDoS block rules. Each rule = metadata{name} + block{} + a source matcher
+  # selected by rule.source: country/asn/tls/ja4 use the ddos_client_source block; ip uses the
+  # rule-level ip_prefix_list block (a sibling of ddos_client_source, not nested in it).
+  dynamic "ddos_mitigation_rules" {
+    for_each = var.ddos.mitigation_rules
+    content {
+      expiration_timestamp = ddos_mitigation_rules.value.expiration_timestamp
+      metadata {
+        name = ddos_mitigation_rules.value.name
+      }
+      block {}
+      dynamic "ddos_client_source" {
+        for_each = ddos_mitigation_rules.value.source != "ip" ? [1] : []
+        content {
+          # null-when-empty on every list: the API returns unset list matchers as absent, so an
+          # emitted empty list ([]) drifts on import (+ exact_values = []).
+          country_list = ddos_mitigation_rules.value.source == "country" && length(ddos_mitigation_rules.value.countries) > 0 ? ddos_mitigation_rules.value.countries : null
+          dynamic "asn_list" {
+            for_each = ddos_mitigation_rules.value.source == "asn" ? [1] : []
+            content {
+              as_numbers = length(ddos_mitigation_rules.value.as_numbers) > 0 ? ddos_mitigation_rules.value.as_numbers : null
+            }
+          }
+          dynamic "tls_fingerprint_matcher" {
+            for_each = ddos_mitigation_rules.value.source == "tls" ? [1] : []
+            content {
+              classes      = length(ddos_mitigation_rules.value.tls_classes) > 0 ? ddos_mitigation_rules.value.tls_classes : null
+              exact_values = length(ddos_mitigation_rules.value.tls_exact) > 0 ? ddos_mitigation_rules.value.tls_exact : null
+            }
+          }
+          dynamic "ja4_tls_fingerprint_matcher" {
+            for_each = ddos_mitigation_rules.value.source == "ja4" ? [1] : []
+            content {
+              exact_values = length(ddos_mitigation_rules.value.ja4_exact) > 0 ? ddos_mitigation_rules.value.ja4_exact : null
+            }
+          }
+        }
+      }
+      dynamic "ip_prefix_list" {
+        for_each = ddos_mitigation_rules.value.source == "ip" ? [1] : []
+        content {
+          ip_prefixes  = length(ddos_mitigation_rules.value.ip_prefixes) > 0 ? ddos_mitigation_rules.value.ip_prefixes : null
+          invert_match = ddos_mitigation_rules.value.ip_invert
+        }
+      }
+    }
+  }
+
   # Fail fast at plan if a crawler domain is configured without a usable password
   # value — a cross-variable check the api_crawler_password variable validation cannot
   # express (clear needs plaintext; blindfold needs location).

--- a/terraform/modules/http-lb/variables_ddos.tf
+++ b/terraform/modules/http-lb/variables_ddos.tf
@@ -18,6 +18,20 @@ variable "ddos" {
     cs_cookie_expiry   = optional(number)
     cs_custom_page     = optional(string)
     cs_js_script_delay = optional(number)
+    # DDoS-3: manual L7 DDoS block rules. Each rule blocks a client source (the ddos_client_source
+    # oneof selected by `source`): country | asn | ip | tls | ja4.
+    mitigation_rules = optional(list(object({
+      name                 = string
+      source               = optional(string, "country") # country | asn | ip | tls | ja4
+      countries            = optional(list(string), [])
+      as_numbers           = optional(list(number), [])
+      ip_prefixes          = optional(list(string), [])
+      ip_invert            = optional(bool, false)
+      tls_classes          = optional(list(string), [])
+      tls_exact            = optional(list(string), [])
+      ja4_exact            = optional(list(string), [])
+      expiration_timestamp = optional(string)
+    })), [])
   })
   default = {}
 
@@ -28,5 +42,9 @@ variable "ddos" {
   validation {
     condition     = var.ddos.rps_threshold == null || var.ddos.rps_threshold >= 1
     error_message = "ddos.rps_threshold must be >= 1 when set."
+  }
+  validation {
+    condition     = alltrue([for r in var.ddos.mitigation_rules : contains(["country", "asn", "ip", "tls", "ja4"], r.source)])
+    error_message = "ddos.mitigation_rules[].source must be country, asn, ip, tls, or ja4."
   }
 }

--- a/terraform/tests/ddos.tftest.hcl
+++ b/terraform/tests/ddos.tftest.hcl
@@ -84,6 +84,62 @@ run "enabled_minimal_renders_block" {
   }
 }
 
+run "mitigation_rules_source_arms_render" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    ddos = {
+      mitigation_rules = [
+        { name = "block-cn", source = "country", countries = ["COUNTRY_CN", "COUNTRY_RU"] },
+        { name = "block-asn", source = "asn", as_numbers = [64512, 64513] },
+        { name = "block-ip", source = "ip", ip_prefixes = ["203.0.113.0/24"], ip_invert = true },
+        { name = "block-tls", source = "tls", tls_classes = ["TRICKBOT"] },
+      ]
+    }
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.ddos_mitigation_rules[0].ddos_client_source.country_list[0] == "COUNTRY_CN"
+    error_message = "country source arm must render country_list"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.ddos_mitigation_rules[0].metadata.name == "block-cn"
+    error_message = "rule metadata.name must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.ddos_mitigation_rules[0].block != null
+    error_message = "block action must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.ddos_mitigation_rules[1].ddos_client_source.asn_list.as_numbers[0] == 64512
+    error_message = "asn source arm must render asn_list.as_numbers"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.ddos_mitigation_rules[2].ip_prefix_list.invert_match == true
+    error_message = "ip source arm must render rule-level ip_prefix_list.invert_match"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.ddos_mitigation_rules[3].ddos_client_source.tls_fingerprint_matcher.classes[0] == "TRICKBOT"
+    error_message = "tls source arm must render tls_fingerprint_matcher.classes"
+  }
+}
+
+run "mitigation_rules_omitted_by_default" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { ddos = {} }
+  assert {
+    condition     = length(xcsh_http_loadbalancer.this.ddos_mitigation_rules) == 0
+    error_message = "ddos_mitigation_rules must be empty by default"
+  }
+}
+
+run "bad_mitigation_source_rejected" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { ddos = { mitigation_rules = [{ name = "r", source = "user_agent" }] } }
+  expect_failures = [var.ddos]
+}
+
 run "bad_clientside_action_rejected" {
   command = plan
   module { source = "./modules/http-lb" }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -123,6 +123,18 @@ variable "ddos" {
     cs_cookie_expiry   = optional(number)
     cs_custom_page     = optional(string)
     cs_js_script_delay = optional(number)
+    mitigation_rules = optional(list(object({
+      name                 = string
+      source               = optional(string, "country")
+      countries            = optional(list(string), [])
+      as_numbers           = optional(list(number), [])
+      ip_prefixes          = optional(list(string), [])
+      ip_invert            = optional(bool, false)
+      tls_classes          = optional(list(string), [])
+      tls_exact            = optional(list(string), [])
+      ja4_exact            = optional(list(string), [])
+      expiration_timestamp = optional(string)
+    })), [])
   })
   default = {}
 }


### PR DESCRIPTION
## Summary

Adds `ddos.mitigation_rules[]` → LB `ddos_mitigation_rules[]` — manual L7 DDoS block rules.

## Changes

- Each rule = `metadata{name}` + `block{}` + a source matcher + optional `expiration_timestamp`.
  `rule.source`: country/asn/tls/ja4 → `ddos_client_source`; **ip → rule-level `ip_prefix_list`**
  (a sibling of `ddos_client_source` in the schema, not nested — verified against the generated
  schema + live GET).
- Every list matcher emitted **null-when-empty** (the API returns unset list matchers absent, so an
  emitted `[]` drifts on import — `+ exact_values = []`; fixed module-side).
- Live-probed feature support first (per the DDoS-2 lesson): country_list rule → 200, round-trips.

## Verification (live, f5-sales-demo, v3.72.15)

- `terraform test`: **374/374** (ddos suite 9/9).
- Live matrix `mitigation-rules` variant (country + asn + ip + tls arms): apply → idempotent →
  whole-LB import **0-change**; canonical restored. **No provider change needed.**

Note: DDoS-2 (`slow_ddos_mitigation`) was closed as unsupported on HTTP-proxy LBs (#145).

Closes #146