### PR TITLE
fix(http-lb): align waf_staging_period validation with provider xcsh schema (1-20 days) (#314)

### DIFF
--- a/terraform/modules/http-lb/variables.tf
+++ b/terraform/modules/http-lb/variables.tf
@@ -277,6 +277,11 @@ variable "waf_staging_period" {
   description = "Staging period (days) when waf_staging_mode is new or new_and_updated."
   type        = number
   default     = 7
+
+  validation {
+    condition     = var.waf_staging_period >= 1 && var.waf_staging_period <= 20
+    error_message = "waf_staging_period must be between 1 and 20 days."
+  }
 }
 
 variable "waf_suppression" {

--- a/terraform/tests/waf_detection.tftest.hcl
+++ b/terraform/tests/waf_detection.tftest.hcl
@@ -122,7 +122,7 @@ run "staging_new_and_updated" {
   module { source = "./modules/http-lb" }
   variables {
     waf_staging_mode   = "new_and_updated"
-    waf_staging_period = 30
+    waf_staging_period = 14
   }
   assert {
     condition     = output.waf_detection_mode == "custom"


### PR DESCRIPTION
Aligns `waf_staging_period` variable validation in `modules/http-lb/variables.tf` and test fixture in `tests/waf_detection.tftest.hcl` with provider `xcsh v3.88.1` schema constraint (1-20 days).

Closes #314