### PR TITLE
CSD: cover client_side_defense.policy (js_insert oneof + exclude_list)

### DIFF
--- a/scripts/csd-matrix.sh
+++ b/scripts/csd-matrix.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# LB client_side_defense policy (CSD) live coverage-matrix harness.
+#
+# Cycles the LIVE webapp-api-protection LB through the csd_pairs variant set and verifies
+# each variant (a) applies, (b) is idempotent (immediate plan = No changes), and (c) is
+# round-trip-import clean for the whole LB (state rm -> import -> plan clean). The challenge_type
+# is an LB-nested oneof, so the import target is the http_loadbalancer itself. Ends on
+# canonical-restore (challenge unset + MUD on -> the LB's normal enable+attach state). Results
+# append to reports/csd-matrix.txt.
+#
+# js/captcha challenge ALL traffic transiently; canonical-restore returns the LB to the MUD
+# default so www/api serve normally afterward. Sequential — no concurrent terraform against the
+# shared azurerm state.
+#
+# Usage: challenge-matrix.sh [START [END]]  (inclusive 0-based index range).
+set -uo pipefail
+
+umask 077
+trap 'rm -rf /tmp/csd-variants 2>/dev/null; rm -f /tmp/csd-*.log 2>/dev/null' EXIT
+
+cd "$(dirname "$0")/../terraform" || exit 1
+ARM_ACCESS_KEY=$(az storage account keys list -n f5salesdemotfstate -g f5-sales-demo-tfstate --query "[0].value" -o tsv)
+export ARM_ACCESS_KEY
+
+NS="webapp-api-protection"
+LB_ADDR="module.http_lb.xcsh_http_loadbalancer.this"
+LB_ID="${NS}/${NS}"
+COMMON=(-input=false -lock=true
+  -var 'lb_domains=["www.f5-sales-demo.com","api.f5-sales-demo.com"]'
+  -var 'subscription_id=75f86c46-9cbc-4f6c-85ea-195e3d3c8ac0')
+VARDIR=/tmp/csd-variants
+REPORT=../reports/csd-matrix.txt
+mkdir -p ../reports
+
+START="${1:-0}"
+END="${2:-9999}"
+
+[ "$#" -eq 0 ] && : >"$REPORT"
+
+count=$(python3 ../scripts/csd_pairs.py --emit "$VARDIR")
+echo "generated $count variants into $VARDIR (running [$START..$END])"
+
+round_trip() {
+  local label="$1" vf="$2"
+  terraform state rm "$LB_ADDR" >/dev/null 2>&1 || {
+    echo "FAIL $label lb-state-rm" >>"$REPORT"
+    return
+  }
+  terraform import "${COMMON[@]}" -var-file="$vf" "$LB_ADDR" "$LB_ID" >/tmp/csd-import.log 2>&1 || {
+    echo "FAIL $label lb-import ($(grep -iE 'error' /tmp/csd-import.log | head -1 | cut -c1-70))" >>"$REPORT"
+    return
+  }
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$vf" >/tmp/csd-rt-plan.log 2>&1
+  case $? in
+  0) echo "PASS $label" >>"$REPORT" ;;
+  2) echo "FAIL $label import-drift" >>"$REPORT" ;;
+  *) echo "FAIL $label rt-plan-error" >>"$REPORT" ;;
+  esac
+}
+
+while read -r idx name vf _flag; do
+  [ "$idx" -lt "$START" ] && continue
+  [ "$idx" -gt "$END" ] && continue
+  label="$idx-$name"
+  echo "--- $label ---"
+  varfile="${VARDIR}/${vf}"
+  if ! terraform apply -auto-approve "${COMMON[@]}" -var-file="$varfile" >/tmp/csd-apply.log 2>&1; then
+    echo "FAIL $label apply ($(grep -iE 'error' /tmp/csd-apply.log | head -1 | cut -c1-80))" >>"$REPORT"
+    continue
+  fi
+  terraform plan -detailed-exitcode "${COMMON[@]}" -var-file="$varfile" >/tmp/csd-plan.log 2>&1
+  case $? in
+  0) round_trip "$label" "$varfile" ;;
+  2) echo "FAIL $label not-idempotent" >>"$REPORT" ;;
+  *) echo "FAIL $label plan-error" >>"$REPORT" ;;
+  esac
+done <"${VARDIR}/manifest.txt"
+
+echo "===== CSD MATRIX RESULTS ($START..$END) ====="
+cat "$REPORT"
+echo "PASS=$(grep -c '^PASS ' "$REPORT") FAIL=$(grep -c '^FAIL ' "$REPORT") SKIP=$(grep -c '^SKIP ' "$REPORT")"

