### PR TITLE
LBA: cover loadbalancer_algorithm oneof (least_active/random/source_ip/ring_hash)

### DIFF
--- a/scripts/lb-algorithm-matrix.sh
+++ b/scripts/lb-algorithm-matrix.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# LB loadbalancer_algorithm (LBA) live coverage-matrix harness.
+#
+# Cycles the LIVE webapp-api-protection LB through the lb_algorithm_pairs variant set and verifies
+# each variant (a) applies, (b) is idempotent (immediate plan = No changes), and (c) is
+# round-trip-import clean for the whole LB (state rm -> import -> plan clean). The challenge_type
+# is an LB-nested oneof, so the import target is the http_loadbalancer itself. Ends on
+# canonical-restore (challenge unset + MUD on -> the LB's normal enable+attach state). Results
+# append to reports/lb-algorithm-matrix.txt.
+#
+# js/captcha challenge ALL traffic transiently; canonical-restore returns the LB to the MUD
+# default so www/api serve normally afterward. Sequential — no concurrent terraform against the
+# shared azurerm state.
+#
+# Usage: challenge-matrix.sh [START [END]]  (inclusive 0-based index range).
+set -uo pipefail
+
+umask 077
+trap 'rm -rf /tmp/lba-variants 2>/dev/null; rm -f /tmp/lba-*.log 2>/dev/null' EXIT
+
+cd "$(dirname "$0")/../terraform" || exit 1
+ARM_ACCESS_KEY=$(az storage account keys list -n f5salesdemotfstate -g f5-sales-demo-tfstate --query "[0].value" -o tsv)
+export ARM_ACCESS_KEY
+
+NS="webapp-api-protection"
+LB_ADDR="module.http_lb.xcsh_http_loadbalancer.this"
+LB_ID="${NS}/${NS}"
+COMMON=(-input=false -lock=true
+  -var 'lb_domains=["www.f5-sales-demo.com","api.f5-sales-demo.com"]'
+  -var 'subscription_id=75f86c46-9cbc-4f6c-85ea-195e3d3c8ac0')
+VARDIR=/tmp/lba-variants
+REPORT=../reports/lb-algorithm-matrix.txt
+mkdir -p ../reports
+
+START="${1:-0}"
+END="${2:-9999}"
+
+[ "$#" -eq 0 ] && : >"$REPORT"
+
+count=$(python3 ../scripts/lb_algorithm_pairs.py --emit "$VARDIR")
+echo "generated $count variants into $VARDIR (running [$START..$END])"
+
+round_trip() {
+  local label="$1" vf="$2"
+  terraform state rm "$LB_ADDR" >/dev/null 2>&1 || {
+    echo "FAIL $label lb-state-rm" >>"$REPORT"
+    return
+  }
+  terraform import "${COMMON[@]}" -var-file="$vf" "$LB_ADDR" "$LB_ID" >/tmp/lba-import.log 2>&1 || {
+    echo "FAIL $label lb-import ($(grep -iE 'error' /tmp/lba-import.log | head -1 | cut -c1-70))" >>"$REPORT"
+    return
+  }
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$vf" >/tmp/lba-rt-plan.log 2>&1
+  case $? in
+  0) echo "PASS $label" >>"$REPORT" ;;
+  2) echo "FAIL $label import-drift" >>"$REPORT" ;;
+  *) echo "FAIL $label rt-plan-error" >>"$REPORT" ;;
+  esac
+}
+
+while read -r idx name vf _flag; do
+  [ "$idx" -lt "$START" ] && continue
+  [ "$idx" -gt "$END" ] && continue
+  label="$idx-$name"
+  echo "--- $label ---"
+  varfile="${VARDIR}/${vf}"
+  if ! terraform apply -auto-approve "${COMMON[@]}" -var-file="$varfile" >/tmp/lba-apply.log 2>&1; then
+    echo "FAIL $label apply ($(grep -iE 'error' /tmp/lba-apply.log | head -1 | cut -c1-80))" >>"$REPORT"
+    continue
+  fi
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$varfile" >/tmp/lba-plan.log 2>&1
+  case $? in
+  0) round_trip "$label" "$varfile" ;;
+  2) echo "FAIL $label not-idempotent" >>"$REPORT" ;;
+  *) echo "FAIL $label plan-error" >>"$REPORT" ;;
+  esac
+done <"${VARDIR}/manifest.txt"
+
+echo "===== LB ALGORITHM MATRIX RESULTS ($START..$END) ====="
+cat "$REPORT"
+echo "PASS=$(grep -c '^PASS ' "$REPORT") FAIL=$(grep -c '^FAIL ' "$REPORT") SKIP=$(grep -c '^SKIP ' "$REPORT")"

