### PR TITLE
fix(http-lb): validate WAF staging period

### DIFF
--- a/terraform/modules/http-lb/variables.tf
+++ b/terraform/modules/http-lb/variables.tf
@@ -277,6 +277,11 @@ variable "waf_staging_period" {
   description = "Staging period (days) when waf_staging_mode is new or new_and_updated."
   type        = number
   default     = 7
+
+  validation {
+    condition     = var.waf_staging_period >= 1 && var.waf_staging_period <= 20
+    error_message = "waf_staging_period must be between 1 and 20 days."
+  }
 }
 
 variable "waf_suppression" {

--- a/terraform/tests/waf_staging_period.tftest.hcl
+++ b/terraform/tests/waf_staging_period.tftest.hcl
@@ -1,0 +1,32 @@
+# Boundary coverage for the provider schema's 1-20 day WAF staging period.
+variables {
+  namespace          = "example"
+  lb_domains         = ["www.example.com"]
+  origin_ip          = "203.0.113.10"
+  origin_port        = 80
+  health_check_path  = "/health"
+  labels             = {}
+  csd_enabled        = false
+  mud_enabled        = false
+  waf_detection_mode = "custom"
+}
+
+run "staging_period_rejects_zero" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    waf_staging_mode   = "new"
+    waf_staging_period = 0
+  }
+  expect_failures = [var.waf_staging_period]
+}
+
+run "staging_period_rejects_above_twenty" {
+  command = plan
+  module { source = "./modules/http-lb" }
+  variables {
+    waf_staging_mode   = "new_and_updated"
+    waf_staging_period = 21
+  }
+  expect_failures = [var.waf_staging_period]
+}


### PR DESCRIPTION
Closes #314

## Summary
- enforce the provider schema range of 1 through 20 days
- add lower- and upper-bound rejection tests

## Validation
- `terraform fmt -check -recursive terraform`
- `terraform -chdir=terraform validate`
- changed-scope PII audit
- AGY reviewer/verifier: approve, zero findings

The plan-level test requires protected `XCSH_API_URL` and `XCSH_API_TOKEN`; CI runs it in the authorized secret context.