### PR TITLE
feat: add CSD statistics behavioral verifier (CSD-3)

### DIFF
--- a/scripts/csd-verify.sh
+++ b/scripts/csd-verify.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# CSD behavioral verification (CSD-3).
+#
+# Closed-loop check that F5 XC Client-Side Defense, once enabled on the LB, actually generates
+# detection STATISTICS from real browser-side attack activity — the plane the config/matrix tests
+# cannot exercise. Pairs with the traffic-generator suites/csd-detection driver (the Combined
+# Detection Script: third-party CDN script injection + external exfil, per csd/docs).
+#
+# CSD detection is fundamentally asynchronous and browser-driven:
+#   - curl cannot trigger it; a real browser must execute the injected CSD JS and beacon to
+#     *.zeronaught.com. The traffic-generator suites/csd-detection suite is that browser driver.
+#   - the CSD backend aggregates beacons before statistics appear (docs: 5-10 min, up to 30).
+# So this verifier separates what is synchronous and deterministic (config gate, driver executed
+# with the CSD beacon returning 200) from what is async (the statistics), and uses the mud-verify
+# exit-3 semantic for "enabled + driven, but stats have not aggregated yet — re-run later".
+#
+# Steps:
+#   1) Gate (exit 2): client_side_defense is configured on the LB AND a protected_domain covering
+#      f5-sales-demo.com exists (CSD returns 500 / never scans without the protected domain).
+#   2) Baseline the CSD /summary counters.
+#   3) DRIVE (opt-in, DRIVE=1): ship the csd-detection suite to the traffic-generator VM and run it;
+#      require its synchronous PASS (CSD JS injected + telemetry beacon 200). Without DRIVE=1 the
+#      verifier only reads the stats plane (assumes traffic was already driven).
+#   4) Detection (exit 3 if not yet): poll /detected_domains for the injected/exfil domains and
+#      /summary suspicious_scripts above baseline.
+#   5) Mitigation: report registered /mitigated_domains and, when a detected domain is mitigated,
+#      the /summary blocked_scripts / mitigated_domains counters.
+#   6) Per-script telemetry (deepest leaf): /scripts (epoch window) -> for a detected script,
+#      /scripts/{id}/{behaviors,networkInteractions} non-empty.
+#   7) Origin cross-check: from the VM, GET the origin /csd-demo/exfil/log (the same-origin attack
+#      recorder) to confirm the origin server observed attack traffic.
+#
+# Exit: 0 = CSD enabled, driven, and detection statistics present; 2 = CSD not enabled/no protected
+# domain; 3 = enabled + driven but statistics not aggregated yet (increase traffic / re-run later).
+# Read-only against the config plane; the CSD stats plane and origin log are read-only.
+#
+# Env: XCSH_API_URL, XCSH_API_TOKEN (required); Azure CLI logged in when DRIVE=1 or the origin
+# cross-check runs. Usage: [DRIVE=1] [POLL_MIN=15] scripts/csd-verify.sh
+set -uo pipefail
+
+: "${XCSH_API_URL:?XCSH_API_URL must be set}"
+: "${XCSH_API_TOKEN:?XCSH_API_TOKEN must be set}"
+NS="${NS:-webapp-api-protection}"
+LB="${LB:-webapp-api-protection}"
+TARGET="${TARGET:-http://www.f5-sales-demo.com/}"
+PROTECTED_ROOT="${PROTECTED_ROOT:-f5-sales-demo.com}"
+VM_NAME="${VM_NAME:-vm-traffic-generator-rmordasiewicz}"
+VM_RG="${VM_RG:-rg-traffic-generator-webapp-api-protection-rmordasiewicz}"
+DRIVE="${DRIVE:-0}"
+POLL_MIN="${POLL_MIN:-15}"
+SUITE_JS="$(cd "$(dirname "$0")/.." && pwd)/../traffic-generator/suites/csd-detection/01-combined-detection.js"
+base="${XCSH_API_URL%/}"
+csd="${base}/api/shape/csd/namespaces/${NS}"
+auth=(-H "Authorization: APIToken ${XCSH_API_TOKEN}")
+
+echo "== 1) CSD enabled on ${NS}/${LB} + protected_domain present? =="
+cfg=$(curl -s "${auth[@]}" "${base}/api/config/namespaces/${NS}/http_loadbalancers/${LB}?response_format=GET_RSP_FORMAT_DEFAULT")
+csd_on=$(printf '%s' "$cfg" | python3 -c '
+import sys, json
+s = (json.load(sys.stdin) or {}).get("spec", {})
+print("yes" if s.get("client_side_defense") is not None else "no")
+' 2>/dev/null || echo "no")
+prot=$(curl -s "${auth[@]}" "${csd}/protected_domains" | python3 -c '
+import sys, json
+root = sys.argv[1]
+d = json.load(sys.stdin) or {}
+items = d.get("items") or d.get("domains_list") or []
+names = [ (i.get("name") or i.get("domain") or "") for i in items ]
+print("yes" if any(root in n for n in names) else "no")
+' "${PROTECTED_ROOT}" 2>/dev/null || echo "no")
+echo "  client_side_defense configured: ${csd_on}"
+echo "  protected_domain ~ ${PROTECTED_ROOT}: ${prot}"
+if [ "${csd_on}" != "yes" ] || [ "${prot}" != "yes" ]; then
+  echo "  => CSD not fully enabled (need client_side_defense on the LB + a protected_domain). "
+  exit 2
+fi
+echo "  => CSD ENABLED"
+
+echo "== 2) Baseline CSD /summary =="
+base_summary=$(curl -s "${auth[@]}" "${csd}/summary")
+base_susp=$(printf '%s' "$base_summary" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("suspicious_scripts",0))' 2>/dev/null || echo 0)
+echo "  suspicious_scripts baseline: ${base_susp}"
+
+if [ "${DRIVE}" = "1" ]; then
+  echo "== 3) Drive csd-detection suite on ${VM_NAME} =="
+  [ -f "${SUITE_JS}" ] || {
+    echo "  suite not found: ${SUITE_JS}"
+    exit 2
+  }
+  b64=$(base64 <"${SUITE_JS}" | tr -d '\n')
+  fqdn="${TARGET#http://}"
+  fqdn="${fqdn#https://}"
+  fqdn="${fqdn%%/*}"
+  remote=$(
+    cat <<REMOTE
+echo '${b64}' | base64 -d > /tmp/csd-combined-detection.js
+NODE_PATH=/usr/lib/node_modules TARGET_PROTOCOL=http node /tmp/csd-combined-detection.js '${fqdn}' 2>&1 | tail -12
+REMOTE
+  )
+  msg=$(az vm run-command invoke --name "${VM_NAME}" --resource-group "${VM_RG}" \
+    --command-id RunShellScript --scripts "${remote}" --query "value[0].message" -o tsv 2>&1)
+  echo "${msg}" | sed 's/^/  /'
+  if ! printf '%s' "${msg}" | grep -q "PASS: CSD injected"; then
+    echo "  => driver did not confirm CSD injection/beacon; CSD not effective on the dataplane."
+    exit 2
+  fi
+else
+  echo "== 3) Drive skipped (DRIVE!=1) — reading stats plane for previously-driven traffic =="
+fi
+
+echo "== 4) Detection statistics (poll up to ${POLL_MIN}m) =="
+deadline=$((SECONDS + POLL_MIN * 60))
+detected="no"
+doms=""
+while :; do
+  dd=$(curl -s "${auth[@]}" "${csd}/detected_domains")
+  read -r cnt doms < <(printf '%s' "$dd" | python3 -c '
+import sys, json
+d = json.load(sys.stdin) or {}
+c = (d.get("domain_summary") or {}).get("totalDomains", {}).get("count", 0)
+names = ",".join((x.get("domain") or "") for x in (d.get("domains_list") or [])[:12])
+print(c, names)
+' 2>/dev/null || echo "0 ")
+  susp=$(curl -s "${auth[@]}" "${csd}/summary" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("suspicious_scripts",0))' 2>/dev/null || echo 0)
+  if { [ -n "${cnt}" ] && [ "${cnt}" != "0" ]; } || [ "${susp}" -gt "${base_susp}" ] 2>/dev/null; then
+    detected="yes"
+    echo "  detected_domains count=${cnt} suspicious_scripts=${susp} domains=[${doms}]"
+    break
+  fi
+  if [ "${SECONDS}" -ge "${deadline}" ]; then
+    echo "  detected_domains count=${cnt} suspicious_scripts=${susp} (baseline ${base_susp})"
+    break
+  fi
+  echo "  ...t+$(((SECONDS) / 60))m count=${cnt} suspicious_scripts=${susp}; waiting (CSD aggregates 5-10m)"
+  sleep 60
+done
+if [ "${detected}" != "yes" ]; then
+  echo "  => CSD enabled + driven, but no statistics aggregated within ${POLL_MIN}m."
+  echo "     Detection is async (docs: 5-10m, up to 30m). Re-run later or increase traffic volume."
+  exit 3
+fi
+
+echo "== 5) Mitigation state =="
+mit=$(curl -s "${auth[@]}" "${csd}/mitigated_domains" | python3 -c '
+import sys, json
+d = json.load(sys.stdin) or {}
+items = d.get("items") or d.get("domains_list") or []
+print(",".join((i.get("name") or i.get("domain") or "") for i in items) or "(none)")
+' 2>/dev/null || echo "(none)")
+sm=$(curl -s "${auth[@]}" "${csd}/summary")
+echo "  registered mitigated_domains: ${mit}"
+echo "  summary blocked_scripts/mitigated_domains: $(printf '%s' "$sm" | python3 -c 'import sys,json;d=json.load(sys.stdin);print(d.get("blocked_scripts",0),"/",d.get("mitigated_domains",0))' 2>/dev/null)"
+
+echo "== 6) Per-script telemetry (deepest leaf) =="
+now=$(date +%s)
+start=$((now - 86400))
+sid=$(curl -s -X POST "${auth[@]}" -H "Content-Type: application/json" \
+  -d "{\"startTime\":\"${start}\",\"endTime\":\"${now}\"}" "${csd}/scripts" | python3 -c '
+import sys, json
+d = json.load(sys.stdin)
+if isinstance(d, dict) and d.get("code"):  # error object
+    print(""); sys.exit(0)
+arr = d.get("scripts") if isinstance(d, dict) else d
+arr = arr or []
+print(arr[0].get("id","") if arr else "")
+' 2>/dev/null || echo "")
+if [ -n "${sid}" ]; then
+  beh=$(curl -s "${auth[@]}" "${csd}/scripts/${sid}/behaviors" | python3 -c 'import sys,json;d=json.load(sys.stdin);print(len(d if isinstance(d,list) else d.get("behaviors",[])))' 2>/dev/null || echo 0)
+  net=$(curl -s "${auth[@]}" "${csd}/scripts/${sid}/networkInteractions" | python3 -c 'import sys,json;d=json.load(sys.stdin);print(len(d if isinstance(d,list) else d.get("networkInteractions",[])))' 2>/dev/null || echo 0)
+  echo "  script ${sid}: behaviors=${beh} networkInteractions=${net}"
+else
+  echo "  no script id yet (script analysis lags detected_domains)"
+fi
+
+echo "== 7) Origin cross-check (from ${VM_NAME}) =="
+remote_log="curl -s -m 15 '${TARGET%/}/csd-demo/exfil/log' | head -c 400"
+olog=$(az vm run-command invoke --name "${VM_NAME}" --resource-group "${VM_RG}" \
+  --command-id RunShellScript --scripts "${remote_log}" --query "value[0].message" -o tsv 2>&1 | grep -v '^\[' | tr -d '\n')
+echo "  origin /csd-demo/exfil/log: ${olog:0:200}"
+
+echo "PASS: CSD enabled, driven, and detection statistics present (detected_domains / suspicious_scripts)."
+exit 0


### PR DESCRIPTION
## Summary

Adds `scripts/csd-verify.sh` — the closed-loop verifier for the CSD statistics plane, the layer the config/`terraform test`/import matrices (CSD-1, CSD-2) cannot exercise. Pairs with the traffic-generator `suites/csd-detection` driver (f5-sales-demo/traffic-generator#336).

## Why

CSD detection is browser-driven and asynchronous: curl cannot trigger it (a real browser must execute the injected CSD sensor and beacon to `*.zeronaught.com`), and the backend aggregates beacons before statistics appear (docs: 5–10 min, up to 30). The verifier separates the **synchronous/deterministic** part (config gate + driver confirms the CSD sensor loaded and its beacon returned 200) from the **async** part (the statistics), using the established `mud-verify` exit-3 semantic for "enabled + driven, but not yet aggregated".

## What it checks

1. **Gate (exit 2):** `client_side_defense` configured on the LB **and** a `protected_domain` covering `f5-sales-demo.com` (CSD never scans without it).
2. Baseline the CSD `/summary` counters.
3. **Drive (opt-in `DRIVE=1`):** ships the `csd-detection` suite to the traffic-generator VM, runs it, requires its synchronous PASS (sensor + beacon 200).
4. **Detection (exit 3 if pending):** polls `/detected_domains` (count/domains) and `/summary suspicious_scripts` above baseline.
5. **Mitigation:** registered `/mitigated_domains` + `blocked_scripts`/`mitigated_domains` counters.
6. **Per-script telemetry (deepest leaf):** `/scripts` (epoch window) → `/scripts/{id}/{behaviors,networkInteractions}`.
7. **Origin cross-check:** origin `/csd-demo/exfil/log` from the VM.

Exit: `0` present · `2` not enabled · `3` driven but async-pending.

## Verification

- `shellcheck` clean; `shfmt -d` clean.
- Live: CSD sensor load + telemetry beacon confirmed **200** from the VM against `www.f5-sales-demo.com/csd-demo/` (the driver's synchronous PASS condition). Statistics aggregation is async per docs; the exit-3 path handles the pending window.

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)