--- a/scripts/csd_pairs.py
+++ b/scripts/csd_pairs.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Generate the Client-Side Defense (CSD) policy coverage matrix.
+
+Cycles the LIVE LB through the client_side_defense.policy js_insert oneof — disabled
+(disable_js_insert) and all_except (js_insert_all_pages_except + exclude_list) — and ends on
+canonical-restore (all_pages, the default the merged baseline uses). csd_enabled stays true.
+Deterministic. Output: JSON to stdout, or files via --emit.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+def build() -> list[dict[str, object]]:
+    """Ordered variant manifest: js_insert arms + canonical (all_pages)."""
+    return [
+        {"name": "disabled", "vars": {"csd": {"js_insert": "disabled"}}},
+        {
+            "name": "all-except",
+            "vars": {
+                "csd": {
+                    "js_insert": "all_except",
+                    "exclude_list": [
+                        {
+                            "name": "skip-admin",
+                            "domain_mode": "suffix",
+                            "domain_value": "f5-sales-demo.com",
+                            "path_mode": "prefix",
+                            "path_value": "/admin",
+                        },
+                        {
+                            "name": "skip-health",
+                            "domain_mode": "any",
+                            "path_mode": "exact",
+                            "path_value": "/health",
+                        },
+                    ],
+                }
+            },
+        },
+        {"name": "canonical-restore", "vars": {"csd": {"js_insert": "all_pages"}}},
+    ]
+
+
+def emit(directory: str) -> int:
+    """Write one <NNN>-<name>.tfvars.json per variant plus manifest.txt (all LIVE)."""
+    out_dir = Path(directory)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for existing in out_dir.iterdir():
+        if existing.name.endswith(".tfvars.json") or existing.name == "manifest.txt":
+            existing.unlink()
+    variants = build()
+    named = [(f"{i:03d}-{v['name']}.tfvars.json", v) for i, v in enumerate(variants)]
+    for fname, v in named:
+        (out_dir / fname).write_text(json.dumps(v["vars"], indent=2) + "\n")
+    lines = [f"{i:03d} {v['name']} {fname} LIVE" for i, (fname, v) in enumerate(named)]
+    (out_dir / "manifest.txt").write_text("\n".join(lines) + "\n")
+    return len(variants)
+
+
+def main(argv: list[str]) -> None:
+    """CLI: --count, --emit <dir>, else JSON to stdout."""
+    match argv[1:]:
+        case ["--count"]:
+            sys.stdout.write(f"{len(build())}\n")
+        case ["--emit", directory]:
+            sys.stdout.write(f"{emit(directory)}\n")
+        case _:
+            json.dump(build(), sys.stdout, indent=2)
+            sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -115,6 +115,7 @@ module "http_lb" {
   challenge                       = var.challenge
   ddos                            = var.ddos
   lb_algorithm                    = var.lb_algorithm
+  csd                             = var.csd
 
   # API Discovery & Crawler (SP1) passthrough. Defaults keep enable_api_discovery {}
   # bare (0-change). The api-discovery matrix cycles the non-default arms.

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -2410,7 +2410,47 @@ resource "xcsh_http_loadbalancer" "this" {
     for_each = var.csd_enabled ? [1] : []
     content {
       policy {
-        js_insert_all_pages {}
+        # JS-insertion oneof: all_pages (default) | disabled | all_except (+ exclude_list).
+        dynamic "js_insert_all_pages" {
+          for_each = var.csd.js_insert == "all_pages" ? [1] : []
+          content {}
+        }
+        dynamic "disable_js_insert" {
+          for_each = var.csd.js_insert == "disabled" ? [1] : []
+          content {}
+        }
+        dynamic "js_insert_all_pages_except" {
+          for_each = var.csd.js_insert == "all_except" ? [1] : []
+          content {
+            dynamic "exclude_list" {
+              for_each = var.csd.exclude_list
+              content {
+                metadata {
+                  name = exclude_list.value.name
+                }
+                # domain matcher oneof.
+                dynamic "any_domain" {
+                  for_each = exclude_list.value.domain_mode == "any" ? [1] : []
+                  content {}
+                }
+                dynamic "domain" {
+                  for_each = exclude_list.value.domain_mode != "any" ? [1] : []
+                  content {
+                    exact_value  = exclude_list.value.domain_mode == "exact" ? exclude_list.value.domain_value : null
+                    regex_value  = exclude_list.value.domain_mode == "regex" ? exclude_list.value.domain_value : null
+                    suffix_value = exclude_list.value.domain_mode == "suffix" ? exclude_list.value.domain_value : null
+                  }
+                }
+                # path matcher oneof (required by the API).
+                path {
+                  path   = exclude_list.value.path_mode == "exact" ? exclude_list.value.path_value : null
+                  prefix = exclude_list.value.path_mode == "prefix" ? exclude_list.value.path_value : null
+                  regex  = exclude_list.value.path_mode == "regex" ? exclude_list.value.path_value : null
+                }
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/terraform/modules/http-lb/variables_csd.tf
+++ b/terraform/modules/http-lb/variables_csd.tf
@@ -1,0 +1,40 @@
+# CSD policy: the client_side_defense.policy JavaScript-insertion oneof (gated by csd_enabled).
+# js_insert = all_pages (default; the current behavior) | disabled (disable_js_insert) | all_except
+# (js_insert_all_pages_except + exclude_list). Each exclude_list entry (all_except only) needs a
+# name (metadata, required by the API), a domain matcher (any/exact/regex/suffix), and a path
+# matcher (exact/prefix/regex, required).
+variable "csd" {
+  description = "Client-Side Defense policy. js_insert = all_pages|disabled|all_except; exclude_list applies only to all_except."
+  type = object({
+    js_insert = optional(string, "all_pages")
+    exclude_list = optional(list(object({
+      name         = string
+      domain_mode  = optional(string, "any") # any | exact | regex | suffix
+      domain_value = optional(string)
+      path_mode    = optional(string, "prefix") # exact | prefix | regex
+      path_value   = string
+    })), [])
+  })
+  default = {}
+
+  validation {
+    condition     = contains(["all_pages", "disabled", "all_except"], var.csd.js_insert)
+    error_message = "csd.js_insert must be all_pages, disabled, or all_except."
+  }
+  validation {
+    condition     = var.csd.js_insert == "all_except" || length(var.csd.exclude_list) == 0
+    error_message = "csd.exclude_list is only valid when csd.js_insert = all_except."
+  }
+  validation {
+    condition     = alltrue([for e in var.csd.exclude_list : contains(["any", "exact", "regex", "suffix"], e.domain_mode)])
+    error_message = "csd.exclude_list[].domain_mode must be any, exact, regex, or suffix."
+  }
+  validation {
+    condition     = alltrue([for e in var.csd.exclude_list : contains(["exact", "prefix", "regex"], e.path_mode)])
+    error_message = "csd.exclude_list[].path_mode must be exact, prefix, or regex."
+  }
+  validation {
+    condition     = alltrue([for e in var.csd.exclude_list : e.domain_mode == "any" || e.domain_value != null])
+    error_message = "csd.exclude_list[].domain_value is required unless domain_mode = any."
+  }
+}

--- a/terraform/tests/csd.tftest.hcl
+++ b/terraform/tests/csd.tftest.hcl
@@ -1,0 +1,100 @@
+# Plan-level tests for CSD policy: client_side_defense.policy js_insert oneof + exclude_list.
+# command = plan, targets ./modules/http-lb. csd_enabled gates the block.
+variables {
+  namespace         = "webapp-api-protection"
+  lb_domains        = ["www.f5-sales-demo.com"]
+  origin_ip         = "203.0.113.10"
+  origin_port       = 80
+  health_check_path = "/health"
+  labels            = {}
+  csd_enabled       = true
+  mud_enabled       = false
+}
+
+run "all_pages_default_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.client_side_defense.policy.js_insert_all_pages != null
+    error_message = "default js_insert must be all_pages"
+  }
+}
+
+run "disabled_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { csd = { js_insert = "disabled" } }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.client_side_defense.policy.disable_js_insert != null
+    error_message = "js_insert=disabled must render disable_js_insert"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.client_side_defense.policy.js_insert_all_pages == null
+    error_message = "js_insert_all_pages must be absent when disabled"
+  }
+}
+
+run "all_except_exclude_list_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    csd = {
+      js_insert = "all_except"
+      exclude_list = [
+        { name = "skip-admin", domain_mode = "suffix", domain_value = "f5-sales-demo.com", path_mode = "prefix", path_value = "/admin" },
+        { name = "skip-health", domain_mode = "any", path_mode = "exact", path_value = "/health" },
+      ]
+    }
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.client_side_defense.policy.js_insert_all_pages_except.exclude_list[0].metadata.name == "skip-admin"
+    error_message = "exclude_list metadata.name must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.client_side_defense.policy.js_insert_all_pages_except.exclude_list[0].domain.suffix_value == "f5-sales-demo.com"
+    error_message = "exclude_list domain suffix_value must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.client_side_defense.policy.js_insert_all_pages_except.exclude_list[0].path.prefix == "/admin"
+    error_message = "exclude_list path prefix must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.client_side_defense.policy.js_insert_all_pages_except.exclude_list[1].any_domain != null
+    error_message = "exclude_list any_domain must render for domain_mode=any"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.client_side_defense.policy.js_insert_all_pages_except.exclude_list[1].path.path == "/health"
+    error_message = "exclude_list path exact must render on path.path"
+  }
+}
+
+run "csd_disabled_omits_block" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { csd_enabled = false }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.client_side_defense == null
+    error_message = "client_side_defense must be omitted when csd_enabled=false"
+  }
+}
+
+run "bad_js_insert_rejected" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { csd = { js_insert = "some_pages" } }
+  expect_failures = [var.csd]
+}
+
+run "exclude_list_requires_all_except" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { csd = { js_insert = "all_pages", exclude_list = [{ name = "x", path_value = "/x" }] } }
+  expect_failures = [var.csd]
+}
+
+run "exclude_domain_value_required" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { csd = { js_insert = "all_except", exclude_list = [{ name = "x", domain_mode = "exact", path_value = "/x" }] } }
+  expect_failures = [var.csd]
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -139,6 +139,21 @@ variable "ddos" {
   default = {}
 }
 
