### PR TITLE
CSD demo: third-party skimmer via cdn-simulator + FQDN mitigation retarget

### DIFF
--- a/terraform/cloud-init/origin-server.yaml
+++ b/terraform/cloud-init/origin-server.yaml
@@ -1500,10 +1500,13 @@ write_files:
       <script src="https://unpkg.com/underscore@1.13.7/underscore-min.js"></script>
       <script src="https://esm.sh/moment@2.30.1"></script>
       <script src="https://ga.jspm.io/npm:dayjs@1.11.13/dayjs.min.js"></script>
-      <!-- First-party checkout logic served as an EXTERNAL script (app.py /checkout.js) so CSD
-           inventories it at load; it reads payment fields (Magecart skimmer) and is flagged High
-           Risk. CSD does NOT inventory inline scripts, which is why this logic must be external. -->
-      <script src="checkout.js"></script>
+      <!-- Magecart skimmer served as a THIRD-PARTY external script via the cdn-simulator edge
+           (${cdn_simulator_host}), which origin-pulls this origin and serves /csd-demo/checkout.js
+           under its own host. Loaded from that third-party host (not same-origin) so CSD inventories
+           it as a distinct third-party domain, flags it High Risk (it reads payment-field values),
+           and mitigating that host blocks it — the detect -> mitigate -> block cycle. CSD does NOT
+           inventory inline scripts, which is why this logic must be external. -->
+      <script src="http://${cdn_simulator_host}/csd-demo/checkout.js"></script>
       </body>
       </html>
 

--- a/terraform/csd_demo_mitigation.tf
+++ b/terraform/csd_demo_mitigation.tf
@@ -1,45 +1,40 @@
 # CSD demo — Phase 3 (Mitigate) reproduced in Terraform.
 #
-# The CSD docs demo (csd/docs/en/demo/phase-3-mitigate.mdx) applies mitigations by POSTing the
-# attack's third-party domains to the CSD mitigated_domains API. This reproduces that step
-# declaratively: when csd_demo_mitigation_enabled = true, the six domains the /csd-demo/ page
-# loads/exfils to (4 CDN supply-chain domains + 2 external exfil endpoints) are registered as
-# xcsh_mitigated_domain resources (via the http-lb module's csd_mitigated_domains input).
+# The CSD docs demo (csd/docs/en/demo/phase-3-mitigate.mdx) applies mitigations by registering the
+# attacking third-party script's host as a CSD mitigated_domain. This reproduces that step
+# declaratively: when csd_demo_mitigation_enabled = true, the cdn-simulator edge host — which serves
+# the behaving skimmer (/csd-demo/checkout.js, a genuine third-party <script src>) — is registered as
+# an xcsh_mitigated_domain (via the http-lb module's csd_mitigated_domains input).
 #
-# This is the mitigate/teardown toggle: set true to apply the mitigations (Phase 3 Step 3), leave
-# false (default) to remove them (Phase 4 teardown of mitigations). CSD mitigation blocks SCRIPT
-# LOADING from mitigated domains (clears the <script> src) — so it meaningfully blocks the 4 CDN
-# supply-chain scripts. The 2 exfil domains are included for demo fidelity (they appear in the
-# mitigated list) though CSD does not intercept fetch() (per the docs).
+# The mitigated host is DERIVED from var.csd_cdn_simulator_host, the same single source of truth that
+# the origin's checkout page loads the skimmer from. There is exactly one behaving third-party script
+# in the demo (checkout.js reads payment fields), so exactly one host to detect and mitigate; the
+# other libraries the page loads are benign (never read fields) and CSD does not flag them.
 #
