### PR TITLE
fix(csd): query a supported script window

### DIFF
--- a/scripts/csd_verify.py
+++ b/scripts/csd_verify.py
@@ -231,7 +231,7 @@ class ApiClient:
         with urllib.request.urlopen(request, timeout=30) as response:
             return json.load(response)
 
-    def snapshot(self, since_epoch: int) -> dict[str, Any]:
+    def snapshot(self) -> dict[str, Any]:
         now = int(time.time())
         ns = urllib.parse.quote(self.namespace)
         lb = urllib.parse.quote(self.load_balancer)
@@ -244,7 +244,7 @@ class ApiClient:
             "scripts": self.request(
                 f"{self.csd}/scripts",
                 method="POST",
-                body={"startTime": str(since_epoch), "endTime": str(now)},
+                body={"startTime": str(now - 86_400), "endTime": str(now)},
             ),
             "summary": self.request(f"{self.csd}/summary"),
             "mitigated_domains": self.request(f"{self.csd}/mitigated_domains"),
@@ -284,7 +284,7 @@ def main() -> int:
     while True:
         try:
             result = evaluate(
-                client.snapshot(args.since_epoch),
+                client.snapshot(),
                 args.expected_domain,
                 args.phase,
                 args.since_epoch,

--- a/scripts/csd_verify.py
+++ b/scripts/csd_verify.py
@@ -22,6 +22,12 @@ CONFIG_FAILURE = 2
 PENDING = 3
 
 
+def http_error_context(error: urllib.error.HTTPError) -> str:
+    """Return useful API failure context without tenant, query, or credential data."""
+    path = urllib.parse.urlsplit(error.url).path
+    return f"HTTP {error.code} at {path}"
+
+
 @dataclass(frozen=True)
 class Evaluation:
     exit_code: int
@@ -289,6 +295,12 @@ def main() -> int:
                 args.phase,
                 args.since_epoch,
             )
+        except urllib.error.HTTPError as error:
+            print(
+                f"CSD verification failed: API/authentication/dataplane error ({http_error_context(error)})",
+                file=sys.stderr,
+            )
+            return CONFIG_FAILURE
         except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as error:
             print(
                 f"CSD verification failed: API/authentication/dataplane error ({type(error).__name__})",

--- a/tests/test_csd_verify.py
+++ b/tests/test_csd_verify.py
@@ -7,10 +7,10 @@ from pathlib import Path
 from unittest.mock import patch
 
 from scripts.csd_verify import (
-    ApiClient,
     CONFIG_FAILURE,
     PENDING,
     VERIFIED,
+    ApiClient,
     evaluate,
     http_error_context,
 )
@@ -33,7 +33,9 @@ class CsdVerifierTests(unittest.TestCase):
             Message(),
             None,
         )
-        self.assertEqual(http_error_context(error), "HTTP 400 at /api/shape/csd/scripts")
+        self.assertEqual(
+            http_error_context(error), "HTTP 400 at /api/shape/csd/scripts"
+        )
 
     def test_scripts_query_uses_an_api_supported_exact_one_day_window(self) -> None:
         client = ApiClient("https://example.invalid", "token", "namespace", "lb")

--- a/tests/test_csd_verify.py
+++ b/tests/test_csd_verify.py
@@ -2,8 +2,9 @@
 import json
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
-from scripts.csd_verify import CONFIG_FAILURE, PENDING, VERIFIED, evaluate
+from scripts.csd_verify import ApiClient, CONFIG_FAILURE, PENDING, VERIFIED, evaluate
 
 FIXTURES = Path(__file__).parent / "fixtures" / "csd"
 DOMAIN = "cdn-simulator-rmordasiewicz.eastus2.cloudapp.azure.com"
@@ -15,6 +16,20 @@ def fixture(name: str) -> dict:
 
 
 class CsdVerifierTests(unittest.TestCase):
+    def test_scripts_query_uses_an_api_supported_exact_one_day_window(self) -> None:
+        client = ApiClient("https://example.invalid", "token", "namespace", "lb")
+        now = 1_788_452_345
+        with (
+            patch("scripts.csd_verify.time.time", return_value=now),
+            patch.object(client, "request", return_value={}) as request,
+        ):
+            client.snapshot()
+        scripts_call = request.call_args_list[3]
+        self.assertEqual(
+            scripts_call.kwargs["body"],
+            {"startTime": str(now - 86_400), "endTime": str(now)},
+        )
+
     def test_exact_fresh_high_risk_detection_with_affected_users_verifies(self) -> None:
         result = evaluate(fixture("detection.json"), DOMAIN, "detection", SINCE)
         self.assertEqual(result.exit_code, VERIFIED)

--- a/tests/test_csd_verify.py
+++ b/tests/test_csd_verify.py
@@ -1,10 +1,19 @@
 # ruff: noqa: PT009,PT027
 import json
 import unittest
+import urllib.error
+from email.message import Message
 from pathlib import Path
 from unittest.mock import patch
 
-from scripts.csd_verify import ApiClient, CONFIG_FAILURE, PENDING, VERIFIED, evaluate
+from scripts.csd_verify import (
+    ApiClient,
+    CONFIG_FAILURE,
+    PENDING,
+    VERIFIED,
+    evaluate,
+    http_error_context,
+)
 
 FIXTURES = Path(__file__).parent / "fixtures" / "csd"
 DOMAIN = "cdn-simulator-rmordasiewicz.eastus2.cloudapp.azure.com"
@@ -16,6 +25,16 @@ def fixture(name: str) -> dict:
 
 
 class CsdVerifierTests(unittest.TestCase):
+    def test_http_error_context_omits_host_query_and_credentials(self) -> None:
+        error = urllib.error.HTTPError(
+            "https://tenant.example/api/shape/csd/scripts?token=secret",
+            400,
+            "bad request",
+            Message(),
+            None,
+        )
+        self.assertEqual(http_error_context(error), "HTTP 400 at /api/shape/csd/scripts")
+
     def test_scripts_query_uses_an_api_supported_exact_one_day_window(self) -> None:
         client = ApiClient("https://example.invalid", "token", "namespace", "lb")
         now = 1_788_452_345


### PR DESCRIPTION
Closes #514

The first production verifier run (#33777588380) exposed the XC API constraint that `/scripts` accepts only exact 1, 7, or 30 day windows. This keeps `SINCE_EPOCH` as the strict evidence filter while fetching one supported day of telemetry. Includes a failing-first regression test.