+variable "csd" {
+  description = "Client-Side Defense policy (client_side_defense.policy, gated by csd_enabled). See module ./modules/http-lb variables_csd.tf."
+  type = object({
+    js_insert = optional(string, "all_pages")
+    exclude_list = optional(list(object({
+      name         = string
+      domain_mode  = optional(string, "any")
+      domain_value = optional(string)
+      path_mode    = optional(string, "prefix")
+      path_value   = string
+    })), [])
+  })
+  default = {}
+}
+
 variable "lb_algorithm" {
   description = "LB load-balancing algorithm (loadbalancer_algorithm oneof). See module ./modules/http-lb variables_lb_algorithm.tf."
   type = object({


### PR DESCRIPTION
## Summary

Extends Client-Side Defense from on/off to its full `client_side_defense.policy`.

## Changes

- New `csd` variable (gated by `csd_enabled`): `js_insert` = `all_pages` (default; unchanged) |
  `disabled` (`disable_js_insert`) | `all_except` (`js_insert_all_pages_except` + `exclude_list`).
- `exclude_list[]` (all_except only): each entry = `metadata{name}` (API-required) + a domain
  matcher (any/exact/regex/suffix) + a `path` matcher (exact/prefix/regex, required).
- Live-probed the shapes first (disable_js_insert → 200; all_pages_except rejects entries missing
  metadata or a path arm → 400).

## Verification (live, f5-sales-demo, v3.72.15)

- `terraform test`: **388/388** (csd suite 7/7).
- Live matrix (`scripts/csd_pairs.py` + `csd-matrix.sh`) **3/3 PASS**: disabled, all-except (suffix+prefix,
  any+exact excludes), canonical-restore — apply → idempotent → whole-LB import **0-change**;
  canonical restored. No provider change needed.

Closes #152