### PR TITLE
docs: restore Pages build

### DIFF
--- a/docs/en/index.mdx
+++ b/docs/en/index.mdx
@@ -7,5 +7,3 @@ sidebar:
   hidden: true
   order: 0
 ---
-
-<!-- linked-issue verification: #463 -->


### PR DESCRIPTION
## Summary

- remove the obsolete linked-issue verification marker that blocks the production MDX build
- remove the resulting terminal blank line
- leave all remaining content unchanged

## Validation

- `bash scripts/lint-mdx-prose.sh <changed-file>`
- `bash scripts/check-pii.sh --scope changed --mode enforce`
- production-equivalent build with `ghcr.io/f5-sales-demo/docs-builder@sha256:ba96cff87c091d2f39f6ec9cf94e7036fb2cad58738bb238ff22a71e6d467e92` and `docker run --pull=never`
- build output verified non-empty

No AGY or Antigravity review was run.

Closes #485