### PR TITLE
CSD-2: cover xcsh_mitigated_domain + xcsh_allowed_domain resources

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -116,6 +116,8 @@ module "http_lb" {
   ddos                            = var.ddos
   lb_algorithm                    = var.lb_algorithm
   csd                             = var.csd
+  csd_mitigated_domains           = var.csd_mitigated_domains
+  csd_allowed_domains             = var.csd_allowed_domains
 
   # API Discovery & Crawler (SP1) passthrough. Defaults keep enable_api_discovery {}
   # bare (0-change). The api-discovery matrix cycles the non-default arms.

--- a/terraform/modules/http-lb/csd_domains.tf
+++ b/terraform/modules/http-lb/csd_domains.tf
@@ -1,0 +1,26 @@
+# CSD-2: mitigated / allowed domain registrations (gated by csd_enabled), keyed by name. Created in
+# the LB namespace, mirroring the root xcsh_protected_domain. No import round-trip (CSD domain API is
+# list/create/delete only — provider Read tolerates the 501 GET-by-name, terraform-provider-xcsh#1044).
+resource "xcsh_mitigated_domain" "this" {
+  for_each = var.csd_enabled ? { for d in var.csd_mitigated_domains : d.name => d } : {}
+
+  name             = each.value.name
+  namespace        = var.namespace
+  mitigated_domain = each.value.domain
+  description      = each.value.description
+  disable          = each.value.disable
+  labels           = each.value.labels
+  annotations      = each.value.annotations
+}
+
+resource "xcsh_allowed_domain" "this" {
+  for_each = var.csd_enabled ? { for d in var.csd_allowed_domains : d.name => d } : {}
+
+  name           = each.value.name
+  namespace      = var.namespace
+  allowed_domain = each.value.domain
+  description    = each.value.description
+  disable        = each.value.disable
+  labels         = each.value.labels
+  annotations    = each.value.annotations
+}

--- a/terraform/modules/http-lb/variables_csd_domains.tf
+++ b/terraform/modules/http-lb/variables_csd_domains.tf
@@ -1,0 +1,42 @@
+# CSD-2: standalone CSD domain registrations beyond the required protected_domain (which stays at
+# the root, as the eTLD+1 prerequisite that must exist before the LB enables CSD). These are optional
+# CSD tuning, created in the LB namespace and gated by csd_enabled:
+#   mitigated_domains — block a detected third-party domain (drives CSD blocked_scripts/mitigated_domains)
+#   allowed_domains   — allowlist a domain so CSD does not flag it
+# Both take a specific host (not an eTLD+1); the CSD domain API is list/create/delete only (GET-by-name
+# 501; domain values tenant-globally-unique -> 409 on re-create), so there is no whole-object import.
+variable "csd_mitigated_domains" {
+  description = "CSD mitigated (blocked) domains. Each: name (DNS-1123) + domain (specific host, e.g. cdn.jsdelivr.net)."
+  type = list(object({
+    name        = string
+    domain      = string
+    description = optional(string)
+    disable     = optional(bool, false)
+    labels      = optional(map(string), {})
+    annotations = optional(map(string), {})
+  }))
+  default = []
+
+  validation {
+    condition     = alltrue([for d in var.csd_mitigated_domains : length(d.domain) > 0 && length(d.domain) <= 256])
+    error_message = "csd_mitigated_domains[].domain must be a non-empty host (<= 256 chars)."
+  }
+}
+
+variable "csd_allowed_domains" {
+  description = "CSD allowed (allowlisted) domains. Each: name (DNS-1123) + domain (specific host)."
+  type = list(object({
+    name        = string
+    domain      = string
+    description = optional(string)
+    disable     = optional(bool, false)
+    labels      = optional(map(string), {})
+    annotations = optional(map(string), {})
+  }))
+  default = []
+
+  validation {
+    condition     = alltrue([for d in var.csd_allowed_domains : length(d.domain) > 0 && length(d.domain) <= 256])
+    error_message = "csd_allowed_domains[].domain must be a non-empty host (<= 256 chars)."
+  }
+}

--- a/terraform/tests/csd_domains.tftest.hcl
+++ b/terraform/tests/csd_domains.tftest.hcl
@@ -1,0 +1,83 @@
+# Plan-level tests for CSD-2: xcsh_mitigated_domain + xcsh_allowed_domain (in the http-lb module,
+# gated by csd_enabled). command = plan, targets ./modules/http-lb. No import round-trip is tested
+# (CSD domain API is list/create/delete only — 501 GET-by-name; verified live via steady-state).
+variables {
+  namespace         = "webapp-api-protection"
+  lb_domains        = ["www.f5-sales-demo.com"]
+  origin_ip         = "203.0.113.10"
+  origin_port       = 80
+  health_check_path = "/health"
+  labels            = {}
+  csd_enabled       = true
+  mud_enabled       = false
+}
+
+run "mitigated_and_allowed_render" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    csd_mitigated_domains = [
+      { name = "block-jsdelivr", domain = "cdn.jsdelivr.net", description = "block skimmer CDN" },
+    ]
+    csd_allowed_domains = [
+      { name = "allow-fonts", domain = "fonts.googleapis.com", labels = { team = "web" } },
+    ]
+  }
+  assert {
+    condition     = xcsh_mitigated_domain.this["block-jsdelivr"].mitigated_domain == "cdn.jsdelivr.net"
+    error_message = "mitigated_domain must render the host"
+  }
+  assert {
+    condition     = xcsh_mitigated_domain.this["block-jsdelivr"].namespace == "webapp-api-protection"
+    error_message = "mitigated_domain must be in the LB namespace"
+  }
+  assert {
+    condition     = xcsh_allowed_domain.this["allow-fonts"].allowed_domain == "fonts.googleapis.com"
+    error_message = "allowed_domain must render the host"
+  }
+  assert {
+    condition     = xcsh_allowed_domain.this["allow-fonts"].labels["team"] == "web"
+    error_message = "allowed_domain labels must render"
+  }
+}
+
+run "disable_toggle_renders" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    csd_mitigated_domains = [{ name = "block-x", domain = "evil.example.com", disable = true }]
+  }
+  assert {
+    condition     = xcsh_mitigated_domain.this["block-x"].disable == true
+    error_message = "disable toggle must render"
+  }
+}
+
+run "omitted_by_default" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  assert {
+    condition     = length(xcsh_mitigated_domain.this) == 0 && length(xcsh_allowed_domain.this) == 0
+    error_message = "no CSD domain resources by default"
+  }
+}
+
+run "not_created_when_csd_disabled" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    csd_enabled           = false
+    csd_mitigated_domains = [{ name = "block-x", domain = "evil.example.com" }]
+  }
+  assert {
+    condition     = length(xcsh_mitigated_domain.this) == 0
+    error_message = "mitigated_domain must not be created when csd_enabled=false"
+  }
+}
+
+run "bad_mitigated_domain_rejected" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables { csd_mitigated_domains = [{ name = "block-empty", domain = "" }] }
+  expect_failures = [var.csd_mitigated_domains]
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -173,6 +173,32 @@ variable "csd" {
   default = {}
 }
 