--- a/scripts/lb_algorithm_pairs.py
+++ b/scripts/lb_algorithm_pairs.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Generate the LB loadbalancer_algorithm (LBA) coverage matrix.
+
+Cycles the LIVE LB through each supported algorithm arm — least_active / random /
+source_ip_stickiness / ring_hash (with a hash_policy) — and ends on canonical-restore
+(round_robin, the server default). cookie_stickiness is excluded (tenant returns 500).
+Deterministic. Output: JSON to stdout, or files via --emit.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+def build() -> list[dict[str, object]]:
+    """Ordered variant manifest: each algorithm arm + canonical (round_robin)."""
+    return [
+        {"name": "least-active", "vars": {"lb_algorithm": {"mode": "least_active"}}},
+        {"name": "random", "vars": {"lb_algorithm": {"mode": "random"}}},
+        {
+            "name": "source-ip-stickiness",
+            "vars": {"lb_algorithm": {"mode": "source_ip_stickiness"}},
+        },
+        {
+            "name": "ring-hash",
+            "vars": {
+                "lb_algorithm": {
+                    "mode": "ring_hash",
+                    "ring_hash_policies": [{"source_ip": True, "terminal": True}],
+                }
+            },
+        },
+        {
+            "name": "canonical-restore",
+            "vars": {"lb_algorithm": {"mode": "round_robin"}},
+        },
+    ]
+
+
+def emit(directory: str) -> int:
+    """Write one <NNN>-<name>.tfvars.json per variant plus manifest.txt (all LIVE)."""
+    out_dir = Path(directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for existing in out_dir.iterdir():
+        if existing.name.endswith(".tfvars.json") or existing.name == "manifest.txt":
+            existing.unlink()
+    variants = build()
+    named = [(f"{i:03d}-{v['name']}.tfvars.json", v) for i, v in enumerate(variants)]
+    for fname, v in named:
+        (out_dir / fname).write_text(json.dumps(v["vars"], indent=2) + "\n")
+    lines = [f"{i:03d} {v['name']} {fname} LIVE" for i, (fname, v) in enumerate(named)]
+    (out_dir / "manifest.txt").write_text("\n".join(lines) + "\n")
+    return len(variants)
+
+
+def main(argv: list[str]) -> None:
+    """CLI: --count, --emit <dir>, else JSON to stdout."""
+    match argv[1:]:
+        case ["--count"]:
+            sys.stdout.write(f"{len(build())}\n")
+        case ["--emit", directory]:
+            sys.stdout.write(f"{emit(directory)}\n")
+        case _:
+            json.dump(build(), sys.stdout, indent=2)
+            sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -114,6 +114,7 @@ module "http_lb" {
   mud_mitigation                  = var.mud_mitigation
   challenge                       = var.challenge
   ddos                            = var.ddos
+  lb_algorithm                    = var.lb_algorithm
 
   # API Discovery & Crawler (SP1) passthrough. Defaults keep enable_api_discovery {}
   # bare (0-change). The api-discovery matrix cycles the non-default arms.

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -2667,6 +2667,34 @@ resource "xcsh_http_loadbalancer" "this" {
     }
   }
 
+  # LBA: load-balancing algorithm oneof. round_robin (default) is omitted (server materializes it,
+  # import-suppressed); the chosen non-default arm is emitted. cookie_stickiness excluded (500).
+  dynamic "least_active" {
+    for_each = var.lb_algorithm.mode == "least_active" ? [1] : []
+    content {}
+  }
+  dynamic "random" {
+    for_each = var.lb_algorithm.mode == "random" ? [1] : []
+    content {}
+  }
+  dynamic "source_ip_stickiness" {
+    for_each = var.lb_algorithm.mode == "source_ip_stickiness" ? [1] : []
+    content {}
+  }
+  dynamic "ring_hash" {
+    for_each = var.lb_algorithm.mode == "ring_hash" ? [1] : []
+    content {
+      dynamic "hash_policy" {
+        for_each = var.lb_algorithm.ring_hash_policies
+        content {
+          header_name = hash_policy.value.header_name
+          source_ip   = hash_policy.value.source_ip
+          terminal    = hash_policy.value.terminal
+        }
+      }
+    }
+  }
+
   # Fail fast at plan if a crawler domain is configured without a usable password
   # value — a cross-variable check the api_crawler_password variable validation cannot
   # express (clear needs plaintext; blindfold needs location).

--- a/terraform/modules/http-lb/variables_lb_algorithm.tf
+++ b/terraform/modules/http-lb/variables_lb_algorithm.tf
@@ -1,0 +1,25 @@
+# LBA: load-balancing algorithm (loadbalancer_algorithm oneof). round_robin is the server default
+# (omit -> materialized + import-suppressed). The other arms are emitted explicitly. ring_hash
+# carries a hash_policy list. cookie_stickiness is intentionally excluded: a live PUT probe returns
+# 500 ("server error in processing request") for every param shape on this tenant.
+variable "lb_algorithm" {
+  description = "LB load-balancing algorithm: round_robin (default) | least_active | random | source_ip_stickiness | ring_hash. ring_hash uses ring_hash_policies (header_name / source_ip / terminal)."
+  type = object({
+    mode = optional(string, "round_robin")
+    ring_hash_policies = optional(list(object({
+      header_name = optional(string)
+      source_ip   = optional(bool, false)
+      terminal    = optional(bool, false)
+    })), [])
+  })
+  default = {}
+
+  validation {
+    condition     = contains(["round_robin", "least_active", "random", "source_ip_stickiness", "ring_hash"], var.lb_algorithm.mode)
+    error_message = "lb_algorithm.mode must be round_robin, least_active, random, source_ip_stickiness, or ring_hash (cookie_stickiness is excluded — tenant returns 500)."
+  }
+  validation {
+    condition     = var.lb_algorithm.mode == "ring_hash" || length(var.lb_algorithm.ring_hash_policies) == 0
+    error_message = "lb_algorithm.ring_hash_policies is only valid when mode = ring_hash."
+  }
+}

--- a/terraform/tests/lb_algorithm.tftest.hcl
+++ b/terraform/tests/lb_algorithm.tftest.hcl
@@ -1,0 +1,87 @@
+# Plan-level tests for LBA: loadbalancer_algorithm oneof. round_robin (default) is omitted;
+# the chosen non-default arm is emitted. command = plan, targets ./modules/http-lb.
+variables {
+  namespace         = "webapp-api-protection"
+  lb_domains        = ["www.f5-sales-demo.com"]
+  origin_ip         = "203.0.113.10"
+  origin_port       = 80
+  health_check_path = "/health"
+  labels            = {}
+  csd_enabled       = false
+  mud_enabled       = false
+}
+
+run "round_robin_default_omits_arms" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.least_active == null && xcsh_http_loadbalancer.this.random == null && xcsh_http_loadbalancer.this.source_ip_stickiness == null && xcsh_http_loadbalancer.this.ring_hash == null
+    error_message = "round_robin default must emit no explicit algorithm arm (server default)"
+  }
+}
+
+run "least_active_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { lb_algorithm = { mode = "least_active" } }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.least_active != null
+    error_message = "least_active arm must render"
+  }
+}
+
+run "random_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { lb_algorithm = { mode = "random" } }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.random != null
+    error_message = "random arm must render"
+  }
+}
+
+run "source_ip_stickiness_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { lb_algorithm = { mode = "source_ip_stickiness" } }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.source_ip_stickiness != null
+    error_message = "source_ip_stickiness arm must render"
+  }
+}
+
+run "ring_hash_with_policies_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    lb_algorithm = {
+      mode = "ring_hash"
+      ring_hash_policies = [
+        { source_ip = true, terminal = true },
+        { header_name = "x-user" },
+      ]
+    }
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.ring_hash.hash_policy[0].source_ip == true
+    error_message = "ring_hash hash_policy source_ip must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.ring_hash.hash_policy[1].header_name == "x-user"
+    error_message = "ring_hash hash_policy header_name must render"
+  }
+}
+
+run "bad_mode_rejected" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { lb_algorithm = { mode = "cookie_stickiness" } }
+  expect_failures = [var.lb_algorithm]
+}
+
+run "ring_hash_policies_require_ring_hash_mode" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { lb_algorithm = { mode = "random", ring_hash_policies = [{ source_ip = true }] } }
+  expect_failures = [var.lb_algorithm]
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -139,6 +139,19 @@ variable "ddos" {
   default = {}
 }
 