-# csd_demo_mitigated_domains uses the SAME type as csd_mitigated_domains so the selection in
-# main.tf (enabled ? demo : user) unifies cleanly. httpbin.org note: the CSD API rejects a bare
-# eTLD+1 as mitigated_domain ("cannot derive eTLD+1"), so the identifier is httpbin.org while the
-# mitigated_domain value is www.httpbin.org — matching the docs' Phase 3 Step 3 exception.
+# This is the mitigate/teardown toggle: set true to apply the mitigation (Phase 3 Step 3), leave
+# false (default) to remove it (Phase 4 teardown, and the "before" detection baseline). CSD
+# mitigation blocks SCRIPT LOADING from the mitigated host (clears the <script> src), so it blocks
+# the third-party skimmer — the detect -> mitigate -> block cycle.
 
 variable "csd_demo_mitigation_enabled" {
-  description = "Apply the CSD demo Phase 3 mitigations (register the /csd-demo/ third-party domains as CSD mitigated_domains). false = teardown/no mitigations."
+  description = "Apply the CSD demo Phase 3 mitigation (register the cdn-simulator skimmer host as a CSD mitigated_domain). false = teardown/no mitigation (also the 'before' detection baseline)."
   type        = bool
   default     = false
 }
 
-variable "csd_demo_mitigated_domains" {
-  description = "The /csd-demo/ third-party domains registered when csd_demo_mitigation_enabled = true (4 CDN supply-chain + 2 external exfil). Same shape as csd_mitigated_domains."
-  type = list(object({
-    name        = string
-    domain      = string
-    description = optional(string)
-    disable     = optional(bool, false)
-    labels      = optional(map(string), {})
-    annotations = optional(map(string), {})
-  }))
-  # Names are DNS-1123 labels (no dots — provider requirement); domain carries the real host.
-  default = [
-    { name = "block-jsdelivr", domain = "cdn.jsdelivr.net", description = "CSD demo: CDN supply-chain script domain" },
-    { name = "block-esm-sh", domain = "esm.sh", description = "CSD demo: CDN supply-chain script domain" },
-    { name = "block-unpkg", domain = "unpkg.com", description = "CSD demo: CDN supply-chain script domain" },
-    { name = "block-jspm", domain = "ga.jspm.io", description = "CSD demo: CDN supply-chain script domain" },
-    { name = "block-httpbin", domain = "www.httpbin.org", description = "CSD demo: external exfil endpoint (eTLD+1 -> www host)" },
-    { name = "block-jsonplaceholder", domain = "jsonplaceholder.typicode.com", description = "CSD demo: external exfil endpoint" },
+locals {
+  # Single source of truth: the host we load the behaving skimmer from (var.csd_cdn_simulator_host)
+  # is exactly the host CSD detects and we mitigate. name is a stable DNS-1123 label (no dots);
+  # domain carries the real FQDN (validated as an FQDN on the variable). Built to the same object
+  # shape as var.csd_mitigated_domains so main.tf's enabled ? demo : user selection type-checks.
+  csd_demo_mitigated_domains = [
+    {
+      name        = "block-cdn-simulator"
+      domain      = var.csd_cdn_simulator_host
+      description = "CSD demo: third-party CDN host serving the behaving skimmer (checkout.js from cdn-simulator)"
+      disable     = false
+      labels      = tomap({})
+      annotations = tomap({})
+    }
   ]
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -118,7 +118,7 @@ module "http_lb" {
   ddos                            = var.ddos
   lb_algorithm                    = var.lb_algorithm
   csd                             = var.csd
-  csd_mitigated_domains           = var.csd_demo_mitigation_enabled ? var.csd_demo_mitigated_domains : var.csd_mitigated_domains
+  csd_mitigated_domains           = var.csd_demo_mitigation_enabled ? local.csd_demo_mitigated_domains : var.csd_mitigated_domains
   csd_allowed_domains             = var.csd_allowed_domains
 
   # API Discovery & Crawler (SP1) passthrough. Defaults keep enable_api_discovery {}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -42,7 +42,9 @@ module "origin_server" {
     { name = "AllowCrAPI", priority = 130, port = "8888" },
   ]
 
-  custom_data = base64encode(templatefile("${path.module}/cloud-init/origin-server.yaml", {}))
+  custom_data = base64encode(templatefile("${path.module}/cloud-init/origin-server.yaml", {
+    cdn_simulator_host = var.csd_cdn_simulator_host
+  }))
 }
 
 # --- F5 XC namespace + HTTP load balancer -------------------------------------

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -42,7 +42,10 @@ module "origin_server" {
     { name = "AllowCrAPI", priority = 130, port = "8888" },
   ]
 
-  custom_data = base64encode(templatefile("${path.module}/cloud-init/origin-server.yaml", {
+  # gzip + base64: the rendered cloud-init exceeds Azure's 65535-byte custom_data
+  # limit uncompressed. cloud-init detects the gzip magic bytes and decompresses
+  # user-data automatically, so the VM receives the same YAML.
+  custom_data = base64gzip(templatefile("${path.module}/cloud-init/origin-server.yaml", {
     cdn_simulator_host = var.csd_cdn_simulator_host
   }))
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -47,6 +47,23 @@ variable "csd_enabled" {
   default     = true
 }
 
+variable "csd_cdn_simulator_host" {
+  description = "FQDN of the cdn-simulator edge that serves the CSD demo's behaving skimmer (/csd-demo/checkout.js) as a THIRD-PARTY script. The cdn-simulator origin-pulls this webapp's origin, so it serves the origin's checkout.js under its own host — making it a distinct domain that CSD detects (and mitigation blocks). Must be an FQDN (not a raw IP) so it matches the F5 XC mitigated-domain exactly; use the cdn-simulator's edge_fqdn output. See docs: deploy the cdn-simulator component pointing origin_host at this origin."
+  type        = string
+  default     = "cdn-simulator-rmordasiewicz.eastus2.cloudapp.azure.com"
+
+  validation {
+    # Must be an FQDN, never a raw IP: F5 XC CSD registers the mitigated domain by
+    # host, and the origin's <script src> host must match it exactly for the
+    # detect -> mitigate -> block cycle. A raw IPv4 cannot be registered reliably.
+    condition = (
+      !can(regex("^(\\d{1,3}\\.){3}\\d{1,3}$", var.csd_cdn_simulator_host))
+      && can(regex("^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$", var.csd_cdn_simulator_host))
+    )
+    error_message = "csd_cdn_simulator_host must be an FQDN (e.g. the cdn-simulator edge_fqdn), not a raw IP, so it matches the F5 XC CSD mitigated-domain exactly."
+  }
+}
+
 variable "mud_enabled" {
   description = "Enable Malicious User Detection: score per-user behavior into threat levels and auto-mitigate (JS challenge / CAPTCHA / temporary block) via a malicious_user_mitigation policy. Requires the tenant MUD addon (verified via a data-source guard, not managed here)."
   type        = bool


### PR DESCRIPTION
Closes #194

Completes the CSD demo's headline **third-party (Magecart) detect → mitigate → block** cycle.

## Changes
1. **Serve (P3)** — the `/csd-demo/` checkout page loads the field-reading `checkout.js` from the **cdn-simulator edge host** (`var.csd_cdn_simulator_host`), not same-origin. cdn-simulator origin-pulls this origin, so it serves the same behaving skimmer under its own host → CSD sees a distinct third-party High-Risk script.
2. **Mitigate (P4)** — the CSD demo mitigated_domain is **derived from the same host var** (single source of truth), replacing the stale 6-domain benign-CDN list. The only behaving third-party script is checkout.js from the cdn-sim host, so that host is exactly what CSD detects and what mitigation blocks.

## FQDN over raw IP (resolves the acceptance-criteria open question)
Uses the cdn-simulator's **Azure public-IP DNS FQDN** `cdn-simulator-rmordasiewicz.eastus2.cloudapp.azure.com` (added in cdn-simulator PR #320) instead of a raw IP — so the origin's `<script src>` host matches the F5 XC mitigated-domain exactly. A `validation` block enforces FQDN-not-IP.

## Verified live
- **FQDN mitigation accepted**: `terraform apply` registered `xcsh_mitigated_domain` `block-cdn-simulator` → the Azure FQDN with **no eTLD+1 rejection** (the concern the issue flagged), and cleaned up the 6 stale domains. `Apply complete: 1 added, 0 changed, 6 destroyed`.
- `terraform fmt -check -recursive` clean.
- FQDN resolves publicly to the edge IP; `/csd-demo/checkout.js` served via cdn-sim (HTTP 200).

## Remaining (this PR's live steps, tracked in #194)
- Origin redeploy (cloud-init change → origin VM replacement, deliberate) so the page actually references the cdn-sim host.
- Before/after population drive proving High-Risk detection then block.

## Notes
- HTTP scheme intentional (HTTP-only env; third-party classification is by host, not scheme).