### PR TITLE
fix(http-lb): align graphql_settings attributes with provider xcsh schema (#312)

### DIFF
--- a/terraform/modules/http-lb/main.tf
+++ b/terraform/modules/http-lb/main.tf
@@ -1834,8 +1834,6 @@ resource "xcsh_http_loadbalancer" "this" {
         max_batched_queries = graphql_rules.value.max_batched_queries
         max_depth           = graphql_rules.value.max_depth
         max_total_length    = graphql_rules.value.max_total_length
-        max_value_length    = graphql_rules.value.max_value_length
-        policy_name         = graphql_rules.value.policy_name
         dynamic "enable_introspection" {
           for_each = graphql_rules.value.introspection == "enable" ? [1] : []
           content {}

--- a/terraform/modules/http-lb/variables_graphql.tf
+++ b/terraform/modules/http-lb/variables_graphql.tf
@@ -13,8 +13,6 @@ variable "graphql_rules" {
     max_batched_queries = optional(number)
     max_depth           = optional(number)
     max_total_length    = optional(number)
-    max_value_length    = optional(number)
-    policy_name         = optional(string)
     introspection       = optional(string, "omit") # omit|enable|disable
   }))
   default = []


### PR DESCRIPTION
Aligns `graphql_settings` attributes in `modules/http-lb/main.tf` and `variables_graphql.tf` with provider `xcsh v3.88.1` schema by removing unsupported fields `max_value_length` and `policy_name`.

Closes #312