+variable "lb_algorithm" {
+  description = "LB load-balancing algorithm (loadbalancer_algorithm oneof). See module ./modules/http-lb variables_lb_algorithm.tf."
+  type = object({
+    mode = optional(string, "round_robin")
+    ring_hash_policies = optional(list(object({
+      header_name = optional(string)
+      source_ip   = optional(bool, false)
+      terminal    = optional(bool, false)
+    })), [])
+  })
+  default = {}
+}
+
 variable "mud_bad_traffic" {
   description = "Have the traffic generator emit identifiable malicious-user traffic (WAF-triggering payloads, forbidden-path scanning, failed logins) so MUD flags a user and applies mitigation. Only takes effect when mud_enabled. Off by default to keep the baseline demo benign."
   type        = bool


### PR DESCRIPTION
## Summary

Adds a `lb_algorithm` variable covering the LB `loadbalancer_algorithm` oneof — how requests are
distributed across origins.

## Changes

- `lb_algorithm.mode`: `round_robin` (default; omitted → server default, import-suppressed) |
  `least_active` | `random` | `source_ip_stickiness` | `ring_hash` (with `ring_hash_policies`:
  header_name / source_ip / terminal).
- `cookie_stickiness` **excluded**: a live PUT probe returns `500` for every param shape on this
  tenant (documented, same class as other 500-gated features).

## Verification (live, f5-sales-demo, v3.72.15)

- `terraform test`: **381/381** (lb_algorithm suite 7/7).
- Live matrix (`scripts/lb_algorithm_pairs.py` + `lb-algorithm-matrix.sh`) **5/5 PASS**:
  least-active, random, source-ip-stickiness, ring-hash, canonical-restore — apply → idempotent →
  whole-LB import **0-change**; canonical restored. No provider change needed.

Closes #148