### PR TITLE
CSD-1: cover client_side_defense js_insertion_rules arm + regex matcher modes

### DIFF
--- a/scripts/csd_pairs.py
+++ b/scripts/csd_pairs.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Generate the Client-Side Defense (CSD) policy coverage matrix.
 
-Cycles the LIVE LB through the client_side_defense.policy js_insert oneof — disabled
-(disable_js_insert) and all_except (js_insert_all_pages_except + exclude_list) — and ends on
-canonical-restore (all_pages, the default the merged baseline uses). csd_enabled stays true.
+Cycles the LIVE LB through the client_side_defense.policy js_insert oneof arms: disabled
+(disable_js_insert), all_except (js_insert_all_pages_except + exclude_list), all_except with regex
+domain/path matchers, and insertion_rules (js_insertion_rules + rules + nested exclude_list). Ends
+on canonical-restore (all_pages, the default the merged baseline uses). csd_enabled stays true.
 Deterministic. Output: JSON to stdout, or files via --emit.
 """
 
@@ -34,6 +35,57 @@ def build() -> list[dict[str, object]]:
                             "domain_mode": "any",
                             "path_mode": "exact",
                             "path_value": "/health",
+                        },
+                    ],
+                }
+            },
+        },
+        {
+            "name": "insertion-rules",
+            "vars": {
+                "csd": {
+                    "js_insert": "insertion_rules",
+                    "insertion_rules": {
+                        "rules": [
+                            {
+                                "name": "ins-home",
+                                "domain_mode": "any",
+                                "path_mode": "prefix",
+                                "path_value": "/",
+                            },
+                            {
+                                "name": "ins-checkout",
+                                "description": "checkout pages",
+                                "domain_mode": "suffix",
+                                "domain_value": "f5-sales-demo.com",
+                                "path_mode": "exact",
+                                "path_value": "/csd-demo/",
+                            },
+                        ],
+                        "exclude_list": [
+                            {
+                                "name": "skip-health",
+                                "domain_mode": "any",
+                                "path_mode": "exact",
+                                "path_value": "/health",
+                            },
+                        ],
+                    },
+                }
+            },
+        },
+        {
+            "name": "all-except-regex",
+            "vars": {
+                "csd": {
+                    "js_insert": "all_except",
+                    "exclude_list": [
+                        {
+                            "name": "skip-regex",
+                            "domain_mode": "regex",
+                            "domain_value": "cdn[.].*",
+                            "path_mode": "regex",
+                            "path_value": "^/static/.*$",
                         },
                     ],
                 }

--- a/terraform/modules/http-lb/locals_csd.tf
+++ b/terraform/modules/http-lb/locals_csd.tf
@@ -1,0 +1,31 @@
+# CSD matcher normalization. The exclude_list / insertion_rules.rules / insertion_rules.exclude_list
+# entries all share one matcher shape (domain any/exact/regex/suffix + path exact/prefix/regex). The
+# domain/path mode->field resolution is written ONCE here (the map comprehension) and applied to all
+# three lists, so main.tf's dynamic blocks just reference the resolved fields.
+locals {
+  _csd_matcher_lists = {
+    exclude_list           = var.csd.exclude_list
+    insertion_rules        = try(var.csd.insertion_rules.rules, [])
+    insertion_exclude_list = try(var.csd.insertion_rules.exclude_list, [])
+  }
+
+  _csd_normalized = {
+    for key, lst in local._csd_matcher_lists : key => [
+      for e in lst : {
+        name          = e.name
+        description   = e.description
+        any_domain    = e.domain_mode == "any"
+        domain_exact  = e.domain_mode == "exact" ? e.domain_value : null
+        domain_regex  = e.domain_mode == "regex" ? e.domain_value : null
+        domain_suffix = e.domain_mode == "suffix" ? e.domain_value : null
+        path_exact    = e.path_mode == "exact" ? e.path_value : null
+        path_prefix   = e.path_mode == "prefix" ? e.path_value : null
+        path_regex    = e.path_mode == "regex" ? e.path_value : null
+      }
+    ]
+  }
+
+  csd_exclude_list           = local._csd_normalized.exclude_list
+  csd_insertion_rules        = local._csd_normalized.insertion_rules
+  csd_insertion_exclude_list = local._csd_normalized.insertion_exclude_list
+}

--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -2410,7 +2410,9 @@ resource "xcsh_http_loadbalancer" "this" {
     for_each = var.csd_enabled ? [1] : []
     content {
       policy {
-        # JS-insertion oneof: all_pages (default) | disabled | all_except (+ exclude_list).
+        # JS-insertion oneof (4 mutually-exclusive arms, API-enforced): all_pages (default) |
+        # disabled | all_except (+ exclude_list) | insertion_rules (+ rules[>=1] + optional
+        # exclude_list). Matcher entries come pre-normalized from local.csd_* (see locals_csd.tf).
         dynamic "js_insert_all_pages" {
           for_each = var.csd.js_insert == "all_pages" ? [1] : []
           content {}
@@ -2423,29 +2425,85 @@ resource "xcsh_http_loadbalancer" "this" {
           for_each = var.csd.js_insert == "all_except" ? [1] : []
           content {
             dynamic "exclude_list" {
-              for_each = var.csd.exclude_list
+              for_each = local.csd_exclude_list
               content {
                 metadata {
-                  name = exclude_list.value.name
+                  name             = exclude_list.value.name
+                  description_spec = exclude_list.value.description
                 }
-                # domain matcher oneof.
                 dynamic "any_domain" {
-                  for_each = exclude_list.value.domain_mode == "any" ? [1] : []
+                  for_each = exclude_list.value.any_domain ? [1] : []
                   content {}
                 }
                 dynamic "domain" {
-                  for_each = exclude_list.value.domain_mode != "any" ? [1] : []
+                  for_each = exclude_list.value.any_domain ? [] : [1]
                   content {
-                    exact_value  = exclude_list.value.domain_mode == "exact" ? exclude_list.value.domain_value : null
-                    regex_value  = exclude_list.value.domain_mode == "regex" ? exclude_list.value.domain_value : null
-                    suffix_value = exclude_list.value.domain_mode == "suffix" ? exclude_list.value.domain_value : null
+                    exact_value  = exclude_list.value.domain_exact
+                    regex_value  = exclude_list.value.domain_regex
+                    suffix_value = exclude_list.value.domain_suffix
                   }
                 }
-                # path matcher oneof (required by the API).
                 path {
-                  path   = exclude_list.value.path_mode == "exact" ? exclude_list.value.path_value : null
-                  prefix = exclude_list.value.path_mode == "prefix" ? exclude_list.value.path_value : null
-                  regex  = exclude_list.value.path_mode == "regex" ? exclude_list.value.path_value : null
+                  path   = exclude_list.value.path_exact
+                  prefix = exclude_list.value.path_prefix
+                  regex  = exclude_list.value.path_regex
+                }
+              }
+            }
+          }
+        }
+        dynamic "js_insertion_rules" {
+          for_each = var.csd.js_insert == "insertion_rules" ? [1] : []
+          content {
+            dynamic "rules" {
+              for_each = local.csd_insertion_rules
+              content {
+                metadata {
+                  name             = rules.value.name
+                  description_spec = rules.value.description
+                }
+                dynamic "any_domain" {
+                  for_each = rules.value.any_domain ? [1] : []
+                  content {}
+                }
+                dynamic "domain" {
+                  for_each = rules.value.any_domain ? [] : [1]
+                  content {
+                    exact_value  = rules.value.domain_exact
+                    regex_value  = rules.value.domain_regex
+                    suffix_value = rules.value.domain_suffix
+                  }
+                }
+                path {
+                  path   = rules.value.path_exact
+                  prefix = rules.value.path_prefix
+                  regex  = rules.value.path_regex
+                }
+              }
+            }
+            dynamic "exclude_list" {
+              for_each = local.csd_insertion_exclude_list
+              content {
+                metadata {
+                  name             = exclude_list.value.name
+                  description_spec = exclude_list.value.description
+                }
+                dynamic "any_domain" {
+                  for_each = exclude_list.value.any_domain ? [1] : []
+                  content {}
+                }
+                dynamic "domain" {
+                  for_each = exclude_list.value.any_domain ? [] : [1]
+                  content {
+                    exact_value  = exclude_list.value.domain_exact
+                    regex_value  = exclude_list.value.domain_regex
+                    suffix_value = exclude_list.value.domain_suffix
+                  }
+                }
+                path {
+                  path   = exclude_list.value.path_exact
+                  prefix = exclude_list.value.path_prefix
+                  regex  = exclude_list.value.path_regex
                 }
               }
             }

--- a/terraform/modules/http-lb/variables_csd.tf
+++ b/terraform/modules/http-lb/variables_csd.tf
@@ -1,40 +1,88 @@
 # CSD policy: the client_side_defense.policy JavaScript-insertion oneof (gated by csd_enabled).
-# js_insert = all_pages (default; the current behavior) | disabled (disable_js_insert) | all_except
-# (js_insert_all_pages_except + exclude_list). Each exclude_list entry (all_except only) needs a
-# name (metadata, required by the API), a domain matcher (any/exact/regex/suffix), and a path
-# matcher (exact/prefix/regex, required).
+# js_insert selects the single oneof arm (all four are mutually exclusive — API-enforced):
+#   all_pages (default) | disabled (disable_js_insert) | all_except (js_insert_all_pages_except +
+#   exclude_list) | insertion_rules (js_insertion_rules + rules[>=1] + optional exclude_list).
+# Every matcher entry (exclude_list / insertion_rules.rules) has: name (metadata, API-required),
+# optional description (metadata.description_spec), a domain matcher (any/exact/regex/suffix), and a
+# path matcher (exact/prefix/regex, required).
 variable "csd" {
-  description = "Client-Side Defense policy. js_insert = all_pages|disabled|all_except; exclude_list applies only to all_except."
+  description = "Client-Side Defense policy. js_insert = all_pages|disabled|all_except|insertion_rules. exclude_list -> all_except; insertion_rules -> js_insertion_rules (rules required, exclude_list optional)."
   type = object({
     js_insert = optional(string, "all_pages")
     exclude_list = optional(list(object({
       name         = string
+      description  = optional(string)
       domain_mode  = optional(string, "any") # any | exact | regex | suffix
       domain_value = optional(string)
       path_mode    = optional(string, "prefix") # exact | prefix | regex
       path_value   = string
     })), [])
+    insertion_rules = optional(object({
+      rules = optional(list(object({
+        name         = string
+        description  = optional(string)
+        domain_mode  = optional(string, "any")
+        domain_value = optional(string)
+        path_mode    = optional(string, "prefix")
+        path_value   = string
+      })), [])
+      exclude_list = optional(list(object({
+        name         = string
+        description  = optional(string)
+        domain_mode  = optional(string, "any")
+        domain_value = optional(string)
+        path_mode    = optional(string, "prefix")
+        path_value   = string
+      })), [])
+    }))
   })
   default = {}
 
   validation {
-    condition     = contains(["all_pages", "disabled", "all_except"], var.csd.js_insert)
-    error_message = "csd.js_insert must be all_pages, disabled, or all_except."
+    condition     = contains(["all_pages", "disabled", "all_except", "insertion_rules"], var.csd.js_insert)
+    error_message = "csd.js_insert must be all_pages, disabled, all_except, or insertion_rules."
   }
   validation {
     condition     = var.csd.js_insert == "all_except" || length(var.csd.exclude_list) == 0
     error_message = "csd.exclude_list is only valid when csd.js_insert = all_except."
   }
   validation {
-    condition     = alltrue([for e in var.csd.exclude_list : contains(["any", "exact", "regex", "suffix"], e.domain_mode)])
-    error_message = "csd.exclude_list[].domain_mode must be any, exact, regex, or suffix."
+    condition     = var.csd.js_insert == "insertion_rules" || var.csd.insertion_rules == null
+    error_message = "csd.insertion_rules is only valid when csd.js_insert = insertion_rules."
   }
   validation {
-    condition     = alltrue([for e in var.csd.exclude_list : contains(["exact", "prefix", "regex"], e.path_mode)])
-    error_message = "csd.exclude_list[].path_mode must be exact, prefix, or regex."
+    condition     = var.csd.js_insert != "insertion_rules" || (var.csd.insertion_rules != null && length(var.csd.insertion_rules.rules) > 0)
+    error_message = "csd.insertion_rules.rules must have at least one rule when js_insert = insertion_rules (API min 1)."
+  }
+  # Matcher validations apply to every list (exclude_list + insertion_rules.rules/exclude_list).
+  validation {
+    condition = alltrue([
+      for e in concat(
+        var.csd.exclude_list,
+        try(var.csd.insertion_rules.rules, []),
+        try(var.csd.insertion_rules.exclude_list, []),
+      ) : contains(["any", "exact", "regex", "suffix"], e.domain_mode)
+    ])
+    error_message = "csd matcher domain_mode must be any, exact, regex, or suffix."
   }
   validation {
-    condition     = alltrue([for e in var.csd.exclude_list : e.domain_mode == "any" || e.domain_value != null])
-    error_message = "csd.exclude_list[].domain_value is required unless domain_mode = any."
+    condition = alltrue([
+      for e in concat(
+        var.csd.exclude_list,
+        try(var.csd.insertion_rules.rules, []),
+        try(var.csd.insertion_rules.exclude_list, []),
+      ) : contains(["exact", "prefix", "regex"], e.path_mode)
+    ])
+    error_message = "csd matcher path_mode must be exact, prefix, or regex."
+  }
+  validation {
+    condition = alltrue([
+      for e in concat(
+        var.csd.exclude_list,
+        try(var.csd.insertion_rules.rules, []),
+        try(var.csd.insertion_rules.exclude_list, []),
+      ) : e.domain_mode == "any" || e.domain_value != null
+    ])
+    error_message = "csd matcher domain_value is required unless domain_mode = any."
   }
 }

--- a/terraform/tests/csd.tftest.hcl
+++ b/terraform/tests/csd.tftest.hcl
@@ -68,6 +68,105 @@ run "all_except_exclude_list_renders" {
   }
 }
 
+run "insertion_rules_render" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    csd = {
+      js_insert = "insertion_rules"
+      insertion_rules = {
+        rules = [
+          { name = "ins-home", domain_mode = "any", path_mode = "prefix", path_value = "/" },
+          { name = "ins-checkout", description = "checkout pages", domain_mode = "suffix", domain_value = "f5-sales-demo.com", path_mode = "exact", path_value = "/csd-demo/" },
+        ]
+        exclude_list = [
+          { name = "skip-health", domain_mode = "any", path_mode = "exact", path_value = "/health" },
+        ]
+      }
+    }
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.client_side_defense.policy.js_insertion_rules.rules[0].any_domain != null
+    error_message = "insertion_rules.rules[0] any_domain must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.client_side_defense.policy.js_insertion_rules.rules[0].path.prefix == "/"
+    error_message = "insertion_rules.rules[0] path prefix must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.client_side_defense.policy.js_insertion_rules.rules[1].metadata.description_spec == "checkout pages"
+    error_message = "insertion_rules.rules[1] metadata.description_spec must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.client_side_defense.policy.js_insertion_rules.rules[1].domain.suffix_value == "f5-sales-demo.com"
+    error_message = "insertion_rules.rules[1] domain suffix_value must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.client_side_defense.policy.js_insertion_rules.exclude_list[0].path.path == "/health"
+    error_message = "insertion_rules.exclude_list[0] path exact must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.client_side_defense.policy.js_insert_all_pages == null
+    error_message = "js_insert_all_pages must be absent when insertion_rules selected"
+  }
+}
+
+run "insertion_rules_regex_modes" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    csd = {
+      js_insert = "insertion_rules"
+      insertion_rules = {
+        rules = [
+          { name = "ins-regex", domain_mode = "regex", domain_value = ".*[.]f5-sales-demo[.]com", path_mode = "regex", path_value = "^/app/.*$" },
+        ]
+      }
+    }
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.client_side_defense.policy.js_insertion_rules.rules[0].domain.regex_value == ".*[.]f5-sales-demo[.]com"
+    error_message = "regex domain_mode must render domain.regex_value"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.client_side_defense.policy.js_insertion_rules.rules[0].path.regex == "^/app/.*$"
+    error_message = "regex path_mode must render path.regex"
+  }
+}
+
+run "all_except_regex_modes" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    csd = {
+      js_insert    = "all_except"
+      exclude_list = [{ name = "skip-regex", domain_mode = "regex", domain_value = "cdn[.].*", path_mode = "regex", path_value = "^/static/.*$" }]
+    }
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.client_side_defense.policy.js_insert_all_pages_except.exclude_list[0].domain.regex_value == "cdn[.].*"
+    error_message = "all_except regex domain_mode must render"
+  }
+  assert {
+    condition     = xcsh_http_loadbalancer.this.client_side_defense.policy.js_insert_all_pages_except.exclude_list[0].path.regex == "^/static/.*$"
+    error_message = "all_except regex path_mode must render"
+  }
+}
+
+run "insertion_rules_requires_rules" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { csd = { js_insert = "insertion_rules", insertion_rules = { rules = [] } } }
+  expect_failures = [var.csd]
+}
+
+run "insertion_rules_requires_mode" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { csd = { js_insert = "all_pages", insertion_rules = { rules = [{ name = "r", path_value = "/" }] } } }
+  expect_failures = [var.csd]
+}
+
 run "csd_disabled_omits_block" {
   command = plan
   module { source = "./modules/http-lb" }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -145,11 +145,30 @@ variable "csd" {
     js_insert = optional(string, "all_pages")
     exclude_list = optional(list(object({
       name         = string
+      description  = optional(string)
       domain_mode  = optional(string, "any")
       domain_value = optional(string)
       path_mode    = optional(string, "prefix")
       path_value   = string
     })), [])
+    insertion_rules = optional(object({
+      rules = optional(list(object({
+        name         = string
+        description  = optional(string)
+        domain_mode  = optional(string, "any")
+        domain_value = optional(string)
+        path_mode    = optional(string, "prefix")
+        path_value   = string
+      })), [])
+      exclude_list = optional(list(object({
+        name         = string
+        description  = optional(string)
+        domain_mode  = optional(string, "any")
+        domain_value = optional(string)
+        path_mode    = optional(string, "prefix")
+        path_value   = string
+      })), [])
+    }))
   })
   default = {}
 }


### PR DESCRIPTION
## Summary

Extends CSD config coverage to its deepest leaves: the `js_insertion_rules` arm + `regex` matcher modes.

## Changes

- Live probe found `js_insertion_rules` is the **4th arm of the js_insert oneof** (mutually
  exclusive), requires `rules[]` (min 1; each needs `metadata{name}` + domain + path), optional
  nested `exclude_list`. `csd.js_insert` gains `insertion_rules`; new `csd.insertion_rules =
  { rules[>=1], exclude_list? }`; matchers gain optional `description` (→ metadata.description_spec).
- New `locals_csd.tf` normalizes each matcher's domain/path mode → resolved fields **once** (DRY),
  applied to all three lists; `main.tf` dynamic blocks reference the locals.
- Covers `regex` domain_mode + `regex` path_mode (previously untested) on `all_except` and `insertion_rules`.

## Verification (live, f5-sales-demo, v3.72.15)

- `terraform test`: **393/393** (csd suite 12/12).
- Live matrix **5/5 PASS**: disabled, all-except, **insertion-rules**, all-except-regex,
  canonical-restore — apply → idempotent → whole-LB import **0-change**; canonical restored. No
  provider change needed.

Closes #154