+variable "csd_mitigated_domains" {
+  description = "CSD mitigated (blocked) domains (xcsh_mitigated_domain). See module ./modules/http-lb variables_csd_domains.tf."
+  type = list(object({
+    name        = string
+    domain      = string
+    description = optional(string)
+    disable     = optional(bool, false)
+    labels      = optional(map(string), {})
+    annotations = optional(map(string), {})
+  }))
+  default = []
+}
+
+variable "csd_allowed_domains" {
+  description = "CSD allowed (allowlisted) domains (xcsh_allowed_domain). See module ./modules/http-lb variables_csd_domains.tf."
+  type = list(object({
+    name        = string
+    domain      = string
+    description = optional(string)
+    disable     = optional(bool, false)
+    labels      = optional(map(string), {})
+    annotations = optional(map(string), {})
+  }))
+  default = []
+}
+
 variable "lb_algorithm" {
   description = "LB load-balancing algorithm (loadbalancer_algorithm oneof). See module ./modules/http-lb variables_lb_algorithm.tf."
   type = object({


### PR DESCRIPTION
## Summary

Adds the two standalone CSD domain resources beyond the required `protected_domain`: `mitigated_domain`
(block a detected third-party host → drives CSD `blocked_scripts`/`mitigated_domains`) and
`allowed_domain` (allowlist a host).

## Changes

- New `csd_mitigated_domains` / `csd_allowed_domains` vars (list of `{name, domain, description?,
  disable?, labels?, annotations?}`) + `csd_domains.tf` resources (for_each by name, in the http-lb
  module, gated by `csd_enabled`, LB namespace). Domain field takes a specific host (≤256).
- **No import round-trip** — the CSD domain API is list/create/delete only (GET-by-name 501; domain
  values tenant-globally-unique → 409). Documented; verified via steady-state.

## Verification (live, f5-sales-demo, v3.72.15)

- `terraform test`: **398/398** (csd_domains suite 5/5).
- Live: applied a mitigated + allowed domain → steady-state plan **0-change** → removed → canonical
  0-change (create/read/delete lifecycle clean).

Closes #156